### PR TITLE
Remove L2 .NET Navigation Header

### DIFF
--- a/entity-framework/docfx.json
+++ b/entity-framework/docfx.json
@@ -77,7 +77,7 @@
       "feedback_system": "GitHub",
       "feedback_github_repo": "dotnet/EntityFramework.Docs",
       "feedback_product_url": "https://github.com/dotnet/efcore/issues/new/choose",
-      "uhfHeaderId": "MSDocsHeader-DotNet"
+      "uhfHeaderId": []
     },
     "fileMetadata": {
       "feedback_product_url": {


### PR DESCRIPTION
[Internal Review - Note that the .NET Nav header has been removed](https://review.docs.microsoft.com/en-us/ef/core/?branch=pr-en-us-2344)

Fixes #2343 

What was updated:
Removed the .NET header value of "MSDocsHeader-DotNet" from "uhfHeaderId" in docfx.json.