### PR TITLE
Mentioning NCache Entity Framework Core Provider

### DIFF
--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -152,6 +152,12 @@ A high-performance second-level query cache. For EF Core: 2.
 
 [GitHub repository](https://github.com/SteffenMangold/EntityFrameworkCore.Cacheable)
 
+### EntityFrameworkCore.NCache
+
+NCache Entity Framework Core Provider is a distributed second level cache provider for caching query results. The distributed architecture of NCache makes it more scalable and highly available. 
+
+[Website](https://www.alachisoft.com/ncache/ef-core-cache.html)
+
 ### Entity Framework Plus
 
 Extends your DbContext with features such as: Include Filter, Auditing, Caching, Query Future, Batch Delete, Batch Update, and more. For EF Core: 2, 3.

--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -154,7 +154,7 @@ A high-performance second-level query cache. For EF Core: 2.
 
 ### EntityFrameworkCore.NCache
 
-NCache Entity Framework Core Provider is a distributed second level cache provider for caching query results. The distributed architecture of NCache makes it more scalable and highly available. 
+NCache Entity Framework Core Provider is a distributed second level cache provider for caching query results. The distributed architecture of NCache makes it more scalable and highly available. For EF Core 2.
 
 [Website](https://www.alachisoft.com/ncache/ef-core-cache.html)
 


### PR DESCRIPTION
Mentioning NCache Entity Framework Core Provider as Second level cache. This is thirdparty provider which caches data on distributed environment. This architecture makes in highly available, scalable and reliable.