### PR TITLE
fix: EF core depends on .NET Standard 2.0.

### DIFF
--- a/entity-framework/core/get-started/install/index.md
+++ b/entity-framework/core/get-started/install/index.md
@@ -9,7 +9,7 @@ uid: core/get-started/install/index
 
 ## Prerequisites
 
-* EF Core is a [.NET Standard 2.1](/dotnet/standard/net-standard) library. So EF Core requires a .NET implementation that supports .NET Standard 2.1 to run. EF Core can also be referenced by other .NET Standard 2.1 libraries.
+* EF Core is a [.NET Standard 2.0](/dotnet/standard/net-standard) library. So EF Core requires a .NET implementation that supports .NET Standard 2.0 to run. EF Core can also be referenced by other .NET Standard 2.0 libraries.
 
 * For example, you can use EF Core to develop apps that target .NET Core. Building .NET Core apps requires the [.NET Core SDK](https://dotnet.microsoft.com/download). Optionally, you can also use a development environment like [Visual Studio](https://visualstudio.microsoft.com/vs), [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac), or [Visual Studio Code](https://code.visualstudio.com). For more information, check [Getting Started with .NET Core](/dotnet/core/get-started).
 


### PR DESCRIPTION
as per nuget.org's package description https://www.nuget.org/packages/Microsoft.EntityFrameworkCore, EF Core depends on NET Standard 2.0, instead of .NET Standard 2.1 as originally mentioned