### PR TITLE
Fix for 2346. Guide people towards the Name= syntax for connection strings

### DIFF
--- a/entity-framework/core/miscellaneous/connection-strings.md
+++ b/entity-framework/core/miscellaneous/connection-strings.md
@@ -61,7 +61,16 @@ public class BloggingContext : DbContext
 
 ## ASP.NET Core
 
-In ASP.NET Core the configuration system is very flexible, and the connection string could be stored in `appsettings.json`, an environment variable, the user secret store, or another configuration source. See the [Configuration section of the ASP.NET Core documentation](https://docs.asp.net/en/latest/fundamentals/configuration.html) for more details. The following example shows the connection string stored in `appsettings.json`.
+In ASP.NET Core the configuration system is very flexible, and the connection string could be stored in `appsettings.json`, an environment variable, the user secret store, or another configuration source. See the [Configuration section of the ASP.NET Core documentation](https://docs.asp.net/en/latest/fundamentals/configuration.html) for more details.
+
+For instance, you can use the [Secret Manager tool](https://docs.microsoft.com/aspnet/core/security/app-secrets#secret-manager) to store your database password and then, in scaffolding, use a connection string that simply consists of `Name=<database-alias>`.
+
+```dotnetcli
+dotnet user-secrets set ConnectionStrings.YourDatabaseAlias "Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=YourDatabase"
+dotnet ef dbcontext scaffold Name=YourDatabaseAlias Microsoft.EntityFrameworkCore.SqlServer
+```
+
+Or the following example shows the connection string stored in `appsettings.json`.
 
 ``` json
 {
@@ -71,7 +80,7 @@ In ASP.NET Core the configuration system is very flexible, and the connection st
 }
 ```
 
-The context is typically configured in `Startup.cs` with the connection string being read from configuration. Note the `GetConnectionString()` method looks for a configuration value whose key is `ConnectionStrings:<connection string name>`. You need to import the [Microsoft.Extensions.Configuration](https://docs.microsoft.com/dotnet/api/microsoft.extensions.configuration) namespace to use this extension method.
+Then the context is typically configured in `Startup.cs` with the connection string being read from configuration. Note the `GetConnectionString()` method looks for a configuration value whose key is `ConnectionStrings:<connection string name>`. You need to import the [Microsoft.Extensions.Configuration](https://docs.microsoft.com/dotnet/api/microsoft.extensions.configuration) namespace to use this extension method.
 
 ``` csharp
 public void ConfigureServices(IServiceCollection services)


### PR DESCRIPTION
Fixes #2346 .

Guide people towards the Name= syntax for connection strings.