### PR TITLE
Updated scaffolding named connection string syntax

### DIFF
--- a/entity-framework/core/managing-schemas/scaffolding.md
+++ b/entity-framework/core/managing-schemas/scaffolding.md
@@ -44,7 +44,7 @@ This works well with the [Secret Manager tool](https://docs.microsoft.com/aspnet
 
 ```dotnetcli
 dotnet user-secrets set ConnectionStrings.Chinook "Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=Chinook"
-dotnet ef dbcontext scaffold Name=Chinook Microsoft.EntityFrameworkCore.SqlServer
+dotnet ef dbcontext scaffold Name=ConnectionStrings.Chinook Microsoft.EntityFrameworkCore.SqlServer
 ```
 
 ## Provider name

--- a/entity-framework/core/miscellaneous/connection-strings.md
+++ b/entity-framework/core/miscellaneous/connection-strings.md
@@ -67,7 +67,7 @@ For instance, you can use the [Secret Manager tool](/aspnet/core/security/app-se
 
 ```dotnetcli
 dotnet user-secrets set ConnectionStrings.YourDatabaseAlias "Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=YourDatabase"
-dotnet ef dbcontext scaffold Name=YourDatabaseAlias Microsoft.EntityFrameworkCore.SqlServer
+dotnet ef dbcontext scaffold Name=ConnectionStrings.YourDatabaseAlias Microsoft.EntityFrameworkCore.SqlServer
 ```
 
 Or the following example shows the connection string stored in `appsettings.json`.


### PR DESCRIPTION
The one in the example was not correct