### PR TITLE
Ordering Caveat in FromSql

### DIFF
--- a/entity-framework/core/querying/raw-sql.md
+++ b/entity-framework/core/querying/raw-sql.md
@@ -50,6 +50,10 @@ You can also construct a DbParameter and supply it as a parameter value. Since a
 
 [!code-csharp[Main](../../../samples/core/Querying/RawSQL/Sample.cs#FromSqlRawStoredProcedureNamedSqlParameter)]
 
+> [!NOTE]
+> **Parameter Ordering**
+> When passing multiple `SqlParameter`s, the ordering in the SQL string must match the order of the parameters in the stored procedure's definition. Failing to do this can result in type conversion exceptions or unexpected behavior when the procedure is executed because Entity Framework Core will apply the order of the `SqlParameter[]` array literally and will not reorder them to match the order defined in the stored procedure's definition. This behavior is not typical of stored procedures when using named parameters and is seemingly specific to `FromSql()`.
+
 ## Composing with LINQ
 
 You can compose on top of the initial raw SQL query using LINQ operators. EF Core will treat it as subquery and compose over it in the database. The following example uses a raw SQL query that selects from a Table-Valued Function (TVF). And then composes on it using LINQ to do filtering and sorting.

--- a/entity-framework/core/querying/raw-sql.md
+++ b/entity-framework/core/querying/raw-sql.md
@@ -52,7 +52,7 @@ You can also construct a DbParameter and supply it as a parameter value. Since a
 
 > [!NOTE]
 > **Parameter Ordering**
-> When passing multiple `SqlParameter`s, the ordering in the SQL string must match the order of the parameters in the stored procedure's definition. Failing to do this can result in type conversion exceptions or unexpected behavior when the procedure is executed because Entity Framework Core will apply the order of the `SqlParameter[]` array literally and will not reorder them to match the order defined in the stored procedure's definition. This behavior is not typical of stored procedures when using named parameters and is seemingly specific to `FromSql()`.
+> Entity Framework Core passes parameters based on the order of the `SqlParameter[]` array. When passing multiple `SqlParameter`s, the ordering in the SQL string must match the order of the parameters in the stored procedure's definition. Failure to do this may result in type conversion exceptions and/or unexpected behavior when the procedure is executed.
 
 ## Composing with LINQ
 


### PR DESCRIPTION
I recently experienced a peculiarity in `FromSql()` in a netcore-2.1 project as described in the commit. I think this may be worth documenting, but I understand if this should be opened as an issue in the EF Core project instead.