### PR TITLE
Fix to #2436 - Filtered include should also notify users about how it interact with tracked entities

### DIFF
--- a/entity-framework/core/querying/related-data.md
+++ b/entity-framework/core/querying/related-data.md
@@ -72,6 +72,18 @@ Alternatively, identical operations can be applied for each navigation that is i
 
 [!code-csharp[Main](../../../samples/core/Querying/RelatedData/Sample.cs#MultipleLeafIncludesFiltered2)]
 
+> [!CAUTION]
+> In case of tracking queries, results of Filtered Include may be unexpected due to [navigation fixup](tracking.md). All relevant entities that have been querried for previously and have been stored in the Change Tracker will be present in the results of Filtered Include query, even if they don't meet the requirements of the filter. Consider using `NoTracking` queries or re-create the DbContext when using Filtered Include in those situations.
+
+Example:
+
+```csharp
+var orders = context.Orders.Where(o => o.Id > 1000).ToList();
+
+// customer entities will have references to all orders where Id > 1000, rathat than > 5000
+var filtered = context.Customers.Include(c => c.Orders.Where(o => o.Id > 5000)).ToList();
+```
+
 ### Include on derived types
 
 You can include related data from navigations defined only on a derived type using `Include` and `ThenInclude`.


### PR DESCRIPTION
adding "caution" block and example

Fixes #2436