### PR TITLE
Refer to the correct property when discussing IModelCacheKeyFactory

### DIFF
--- a/entity-framework/core/modeling/dynamic-model.md
+++ b/entity-framework/core/modeling/dynamic-model.md
@@ -15,9 +15,9 @@ Unfortunately, this code wouldn't work as-is, since EF builds the model and runs
 
 ## IModelCacheKeyFactory
 
-EF uses the `IModelCacheKeyFactory` to generate cache keys for models; by default, EF assumes that for any given context type the model will be the same, so the default implementation of this service returns a key that just contains the context type. To produce different models from the same context type, you need to replace the `IModelCacheKeyFactory` service with the correct  implementation; the generated key will be compared to other model keys using the `Equals` method, taking into account all the variables that affect the model:
+EF uses the `IModelCacheKeyFactory` to generate cache keys for models; by default, EF assumes that for any given context type the model will be the same, so the default implementation of this service returns a key that just contains the context type. To produce different models from the same context type, you need to replace the `IModelCacheKeyFactory` service with the correct implementation; the generated key will be compared to other model keys using the `Equals` method, taking into account all the variables that affect the model.
 
-The following implementation takes the `IgnoreIntProperty` into account when producing a model cache key:
+The following implementation takes the `UseIntProperty` into account when producing a model cache key:
 
 [!code-csharp[Main](../../../samples/core/Modeling/DynamicModel/DynamicModelCacheKeyFactory.cs?name=DynamicModel)]
 


### PR DESCRIPTION
The code in the sample shows `UseIntProperty` but the explanation refers to `IgnoreIntProperty`, so I've updated this accordingly.

I also removed an extraneous space and swapped a trailing `:` for a `.`. I wouldn't have submitted a PR for just those, but I took the opportunity whilst I was in the topic.