### PR TITLE
Avoid unnecessary views in URL to other product docs

### DIFF
--- a/entity-framework/core/miscellaneous/cli/dotnet.md
+++ b/entity-framework/core/miscellaneous/cli/dotnet.md
@@ -9,7 +9,7 @@ uid: core/miscellaneous/cli/dotnet
 
 # Entity Framework Core tools reference - .NET Core CLI
 
-The command-line interface (CLI) tools for Entity Framework Core perform design-time development tasks. For example, they create [migrations](/aspnet/core/data/ef-mvc/migrations?view=aspnetcore-2.0), apply migrations, and generate code for a model based on an existing database. The commands are an extension to the cross-platform [dotnet](/dotnet/core/tools) command, which is part of the [.NET Core SDK](https://www.microsoft.com/net/core). These tools work with .NET Core projects.
+The command-line interface (CLI) tools for Entity Framework Core perform design-time development tasks. For example, they create [migrations](/aspnet/core/data/ef-mvc/migrations), apply migrations, and generate code for a model based on an existing database. The commands are an extension to the cross-platform [dotnet](/dotnet/core/tools) command, which is part of the [.NET Core SDK](https://www.microsoft.com/net/core). These tools work with .NET Core projects.
 
 If you're using Visual Studio, we recommend the [Package Manager Console tools](xref:core/miscellaneous/cli/powershell) instead:
 

--- a/entity-framework/core/miscellaneous/cli/powershell.md
+++ b/entity-framework/core/miscellaneous/cli/powershell.md
@@ -8,7 +8,7 @@ uid: core/miscellaneous/cli/powershell
 ---
 # Entity Framework Core tools reference - Package Manager Console in Visual Studio
 
-The Package Manager Console (PMC) tools for Entity Framework Core perform design-time development tasks. For example, they create [migrations](/aspnet/core/data/ef-mvc/migrations?view=aspnetcore-2.0), apply migrations, and generate code for a model based on an existing database. The commands run inside of Visual Studio using the [Package Manager Console](/nuget/tools/package-manager-console). These tools work with both .NET Framework and .NET Core projects.
+The Package Manager Console (PMC) tools for Entity Framework Core perform design-time development tasks. For example, they create [migrations](/aspnet/core/data/ef-mvc/migrations), apply migrations, and generate code for a model based on an existing database. The commands run inside of Visual Studio using the [Package Manager Console](/nuget/tools/package-manager-console). These tools work with both .NET Framework and .NET Core projects.
 
 If you aren't using Visual Studio, we recommend the [EF Core Command-line Tools](xref:core/miscellaneous/cli/dotnet) instead. The .NET Core CLI tools are cross-platform and run inside a command prompt.
 

--- a/entity-framework/core/miscellaneous/testing/index.md
+++ b/entity-framework/core/miscellaneous/testing/index.md
@@ -8,6 +8,7 @@ uid: core/miscellaneous/testing/index
 # Testing code that uses EF Core
 
 Testing code that accesses a database requires either:
+
 * Running queries and updates against the same database system used in production.
 * Running queries and updates against some other easier to manage database system.
 * Using test doubles or some other mechanism to avoid using a database at all.
@@ -15,14 +16,14 @@ Testing code that accesses a database requires either:
 This document outlines the trade-offs involved in each of these choices and shows how EF Core can be used with each approach.  
 
 > [!TIP]
-> See [EF Core testing sample](xref:core/miscellaneous/testing/testing-sample) for code demonstrating the concepts introduced here. 
+> See [EF Core testing sample](xref:core/miscellaneous/testing/testing-sample) for code demonstrating the concepts introduced here.
 
 ## All database providers are not equal
 
 It is very important to understand that EF Core is not designed to abstract every aspect of the underlying database system.
 Instead, EF Core is a common set of patterns and concepts that can be used with any database system.
 EF Core database providers then layer database-specific behavior and functionality over this common framework.
-This allows each database system to do what it does best while still maintaining commonality, where appropriate, with other database systems. 
+This allows each database system to do what it does best while still maintaining commonality, where appropriate, with other database systems.
 
 Fundamentally, this means that switching out the database provider will change EF Core behavior and the application can't be expected to function correctly unless it explicitly accounts for any differences in behavior.
 That being said, in many cases doing this will work because there is a high degree of commonality amongst relational databases.
@@ -41,23 +42,24 @@ This illustrates the main trade-off involved throughout these approaches: when i
 Luckily, in this case the answer is quite easy: use local or on-premises SQL Server for developer testing.
 SQL Azure and SQL Server are extremely similar, so testing against SQL Server is usually a reasonable trade-off.
 That being said, it is still wise to run tests against SQL Azure itself before going into production.
- 
-### LocalDB 
+
+### LocalDB
 
 All the major database systems have some form of "Developer Edition" for local testing.
-SQL Server also has a feature called [LocalDB](/sql/database-engine/configure-windows/sql-server-express-localdb?view=sql-server-ver15).
+SQL Server also has a feature called [LocalDB](/sql/database-engine/configure-windows/sql-server-express-localdb).
 The primary advantage of LocalDB is that it spins up the database instance on demand.
 This avoids having a database service running on your machine even when you're not running tests.
 
 LocalDB is not without its issues:
-* It doesn't support everything that [SQL Server Developer Edition](/sql/sql-server/editions-and-components-of-sql-server-2016?view=sql-server-ver15) does.
+
+* It doesn't support everything that [SQL Server Developer Edition](/sql/sql-server/editions-and-components-of-sql-server-version-15?view=sql-server-ver15&preserve-view=true) does.
 * It isn't available on Linux.
 * It can cause lag on first test run as the service is spun up.
 
 Personally, I've never found it a problem having a database service running on my dev machine and I would generally recommend using Developer Edition instead.
 However, LocalDB may be appropriate for some people, especially on less powerful dev machines.
 
-[Running SQL Server](/sql/linux/quickstart-install-connect-docker?view=sql-server-ver15) (or any other database system) in a Docker container (or similar) is another way to avoid running the database system directly on your development machine.  
+[Running SQL Server](/sql/linux/quickstart-install-connect-docker) (or any other database system) in a Docker container (or similar) is another way to avoid running the database system directly on your development machine.  
 
 ## Approach 2: SQLite
 
@@ -71,17 +73,19 @@ The next best choice is to use something with similar functionality.
 This usually means another relational database, for which [SQLite](https://sqlite.org/index.html) is the obvious choice.
 
 SQLite is a good choice because:
+
 * It runs in-process with your application and so has low overhead.
 * It uses simple, automatically created files for databases, and so doesn't require database management.
 * It has an in-memory mode that avoids even the file creation.
 
 However, remember that:
+
 * SQLite inevitability doesn't support everything that your production database system does.
 * SQLite will behave differently than your production database system for some queries.
 
 So if you do use SQLite for some testing, make sure to also test against your real database system.
 
-See [Testing with SQLite](xref:core/miscellaneous/testing/sqlite) for EF Core specific guidance. 
+See [Testing with SQLite](xref:core/miscellaneous/testing/sqlite) for EF Core specific guidance.
 
 ## Approach 3: The EF Core in-memory database
 
@@ -108,6 +112,6 @@ Doing so is difficult, cumbersome, and fragile.
 
 Instead we use the EF in-memory database when unit testing something that uses DbContext.
 In this case using the EF in-memory database is appropriate because the test is not dependent on database behavior.
-Just don't do this to test actual database queries or updates.   
+Just don't do this to test actual database queries or updates.
 
-The [EF Core testing sample](xref:core/miscellaneous/testing/testing-sample) demonstrates tests using the EF in-memory database, as well as SQL Server and SQLite. 
+The [EF Core testing sample](xref:core/miscellaneous/testing/testing-sample) demonstrates tests using the EF in-memory database, as well as SQL Server and SQLite.

--- a/entity-framework/core/miscellaneous/testing/testing-sample.md
+++ b/entity-framework/core/miscellaneous/testing/testing-sample.md
@@ -11,25 +11,26 @@ no-loc: [Item, Tag, Items, Tags, items, tags]
 
 > [!TIP]
 > The code in this document can be found on GitHub as a [runnable sample](https://github.com/dotnet/EntityFramework.Docs/tree/master/samples/core/Miscellaneous/Testing/ItemsWebApi/).
-> Note that some of these tests **are expected to fail**. The reasons for this are explained below. 
+> Note that some of these tests **are expected to fail**. The reasons for this are explained below.
 
 This doc walks through a sample for testing code that uses EF Core.
 
 ## The application
 
 The [sample](https://github.com/dotnet/EntityFramework.Docs/tree/master/samples/core/Miscellaneous/Testing/ItemsWebApi/) contains two projects:
-- ItemsWebApi: A very simple [Web API backed by ASP.NET Core](/aspnet/core/tutorials/first-web-api?view=aspnetcore-3.1&tabs=visual-studio) with a single controller
+
+- ItemsWebApi: A very simple [Web API backed by ASP.NET Core](/aspnet/core/tutorials/first-web-api) with a single controller
 - Tests: An [XUnit](https://xunit.net/) test project to test the controller
 
 ### The model and business rules
 
 The model backing this API has two entity types: Items and Tags.
 
-* Items have a case-sensitive name and a collection of Tags.
-* Each Tag has a label and a count representing the number of times it has been applied to the Item.
-* Each Item should only have one Tag with a given label.
-  * If an item is tagged with the same label more than once, then the count on the existing tag with that label is incremented instead of a new tag being created. 
-* Deleting an Item should delete all associated Tags.
+- Items have a case-sensitive name and a collection of Tags.
+- Each Tag has a label and a count representing the number of times it has been applied to the Item.
+- Each Item should only have one Tag with a given label.
+  - If an item is tagged with the same label more than once, then the count on the existing tag with that label is incremented instead of a new tag being created.
+- Deleting an Item should delete all associated Tags.
 
 #### The Item entity type
 
@@ -42,11 +43,12 @@ And its configuration in `DbContext.OnModelCreating`:
 [!code-csharp[ConfigureItem](../../../../samples/core/Miscellaneous/Testing/ItemsWebApi/ItemsWebApi/ItemsContext.cs?name=ConfigureItem)]
 
 Notice that entity type constrains the way it can be used to reflect the domain model and business rules. In particular:
+
 - The primary key is mapped directly to the `_id` field and not exposed publicly
   - EF detects and uses the private constructor accepting the primary key value and name.
-- The `Name` property is read-only and set only in the constructor. 
+- The `Name` property is read-only and set only in the constructor.
 - Tags are exposed as a `IReadOnlyList<Tag>` to prevent arbitrary modification.
-  - EF associates the `Tags` property with the `_tags` backing field by matching their names. 
+  - EF associates the `Tags` property with the `_tags` backing field by matching their names.
   - The `AddTag` method takes a tag label and implements the business rule described above.
     That is, a tag is only added for new labels.
     Otherwise the count on an existing label is incremented.
@@ -95,29 +97,29 @@ Most validation and error handling have been removed to reduce clutter.
 ## The Tests
 
 The tests are organized to run with multiple database provider configurations:
-* The SQL Server provider, which is the provider used by the application
-* The SQLite provider
-* The SQLite provider using in-memory SQLite databases
-* The EF in-memory database provider
+
+- The SQL Server provider, which is the provider used by the application
+- The SQLite provider
+- The SQLite provider using in-memory SQLite databases
+- The EF in-memory database provider
 
 This is achieved by putting all the tests in a base class, then inheriting from this to test with each provider.
 
 > [!TIP]
 > You will need to change the SQL Server connection string if you're not using LocalDB.
-
-> [!TIP]
-> See [Testing with SQLite](xref:core/miscellaneous/testing/sqlite) for guidance on using SQLite for in-memory testing. 
+> See [Testing with SQLite](xref:core/miscellaneous/testing/sqlite) for guidance on using SQLite for in-memory testing.
 
 The following two tests are expected to fail:
-* `Can_remove_item_and_all_associated_tags` when running with the EF in-memory database provider
-* `Can_add_item_differing_only_by_case` when running with the SQL Server provider
+
+- `Can_remove_item_and_all_associated_tags` when running with the EF in-memory database provider
+- `Can_add_item_differing_only_by_case` when running with the SQL Server provider
 
 This is covered in more detail below.
 
 ### Setting up and seeding the database
 
 XUnit, like most testing frameworks, will create a new test class instance for each test run.
-Also, XUnit will not run tests within a given test class in parallel. 
+Also, XUnit will not run tests within a given test class in parallel.
 This means that we can setup and configure the database in the test constructor and it will be in a well-known state for each test.
 
 > [!TIP]
@@ -126,11 +128,12 @@ This means that we can setup and configure the database in the test constructor 
 > Approaches for reducing this overhead are covered in [Sharing databases across tests](xref:core/miscellaneous/testing/sharing-databases).
 
 When each test is run:
-* DbContextOptions are configured for the provider in use and passed to the base class constructor
-  * These options are stored in a property and used throughout the tests for creating DbContext instances
-* A Seed method is called to create and seed the database
-  * The Seed method ensures the database is clean by deleting it and then re-creating it
-  * Some well-known test entities are created and saved to the database
+
+- DbContextOptions are configured for the provider in use and passed to the base class constructor
+  - These options are stored in a property and used throughout the tests for creating DbContext instances
+- A Seed method is called to create and seed the database
+  - The Seed method ensures the database is clean by deleting it and then re-creating it
+  - Some well-known test entities are created and saved to the database
 
 [!code-csharp[Seeding](../../../../samples/core/Miscellaneous/Testing/ItemsWebApi/Tests/ItemsControllerTest.cs?name=Seeding)]
 
@@ -150,12 +153,12 @@ For example:
 
 [!code-csharp[CanGetItems](../../../../samples/core/Miscellaneous/Testing/ItemsWebApi/Tests/ItemsControllerTest.cs?name=CanGetItems)]
 
-Notice that different DbContext instances are used to seed the database and run the tests. 
+Notice that different DbContext instances are used to seed the database and run the tests.
 This ensures that the test is not using (or tripping over) entities tracked by the context when seeding.
 It also better matches what happens in web apps and services.
 
 Tests that mutate the database create a second DbContext instance in the test for similar reasons.
-That is, creating a new, clean, context and then reading into it from the database to ensure that the changes were saved to the database. 
+That is, creating a new, clean, context and then reading into it from the database to ensure that the changes were saved to the database.
 For example:
 
 [!code-csharp[CanAddItem](../../../../samples/core/Miscellaneous/Testing/ItemsWebApi/Tests/ItemsControllerTest.cs?name=CanAddItem)]
@@ -183,7 +186,7 @@ Running this test against the EF in-memory database indicates that everything is
 Everything still looks fine when using SQLite.
 But the test fails when run against SQL Server!
 
-```
+```console
 System.InvalidOperationException : Sequence contains more than one element
    at System.Linq.ThrowHelper.ThrowMoreThanOneElementException()
    at System.Linq.Enumerable.Single[TSource](IEnumerable`1 source)
@@ -194,14 +197,14 @@ System.InvalidOperationException : Sequence contains more than one element
 ```
 
 This is because both the EF in-memory database and the SQLite database are case-sensitive by default.
-SQL Server, on the other hand, is case-insensitive! 
+SQL Server, on the other hand, is case-insensitive!
 
 EF Core, by design, does not change these behaviors because forcing a change in case-sensitivity can have a big performance impact.
 
 Once we know this is a problem we can fix the application and compensate in tests.
 However, the point here is that this bug could be missed if only testing with the EF in-memory database or SQLite providers.
 
-### Test fails when the application is correct 
+### Test fails when the application is correct
 
 Another of the requirements for our application is that "deleting an Item should delete all associated Tags."
 Again, easy to test:
@@ -210,14 +213,14 @@ Again, easy to test:
 
 This test passes on SQL Server and SQLite, but fails with the EF in-memory database!
 
-```
+```console
 Assert.False() Failure
 Expected: False
 Actual:   True
    at Tests.ItemsControllerTest.Can_remove_item_and_all_associated_tags()
 ```
 
-In this case, the application is working correctly because SQL Server supports [cascade deletes](xref:core/saving/cascade-delete). 
+In this case, the application is working correctly because SQL Server supports [cascade deletes](xref:core/saving/cascade-delete).
 SQLite also supports cascade deletes, as do most relational databases, so testing this on SQLite works.
 On the other hand, the EF in-memory database [does not support cascade deletes](https://github.com/dotnet/efcore/issues/3924).
 This means that this part of the application cannot be tested with the EF in-memory database provider.

--- a/entity-framework/core/modeling/value-comparers.md
+++ b/entity-framework/core/modeling/value-comparers.md
@@ -19,7 +19,7 @@ uid: core/modeling/value-comparers
 EF Core needs to compare property values when:
 
 * Determining whether a property has been changed as part of [detecting changes for updates](xref:core/saving/basic)
-* Determining whether two key values are the same when resolving relationships 
+* Determining whether two key values are the same when resolving relationships
 
 This is handled automatically for common primitive types such as int, bool, DateTime, etc.
 
@@ -61,6 +61,7 @@ Consider a property that uses a value converter to map a simple, immutable class
 [!code-csharp[ConfigureImmutableClassProperty](../../../samples/core/Modeling/ValueConversions/MappingImmutableClassProperty.cs?name=ConfigureImmutableClassProperty)]
 
 Properties of this type do not need special comparisons or snapshots because:
+
 * Equality is overridden so that different instances will compare correctly
 * The type is immutable, so there is no chance of mutating a snapshot value
 
@@ -85,11 +86,12 @@ It is recommended that you use immutable types (classes or structs) with value c
 This is usually more efficient and has cleaner semantics than using a mutable type.
 
 However, that being said, it is common to use properties of types that the application cannot change.
-For example, mapping a property containing a list of numbers: 
+For example, mapping a property containing a list of numbers:
 
 [!code-csharp[ListProperty](../../../samples/core/Modeling/ValueConversions/MappingListProperty.cs?name=ListProperty)]
 
-The [`List<T>` class](/dotnet/api/system.collections.generic.list-1?view=netstandard-2.1):
+The [`List<T>` class](/dotnet/api/system.collections.generic.list-1):
+
 * Has reference equality; two lists containing the same values are treated as different.
 * Is mutable; values in the list can be added and removed.
 
@@ -106,6 +108,7 @@ This then requires setting a `ValueComparer<T>` on the property to force EF Core
 > Instead, the code above calls SetValueComparer on the lower-level IMutableProperty exposed by the builder as 'Metadata'.
 
 The `ValueComparer<T>` constructor accepts three expressions:
+
 * An expression for checking equality
 * An expression for generating a hash code
 * An expression to snapshot a value  
@@ -118,20 +121,20 @@ Be immutable instead if you can.)
 
 The snapshot is created by cloning the list with ToList.
 Again, this is only needed if the lists are going to be mutated.
-Be immutable instead if you can. 
+Be immutable instead if you can.
 
 > [!NOTE]  
 > Value converters and comparers are constructed using expressions rather than simple delegates.
 > This is because EF inserts these expressions into a much more complex expression tree that is then compiled into an entity shaper delegate.
 > Conceptually, this is similar to compiler inlining.
-> For example, a simple conversion may just be a compiled in cast, rather than a call to another method to do the conversion.    
+> For example, a simple conversion may just be a compiled in cast, rather than a call to another method to do the conversion.
 
 ### Key comparers
 
 The background section covers why key comparisons may require special semantics.
 Make sure to create a comparer that is appropriate for keys when setting it on a primary, principal, or foreign key property.
 
-Use [SetKeyValueComparer](/dotnet/api/microsoft.entityframeworkcore.mutablepropertyextensions.setkeyvaluecomparer?view=efcore-3.1) in the rare cases where different semantics is required on the same property.
+Use [SetKeyValueComparer](/dotnet/api/microsoft.entityframeworkcore.mutablepropertyextensions.setkeyvaluecomparer) in the rare cases where different semantics is required on the same property.
 
 > [!NOTE]  
 > SetStructuralComparer has been obsoleted in EF Core 5.0.
@@ -141,7 +144,7 @@ Use [SetKeyValueComparer](/dotnet/api/microsoft.entityframeworkcore.mutableprope
 
 Sometimes the default comparison used by EF Core may not be appropriate.
 For example, mutation of byte arrays is not, by default, detected in EF Core.
-This can be overridden by setting a different comparer on the property: 
+This can be overridden by setting a different comparer on the property:
 
 [!code-csharp[OverrideComparer](../../../samples/core/Modeling/ValueConversions/OverridingByteArrayComparisons.cs?name=OverrideComparer)]
 

--- a/entity-framework/core/providers/sql-server/azure-sql-database.md
+++ b/entity-framework/core/providers/sql-server/azure-sql-database.md
@@ -29,6 +29,5 @@ Use [HasPerformanceLevelSql](/dotnet/api/Microsoft.EntityFrameworkCore.SqlServer
 
 [!code-csharp[HasPerformanceLevel](../../../../samples/core/SqlServer/AzureDatabase/AzureSqlContext.cs?name=HasPerformanceLevelSql)]
 
-
 >[!TIP]
-> You can find all the supported values in the [ALTER DATABASE documentation](/sql/t-sql/statements/alter-database-transact-sql?view=azuresqldb-current).
+> You can find all the supported values in the [ALTER DATABASE documentation](/sql/t-sql/statements/alter-database-transact-sql?view=azuresqldb-current&preserve-view=true).

--- a/entity-framework/core/what-is-new/ef-core-5.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-5.0/whatsnew.md
@@ -487,7 +487,7 @@ In previous releases, this behavior was configurable through registration of a p
 
 ### Savepoints
 
-EF Core now supports [savepoints](/SQL/t-sql/language-elements/save-transaction-transact-sql?view=sql-server-ver15#remarks) for greater control over transactions that execute multiple operations.
+EF Core now supports [savepoints](/sql/t-sql/language-elements/save-transaction-transact-sql#remarks) for greater control over transactions that execute multiple operations.
 
 Savepoints can be manually created, released, and rolled back. For example:
 
@@ -845,7 +845,7 @@ Documentation is tracked by issue [#2273](https://github.com/dotnet/EntityFramew
 
 ### Flow arguments into IDesignTimeDbContextFactory
 
-Arguments are now flowed from the command line into the `CreateDbContext` method of [IDesignTimeDbContextFactory](/dotnet/api/microsoft.entityframeworkcore.design.idesigntimedbcontextfactory-1?view=efcore-3.1). For example, to indicate this is a dev build, a custom argument (e.g. `dev`) can be passed on the command line:
+Arguments are now flowed from the command line into the `CreateDbContext` method of [IDesignTimeDbContextFactory](/dotnet/api/microsoft.entityframeworkcore.design.idesigntimedbcontextfactory-1). For example, to indicate this is a dev build, a custom argument (e.g. `dev`) can be passed on the command line:
 
 ```
 dotnet ef migrations add two --verbose --dev
@@ -1118,7 +1118,7 @@ Documentation is tracked by issue [#2075](https://github.com/dotnet/EntityFramew
 
 ### Change-tracking proxies
 
-EF Core can now generate runtime proxies that automatically implement [INotifyPropertyChanging](/dotnet/api/system.componentmodel.inotifypropertychanging?view=netcore-3.1) and [INotifyPropertyChanged](/dotnet/api/system.componentmodel.inotifypropertychanged?view=netcore-3.1). These then report value changes on entity properties directly to EF Core, avoiding the need to scan for changes. However, proxies come with their own set of limitations, so they are not for everyone.
+EF Core can now generate runtime proxies that automatically implement [INotifyPropertyChanging](/dotnet/api/system.componentmodel.inotifypropertychanging) and [INotifyPropertyChanged](/dotnet/api/system.componentmodel.inotifypropertychanged). These then report value changes on entity properties directly to EF Core, avoiding the need to scan for changes. However, proxies come with their own set of limitations, so they are not for everyone.
 
 Documentation is tracked by issue [#2076](https://github.com/dotnet/EntityFramework.Docs/issues/2076).
 


### PR DESCRIPTION
View is like product version.
By not specifying the view, it will go to the latest version automatically.
In some cases we need to target particular view there we need to add &preserve-view=true

New warnings everyday!