### PR TITLE
Fix for 2335. Adding definition of PMC before first use.

### DIFF
--- a/entity-framework/core/get-started/index.md
+++ b/entity-framework/core/get-started/index.md
@@ -111,7 +111,7 @@ The following steps use [migrations](xref:core/managing-schemas/migrations/index
 
 ### [Visual Studio](#tab/visual-studio)
 
-* Run the following commands in **Package Manager Console**
+* Run the following commands in **Package Manager Console (PMC)**
 
   ``` PowerShell
   Install-Package Microsoft.EntityFrameworkCore.Tools


### PR DESCRIPTION
Fixes the part of #2335 about defining PMC before first use. Found that there was only 1 case where we were just using the abbreviation without defining it. 