### PR TITLE
fix header level

### DIFF
--- a/entity-framework/core/what-is-new/ef-core-5.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-5.0/whatsnew.md
@@ -16,7 +16,7 @@ We will add links from here to the official documentation as it is published.
 
 ## Preview 8
 
-## Table-per-type (TPT) mapping
+### Table-per-type (TPT) mapping
 
 By default, EF Core maps an inheritance hierarchy of .NET types to a single database table. This is known as table-per-hierarchy (TPH) mapping. EF Core 5.0 also allows mapping each .NET type in an inheritance hierarchy to a different database table; known as table-per-type (TPT) mapping.
 


### PR DESCRIPTION
I imagine we should only have version numbers on the right TOC
![image](https://user-images.githubusercontent.com/12971179/91507935-fadade00-e88a-11ea-9a77-23267117aa50.png)
