### PR TITLE
Making sure we reference .NET Core CLI.

### DIFF
--- a/entity-framework/core/managing-schemas/scaffolding.md
+++ b/entity-framework/core/managing-schemas/scaffolding.md
@@ -79,11 +79,11 @@ Scaffold-DbContext ... -Tables Artist, Album
 
 ## Preserving names
 
-Table and column names are fixed up to better match the .NET naming conventions for types and properties by default. Specifying the `-UseDatabaseNames` switch in PMC or the `--use-database-names` option in the CLI will disable this behavior preserving the original database names as much as possible. Invalid .NET identifiers will still be fixed and synthesized names like navigation properties will still conform to .NET naming conventions.
+Table and column names are fixed up to better match the .NET naming conventions for types and properties by default. Specifying the `-UseDatabaseNames` switch in PMC or the `--use-database-names` option in the .NET Core CLI will disable this behavior preserving the original database names as much as possible. Invalid .NET identifiers will still be fixed and synthesized names like navigation properties will still conform to .NET naming conventions.
 
 ## Fluent API or Data Annotations
 
-Entity types are configured using the Fluent API by default. Specify `-DataAnnotations` (PMC) or `--data-annotations` (CLI) to instead use data annotations when possible.
+Entity types are configured using the Fluent API by default. Specify `-DataAnnotations` (PMC) or `--data-annotations` (.NET Core CLI) to instead use data annotations when possible.
 
 For example, using the Fluent API will scaffold this:
 
@@ -103,7 +103,7 @@ public string Title { get; set; }
 
 ## DbContext name
 
-The scaffolded DbContext class name will be the name of the database suffixed with *Context* by default. To specify a different one, use `-Context` in PMC and `--context` in the CLI.
+The scaffolded DbContext class name will be the name of the database suffixed with *Context* by default. To specify a different one, use `-Context` in PMC and `--context` in the .NET Core CLI.
 
 ## Directories and namespaces
 

--- a/entity-framework/core/miscellaneous/cli/dotnet.md
+++ b/entity-framework/core/miscellaneous/cli/dotnet.md
@@ -6,7 +6,7 @@ ms.date: 07/11/2019
 uid: core/miscellaneous/cli/dotnet
 ---
 
-# Entity Framework Core tools reference - .NET CLI
+# Entity Framework Core tools reference - .NET Core CLI
 
 The command-line interface (CLI) tools for Entity Framework Core perform design-time development tasks. For example, they create [migrations](/aspnet/core/data/ef-mvc/migrations?view=aspnetcore-2.0), apply migrations, and generate code for a model based on an existing database. The commands are an extension to the cross-platform [dotnet](/dotnet/core/tools) command, which is part of the [.NET Core SDK](https://www.microsoft.com/net/core). These tools work with .NET Core projects.
 

--- a/entity-framework/core/miscellaneous/cli/powershell.md
+++ b/entity-framework/core/miscellaneous/cli/powershell.md
@@ -9,7 +9,7 @@ uid: core/miscellaneous/cli/powershell
 
 The Package Manager Console (PMC) tools for Entity Framework Core perform design-time development tasks. For example, they create [migrations](/aspnet/core/data/ef-mvc/migrations?view=aspnetcore-2.0), apply migrations, and generate code for a model based on an existing database. The commands run inside of Visual Studio using the [Package Manager Console](/nuget/tools/package-manager-console). These tools work with both .NET Framework and .NET Core projects.
 
-If you aren't using Visual Studio, we recommend the [EF Core Command-line Tools](dotnet.md) instead. The CLI tools are cross-platform and run inside a command prompt.
+If you aren't using Visual Studio, we recommend the [EF Core Command-line Tools](dotnet.md) instead. The .NET Core CLI tools are cross-platform and run inside a command prompt and work with .NET Core projects only.
 
 ## Installing the tools
 

--- a/entity-framework/core/miscellaneous/cli/powershell.md
+++ b/entity-framework/core/miscellaneous/cli/powershell.md
@@ -9,7 +9,7 @@ uid: core/miscellaneous/cli/powershell
 
 The Package Manager Console (PMC) tools for Entity Framework Core perform design-time development tasks. For example, they create [migrations](/aspnet/core/data/ef-mvc/migrations?view=aspnetcore-2.0), apply migrations, and generate code for a model based on an existing database. The commands run inside of Visual Studio using the [Package Manager Console](/nuget/tools/package-manager-console). These tools work with both .NET Framework and .NET Core projects.
 
-If you aren't using Visual Studio, we recommend the [EF Core Command-line Tools](dotnet.md) instead. The .NET Core CLI tools are cross-platform and run inside a command prompt and work with .NET Core projects only.
+If you aren't using Visual Studio, we recommend the [EF Core Command-line Tools](dotnet.md) instead. The .NET Core CLI tools are cross-platform and run inside a command prompt.
 
 ## Installing the tools
 

--- a/entity-framework/core/miscellaneous/rc1-rc2-upgrade.md
+++ b/entity-framework/core/miscellaneous/rc1-rc2-upgrade.md
@@ -95,11 +95,11 @@ services.AddEntityFrameworkSqlServer()
 > [!WARNING]  
 > We recommend allowing EF to internally manage its own services, unless you have a reason to combine the internal EF services into your application service provider. The main reason you may want to do this is to use your application service provider to replace services that EF uses internally
 
-## DNX Commands => .NET CLI (ASP.NET Core Projects Only)
+## DNX Commands => .NET Core CLI (ASP.NET Core Projects Only)
 
 If you previously used the `dnx ef` commands for ASP.NET 5 projects, these have now moved to `dotnet ef` commands. The same command syntax still applies. You can use `dotnet ef --help` for syntax information.
 
-The way commands are registered has changed in RC2, due to DNX being replaced by .NET CLI. Commands are now registered in a `tools` section in `project.json`:
+The way commands are registered has changed in RC2, due to DNX being replaced by the .NET Core CLI. Commands are now registered in a `tools` section in `project.json`:
 
 ``` json
 "tools": {


### PR DESCRIPTION
Fixes #2335 (remaining part). Make sure we reference ".NET Core CLI" where we haven't already defined "CLI" as an abbreviation for that.