### PR TITLE
Fix the CreatePoint() example

### DIFF
--- a/entity-framework/core/modeling/spatial.md
+++ b/entity-framework/core/modeling/spatial.md
@@ -87,7 +87,7 @@ You can use constructors to create geometry objects; however, NTS recommends usi
 
 ``` csharp
 var geometryFactory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
-var currentLocation = geometryFactory.CreatePoint(-122.121512, 47.6739882);
+var currentLocation = geometryFactory.CreatePoint(new Coordinate(-122.121512, 47.6739882));
 ```
 
 > [!NOTE]


### PR DESCRIPTION
The Point.CreatePoint() method has two variants:

public Point CreatePoint(CoordinateSequence coordinates);
public Point CreatePoint(Coordinate coordinate); 

It does not support (or no longer supports) a variant that takes two decimals as described in this example. Visual Studio 2019 marks the current version of line 90 as an error.

The decimal values in the example need to be wrapped in a Coordinate object that can be constructed from those values. Then the CreatePoint() method can work as intended.