### PR TITLE
Fix for issues 2422 and 2405.

### DIFF
--- a/entity-framework/core/miscellaneous/cli/dotnet.md
+++ b/entity-framework/core/miscellaneous/cli/dotnet.md
@@ -233,13 +233,14 @@ Options:
 | <nobr>`-d`</nobr> | `--data-annotations`                   | Use attributes to configure the model (where possible). If this option is omitted, only the fluent API is used.                                                                |
 | `-c`            | `--context <NAME>`                       | The name of the `DbContext` class to generate.                                                                                                                                 |
 |                 | `--context-dir <PATH>`                   | The directory to put the `DbContext` class file in. Paths are relative to the project directory. Namespaces are derived from the folder names.                                 |
-|                 | `--context-namespace <NAMESPACE>`        | The namespace to use for the generated `DbContext` class. Note: overrides `--namespace`.                                 |
+|                 | `--context-namespace <NAMESPACE>`        | The namespace to use for the generated `DbContext` class. Note: overrides `--namespace`. (Available from EFCore 5.0.0 onwards.)        |
 | `-f`            | `--force`                                | Overwrite existing files.                                                                                                                                                      |
 | `-o`            | `--output-dir <PATH>`                    | The directory to put entity class files in. Paths are relative to the project directory.                                                                                       |
-| `-n`            | `--namespace <NAMESPACE>`                | The namespace to use for all generated classes. Defaults to generated from the root namespace and the output directory.                    |
+| `-n`            | `--namespace <NAMESPACE>`                | The namespace to use for all generated classes. Defaults to generated from the root namespace and the output directory. (Available from EFCore 5.0.0 onwards.)        |
 |                 | <nobr>`--schema <SCHEMA_NAME>...`</nobr> | The schemas of tables to generate entity types for. To specify multiple schemas, repeat `--schema` for each one. If this option is omitted, all schemas are included.          |
 | `-t`            | `--table <TABLE_NAME>`...                | The tables to generate entity types for. To specify multiple tables, repeat `-t` or `--table` for each one. If this option is omitted, all tables are included.                |
 |                 | `--use-database-names`                   | Use table and column names exactly as they appear in the database. If this option is omitted, database names are changed to more closely conform to C# name style conventions. |
+|                 | `--no-onconfiguring`                     | Suppresses generation of the `OnConfiguring` method in the generated `DbContext` class. (Available from EFCore 5.0.0 onwards.)        |
 
 The following example scaffolds all schemas and tables and puts the new files in the *Models* folder.
 
@@ -268,7 +269,7 @@ Options:
 |                   | Option                             | Description                                                                                                      |
 |:------------------|:-----------------------------------|:-----------------------------------------------------------------------------------------------------------------|
 | <nobr>`-o`</nobr> | <nobr>`--output-dir <PATH>`</nobr> | The directory use to output the files. Paths are relative to the target project directory. Defaults to "Migrations". |
-| <nobr>`-n`</nobr> | <nobr>`--namespace <NAMESPACE>`</nobr> | The namespace to use for the generated classes. Defaults to generated from the output directory. |
+| <nobr>`-n`</nobr> | <nobr>`--namespace <NAMESPACE>`</nobr> | The namespace to use for the generated classes. Defaults to generated from the output directory. (Available from EFCore 5.0.0 onwards.) |
 
 ## dotnet ef migrations list
 

--- a/entity-framework/core/miscellaneous/cli/powershell.md
+++ b/entity-framework/core/miscellaneous/cli/powershell.md
@@ -147,7 +147,7 @@ Parameters:
 |:----------------------------------|:------------------------------------------------------------------------------------------------------------------------|
 | <nobr>-Name \<String><nobr>       | The name of the migration. This is a positional parameter and is required.                                              |
 | <nobr>-OutputDir \<String></nobr> | The directory use to output the files. Paths are relative to the target project directory. Defaults to "Migrations". |
-| <nobr>-Namespace \<String></nobr> | The namespace to use for the generated classes. Defaults to generated from the output directory. |
+| <nobr>-Namespace \<String></nobr> | The namespace to use for the generated classes. Defaults to generated from the output directory. (Available from EFCore 5.0.0 onwards.) |
 
 ## Drop-Database
 
@@ -185,14 +185,15 @@ Parameters:
 | <nobr>-Provider \<String></nobr>   | The provider to use. Typically this is the name of the NuGet package, for example: `Microsoft.EntityFrameworkCore.SqlServer`. This is a positional parameter and is required.                                                                                           |
 | -OutputDir \<String>               | The directory to put files in. Paths are relative to the project directory.                                                                                                                                                                                             |
 | -ContextDir \<String>              | The directory to put the `DbContext` file in. Paths are relative to the project directory.                                                                                                                                                               |
-| -Namespace \<String>               | The namespace to use for all generated classes. Defaults to generated from the root namespace and the output directory.                                                                                                                                                                                             |
-| -ContextNamespace \<String>        | The namespace to use for the generated `DbContext` class. Note: overrides `-Namespace`.                                                                                                                                                                              |
+| -Namespace \<String>               | The namespace to use for all generated classes. Defaults to generated from the root namespace and the output directory. (Available from EFCore 5.0.0 onwards.) |
+| -ContextNamespace \<String>        | The namespace to use for the generated `DbContext` class. Note: overrides `-Namespace`. (Available from EFCore 5.0.0 onwards.) |
 | -Context \<String>                 | The name of the `DbContext` class to generate.                                                                                                                                                                                                                          |
 | -Schemas \<String[]>               | The schemas of tables to generate entity types for. If this parameter is omitted, all schemas are included.                                                                                                                                                             |
 | -Tables \<String[]>                | The tables to generate entity types for. If this parameter is omitted, all tables are included.                                                                                                                                                                         |
 | -DataAnnotations                   | Use attributes to configure the model (where possible). If this parameter is omitted, only the fluent API is used.                                                                                                                                                      |
 | -UseDatabaseNames                  | Use table and column names exactly as they appear in the database. If this parameter is omitted, database names are changed to more closely conform to C# name style conventions.                                                                                       |
 | -Force                             | Overwrite existing files.                                                                                                                                                                                                                                               |
+| -NoOnConfiguring                   | Suppresses generation of the `OnConfiguring` method in the generated `DbContext` class. (Available from EFCore 5.0.0 onwards.) |
 
 Example:
 


### PR DESCRIPTION
Fixes #2422.  Document that the `-Namespace` and `-ContextNamespace` flags on `Scaffold-DbContext`, plus the `-Namespace` flag on `Add-Migration` are only available in 5.0.0 (and similarly for the command-line equivalents).

Fixes #2405. Document the `-NoOnConfiguring` flag on `Scaffold-DbContext`, also only available in 5.0.0 (and its command-line equivalent).