### PR TITLE
Args param is now used for IDesignTimeDbContextFactory

### DIFF
--- a/entity-framework/core/miscellaneous/cli/dbcontext-creation.md
+++ b/entity-framework/core/miscellaneous/cli/dbcontext-creation.md
@@ -35,8 +35,9 @@ You can also tell the tools how to create your DbContext by implementing the `ID
 [!code-csharp[Main](../../../../samples/core/Miscellaneous/CommandLine/BloggingContextFactory.cs)]
 
 > [!NOTE]
-> Prior to 5.0.0 the `args` parameter was unused (see [this issue][8]). This was fixed in the 5.0.0 release and now any 
-> additional design-time arguments are passed into the application through that parameter.
+> Prior to EFCore 5.0 the `args` parameter was unused (see [this issue][8]).
+> This is fixed in EFCore 5.0 and any additional design-time arguments
+> are passed into the application through that parameter.
 
 A design-time factory can be especially useful if you need to configure the DbContext differently for design time than at run time, if the `DbContext` constructor takes additional parameters are not registered in DI, if you are not using DI at all, or if for some reason you prefer not to have a `BuildWebHost` method in your ASP.NET Core application's `Main` class.
 

--- a/entity-framework/core/miscellaneous/cli/dbcontext-creation.md
+++ b/entity-framework/core/miscellaneous/cli/dbcontext-creation.md
@@ -35,8 +35,8 @@ You can also tell the tools how to create your DbContext by implementing the `ID
 [!code-csharp[Main](../../../../samples/core/Miscellaneous/CommandLine/BloggingContextFactory.cs)]
 
 > [!NOTE]
-> The `args` parameter is currently unused. There is [an issue][8] tracking the ability to specify design-time arguments
-> from the tools.
+> Prior to 5.0.0 the `args` parameter was unused (see [this issue][8]). This was fixed in the 5.0.0 release and now any 
+> additional design-time arguments are passed into the application through that parameter.
 
 A design-time factory can be especially useful if you need to configure the DbContext differently for design time than at run time, if the `DbContext` constructor takes additional parameters are not registered in DI, if you are not using DI at all, or if for some reason you prefer not to have a `BuildWebHost` method in your ASP.NET Core application's `Main` class.
 


### PR DESCRIPTION
Specify that the args param is now used for IDesignTimeDbContextFactory implementations.