### PR TITLE
Fix up wording when discussing MigrationBuilder.ActiveProvider

### DIFF
--- a/entity-framework/core/managing-schemas/migrations/providers.md
+++ b/entity-framework/core/managing-schemas/migrations/providers.md
@@ -65,7 +65,7 @@ Id = table.Column<int>(nullable: false)
     .Annotation("Sqlite:Autoincrement", true),
 ```
 
-If operations can only be applied on one provider (or they're differently between providers), use the `ActiveProvider` property to tell which provider is active.
+If operations can be applied only for one provider, or they're different between providers, use the `ActiveProvider` property to determine which provider is active:
 
 ``` csharp
 if (migrationBuilder.ActiveProvider == "Microsoft.EntityFrameworkCore.SqlServer")


### PR DESCRIPTION
I noticed that "differently" should be "different", but I made a couple of other small change to the sentance. Please let me know if these kinds of changes are appreciated, and I will continue to submit PRs as I read through more of the topics.