### PR TITLE
Stating when the BackingField and Keyless attributes became available

### DIFF
--- a/entity-framework/core/modeling/backing-field.md
+++ b/entity-framework/core/modeling/backing-field.md
@@ -24,7 +24,7 @@ In the following sample, the `Url` property is configured to have `_url` as its 
 
 Note that backing fields are only discovered for properties that are included in the model. For more information on which properties are included in the model, see [Including & Excluding Properties](included-properties.md).
 
-You can also configure backing fields by using a Data Annotation or the Fluent API, e.g. if the field name doesn't correspond to the above conventions:
+You can also configure backing fields by using a Data Annotation (available in EFCore 5.0) or the Fluent API, e.g. if the field name doesn't correspond to the above conventions:
 
 ### [Data Annotations](#tab/data-annotations)
 

--- a/entity-framework/core/modeling/keyless-entity-types.md
+++ b/entity-framework/core/modeling/keyless-entity-types.md
@@ -9,7 +9,7 @@ uid: core/modeling/keyless-entity-types
 # Keyless Entity Types
 
 > [!NOTE]
-> This feature was added in EF Core 2.1 under the name of query types. In EF Core 3.0 the concept was renamed to keyless entity types.
+> This feature was added in EF Core 2.1 under the name of query types. In EF Core 3.0 the concept was renamed to keyless entity types. The `[Keyless]` Data Annotation became available in EFCore 5.0.
 
 In addition to regular entity types, an EF Core model can contain _keyless entity types_, which can be used to carry out database queries against data that doesn't contain key values.
 


### PR DESCRIPTION
Fixes #2294 

Updating to say when the `Keyless` attribute became available (also the same info about the `BackingField` attribute).