### PR TITLE
change [owned type] to [owned entity]

### DIFF
--- a/entity-framework/core/modeling/owned-entities.md
+++ b/entity-framework/core/modeling/owned-entities.md
@@ -10,7 +10,7 @@ uid: core/modeling/owned-entities
 
 EF Core allows you to model entity types that can only ever appear on navigation properties of other entity types. These are called _owned entity types_. The entity containing an owned entity type is its _owner_.
 
-Owned entities are essentially a part of the owner and cannot exist without it, they are conceptually similar to [aggregates](https://martinfowler.com/bliki/DDD_Aggregate.html). This means that the owned type is by definition on the dependent side of the relationship with the owner.
+Owned entities are essentially a part of the owner and cannot exist without it, they are conceptually similar to [aggregates](https://martinfowler.com/bliki/DDD_Aggregate.html). This means that the owned entity is by definition on the dependent side of the relationship with the owner.
 
 ## Explicit configuration
 


### PR DESCRIPTION
in this article yo use [owned entity] and [owned type] interchangeably but in this sentence it's better to use [owned entity] not to make any confusing to user

Suggestion :: to use only one term