### PR TITLE
Documentation Update: Add from and to usage examples to migration script samples

### DIFF
--- a/entity-framework/core/managing-schemas/migrations/index.md
+++ b/entity-framework/core/managing-schemas/migrations/index.md
@@ -237,13 +237,13 @@ Script-Migration
 #### With From (to implied)
 This will generate a SQL script from this migration to the latest migration.
 ```powershell
-Script-Migration -From 20190725054716_Add_new_tables
+Script-Migration 20190725054716_Add_new_tables
 ```
 
 #### With From and To
 This will generate a SQL script from the `from` migration to the specified `to` migration.
 ```powershell
-Script-Migration -From 20190725054716_Add_new_tables -To 20190829031257_Add_audit_table
+Script-Migration 20190725054716_Add_new_tables 20190829031257_Add_audit_table
 ```
 You can use a `from` that is newer than the `to` in order to generate a rollback script. *Please take note of potential data loss scenarios.*
 

--- a/entity-framework/core/managing-schemas/migrations/index.md
+++ b/entity-framework/core/managing-schemas/migrations/index.md
@@ -209,15 +209,43 @@ When debugging your migrations or deploying them to a production database, it's 
 
 ### [.NET Core CLI](#tab/dotnet-core-cli)
 
+#### Basic Usage
 ```dotnetcli
 dotnet ef migrations script
 ```
 
+#### With From (to implied)
+This will generate a SQL script from this migration to the latest migration.
+```dotnetcli
+dotnet ef migrations script 20190725054716_Add_new_tables
+```
+
+#### With From and To
+This will generate a SQL script from the `from` migration to the specified `to` migration.
+```dotnetcli
+dotnet ef migrations script 20190725054716_Add_new_tables 20190829031257_Add_audit_table
+```
+You can use a `from` that is newer than the `to` in order to generate a rollback script. *Please take note of potential data loss scenarios.*
+
 ### [Visual Studio](#tab/vs)
 
+#### Basic Usage
 ``` powershell
 Script-Migration
 ```
+
+#### With From (to implied)
+This will generate a SQL script from this migration to the latest migration.
+```powershell
+Script-Migration -From 20190725054716_Add_new_tables
+```
+
+#### With From and To
+This will generate a SQL script from the `from` migration to the specified `to` migration.
+```powershell
+Script-Migration -From 20190725054716_Add_new_tables -To 20190829031257_Add_audit_table
+```
+You can use a `from` that is newer than the `to` in order to generate a rollback script. *Please take note of potential data loss scenarios.*
 
 ***
 


### PR DESCRIPTION
This updates the documentation to add a from and to usage examples to migration script samples on the Migrations page under the General SQL Scripts section. I believe that this will help new users of EF code-first as there are no examples of its usage in the current EF Core documentation.