### PR TITLE
Remove ms.assetid

### DIFF
--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -3,7 +3,6 @@ title: Tools & Extensions - EF Core
 description: External tools and extensions for Entity Framework Core
 author: ErikEJ
 ms.date: 04/11/2020
-ms.assetid: 14fffb6c-a687-4881-a094-af4a1359a296
 uid: core/extensions/index
 ---
 

--- a/entity-framework/core/get-started/index.md
+++ b/entity-framework/core/get-started/index.md
@@ -3,7 +3,6 @@ title: Getting Started - EF Core
 description: Getting started tutorial for Entity Framework Core
 author: rick-anderson
 ms.date: 09/17/2019
-ms.assetid: 3c88427c-20c6-42ec-a736-22d3eccd5071
 uid: core/get-started/index
 ---
 

--- a/entity-framework/core/get-started/install/index.md
+++ b/entity-framework/core/get-started/install/index.md
@@ -3,7 +3,6 @@ title: Installing Entity Framework Core - EF Core
 description: Installation instructions for Entity Framework Core
 author: divega
 ms.date: 08/06/2017
-ms.assetid: 608cc774-c570-4809-8a3e-cd2c8446b8b2
 uid: core/get-started/install/index
 ---
 # Installing Entity Framework Core

--- a/entity-framework/core/index.md
+++ b/entity-framework/core/index.md
@@ -3,7 +3,6 @@ title: Overview of Entity Framework Core - EF Core
 description: General introductory overiew of Entity Framework Core
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: bc2a2676-bc46-493f-bf49-e3cc97994d57
 uid: core/index
 ---
 

--- a/entity-framework/core/managing-schemas/scaffolding.md
+++ b/entity-framework/core/managing-schemas/scaffolding.md
@@ -4,7 +4,6 @@ description: Reverse engineering a model from an existing database using Entity 
 author: bricelam
 ms.author: bricelam
 ms.date: 11/13/2018
-ms.assetid: 6263EF7D-4989-42E6-BDEE-45DA770342FB
 uid: core/managing-schemas/scaffolding
 ---
 # Reverse Engineering

--- a/entity-framework/core/miscellaneous/async.md
+++ b/entity-framework/core/miscellaneous/async.md
@@ -3,7 +3,6 @@ title: Asynchronous Programming - EF Core
 description: Querying and saving data asynchronously with Entity Framework Core
 author: roji
 ms.date: 9/2/2020
-ms.assetid: 38f71624-7a68-4c72-a918-3e7b858ef090
 uid: core/miscellaneous/async
 ---
 # Asynchronous Programming

--- a/entity-framework/core/miscellaneous/collations-and-case-sensitivity.md
+++ b/entity-framework/core/miscellaneous/collations-and-case-sensitivity.md
@@ -3,7 +3,6 @@ title: Collations and case sensitivity - EF Core
 description: Configuring collations and case-sensitivity in the database and on queries with Entity Framework Core
 author: roji
 ms.date: 04/27/2020
-ms.assetid: bde4e0ee-fba3-4813-a849-27049323d301
 uid: core/miscellaneous/collations-and-case-sensitivity
 ---
 # Collations and Case Sensitivity

--- a/entity-framework/core/miscellaneous/configuring-dbcontext.md
+++ b/entity-framework/core/miscellaneous/configuring-dbcontext.md
@@ -3,7 +3,6 @@ title: Configuring a DbContext - EF Core
 description: Strategies for configuring DbContexts with Entity Framework Core
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: d7a22b5a-4c5b-4e3b-9897-4d7320fcd13f
 uid: core/miscellaneous/configuring-dbcontext
 ---
 # Configuring a DbContext

--- a/entity-framework/core/miscellaneous/connection-resiliency.md
+++ b/entity-framework/core/miscellaneous/connection-resiliency.md
@@ -3,7 +3,6 @@ title: Connection Resiliency - EF Core
 description: Using connection resiliency to automatically retry failed commands with Entity Framework Core
 author: rowanmiller
 ms.date: 11/15/2016
-ms.assetid: e079d4af-c455-4a14-8e15-a8471516d748
 uid: core/miscellaneous/connection-resiliency
 ---
 

--- a/entity-framework/core/miscellaneous/connection-strings.md
+++ b/entity-framework/core/miscellaneous/connection-strings.md
@@ -3,7 +3,6 @@ title: Connection Strings - EF Core
 description: Managing connection strings under different environments with Entity Framework Core
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: aeb0f5f8-b212-4f89-ae83-c642a5190ba0
 uid: core/miscellaneous/connection-strings
 ---
 # Connection Strings

--- a/entity-framework/core/miscellaneous/logging.md
+++ b/entity-framework/core/miscellaneous/logging.md
@@ -3,7 +3,6 @@ title: Logging - EF Core
 description: Configuring logging with Entity Framework Core
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: f6e35c6d-45b7-4258-be1d-87c1bb67438d
 uid: core/miscellaneous/logging
 ---
 # Logging

--- a/entity-framework/core/miscellaneous/nullable-reference-types.md
+++ b/entity-framework/core/miscellaneous/nullable-reference-types.md
@@ -3,7 +3,6 @@ title: Working with nullable reference types - EF Core
 description: Working with C# nullable reference types when using Entity Framework Core
 author: roji
 ms.date: 09/09/2019
-ms.assetid: bde4e0ee-fba3-4813-a849-27049323d301
 uid: core/miscellaneous/nullable-reference-types
 ---
 # Working with Nullable Reference Types

--- a/entity-framework/core/modeling/backing-field.md
+++ b/entity-framework/core/modeling/backing-field.md
@@ -3,7 +3,6 @@ title: Backing Fields - EF Core
 description: Configuring backing fields for properties in an Entity Framework Core model
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: a628795e-64df-4f24-a5e8-76bc261e7ed8
 uid: core/modeling/backing-field
 ---
 # Backing Fields

--- a/entity-framework/core/modeling/concurrency.md
+++ b/entity-framework/core/modeling/concurrency.md
@@ -3,7 +3,6 @@ title: Concurrency Tokens - EF Core
 description: Configuring concurrency tokens for optimistic concurrency control in an Entity Framework Core model
 author: AndriySvyryd
 ms.date: 01/03/2020
-ms.assetid: bc8b1cb0-befe-4b67-8004-26e6c5f69385
 uid: core/modeling/concurrency
 ---
 # Concurrency Tokens

--- a/entity-framework/core/modeling/constructors.md
+++ b/entity-framework/core/modeling/constructors.md
@@ -3,7 +3,6 @@ title: Entity types with constructors - EF Core
 description: Using constructors to bind data with Entity Framework Core model
 author: ajcvickers
 ms.date: 02/23/2018
-ms.assetid: 420AFFE7-B709-4A68-9149-F06F8746FB33
 uid: core/modeling/constructors
 ---
 # Entity types with constructors

--- a/entity-framework/core/modeling/data-seeding.md
+++ b/entity-framework/core/modeling/data-seeding.md
@@ -4,7 +4,6 @@ description: Using data seeding to populate a database with an initial set of da
 author: AndriySvyryd
 ms.author: ansvyryd
 ms.date: 11/02/2018
-ms.assetid: 3154BF3C-1749-4C60-8D51-AE86773AA116
 uid: core/modeling/data-seeding
 ---
 # Data Seeding

--- a/entity-framework/core/modeling/dynamic-model.md
+++ b/entity-framework/core/modeling/dynamic-model.md
@@ -3,7 +3,6 @@ title: Alternating between multiple models with the same DbContext type - EF Cor
 description: Alternating between multiple models with the same DbContext type using Entity Framework Core
 author: AndriySvyryd
 ms.date: 01/03/2020
-ms.assetid: 3154BF3C-1749-4C60-8D51-AE86773AA116
 uid: core/modeling/dynamic-model
 ---
 # Alternating between multiple models with the same DbContext type

--- a/entity-framework/core/modeling/entity-properties.md
+++ b/entity-framework/core/modeling/entity-properties.md
@@ -3,7 +3,6 @@ title: Entity Properties - EF Core
 description: How to configure and map entity properties using Entity Framework Core
 author: lajones
 ms.date: 05/27/2020
-ms.assetid: e9dff604-3469-4a05-8f9e-18ac281d82a9
 uid: core/modeling/entity-properties
 ---
 # Entity Properties

--- a/entity-framework/core/modeling/entity-types.md
+++ b/entity-framework/core/modeling/entity-types.md
@@ -3,7 +3,6 @@ title: Entity Types - EF Core
 description: How to configure and map entity types using Entity Framework Core
 author: roji
 ms.date: 12/03/2019
-ms.assetid: cbe6935e-2679-4b77-8914-a8d772240cf1
 uid: core/modeling/entity-types
 ---
 # Entity Types

--- a/entity-framework/core/modeling/index.md
+++ b/entity-framework/core/modeling/index.md
@@ -3,7 +3,6 @@ title: Creating and configuring a model - EF Core
 description: Overview of creating and configuring a model with Entity Framework Core
 author: rowanmiller
 ms.date: 11/05/2019
-ms.assetid: 88253ff3-174e-485c-b3f8-768243d01ee1
 uid: core/modeling/index
 ---
 # Creating and configuring a model

--- a/entity-framework/core/modeling/indexes.md
+++ b/entity-framework/core/modeling/indexes.md
@@ -3,7 +3,6 @@ title: Indexes - EF Core
 description: Configuring indexes in an Entity Framework Core model
 author: roji
 ms.date: 12/16/2019
-ms.assetid: 85b92003-b692-417d-ac1d-76d40dce664b
 uid: core/modeling/indexes
 ---
 # Indexes

--- a/entity-framework/core/modeling/sequences.md
+++ b/entity-framework/core/modeling/sequences.md
@@ -3,7 +3,6 @@ title: Sequences - EF Core
 description: Configuring sequences in an Entity Framework Core model
 author: roji
 ms.date: 12/18/2019
-ms.assetid: 94f81a92-3c72-4e14-912a-f99310374e42
 uid: core/modeling/sequences
 ---
 # Sequences

--- a/entity-framework/core/modeling/shadow-properties.md
+++ b/entity-framework/core/modeling/shadow-properties.md
@@ -3,7 +3,6 @@ title: Shadow Properties - EF Core
 description: Configuring shadow properties in an Entity Framework Core model
 author: AndriySvyryd
 ms.date: 01/03/2020
-ms.assetid: 75369266-d2b9-4416-b118-ed238f81f599
 uid: core/modeling/shadow-properties
 ---
 # Shadow Properties

--- a/entity-framework/core/modeling/spatial.md
+++ b/entity-framework/core/modeling/spatial.md
@@ -4,7 +4,6 @@ description: Using spatial data in an Entity Framework Core model
 author: bricelam
 ms.author: bricelam
 ms.date: 11/01/2018
-ms.assetid: 2BDE29FC-4161-41A0-841E-69F51CCD9341
 uid: core/modeling/spatial
 ---
 # Spatial Data

--- a/entity-framework/core/modeling/value-conversions.md
+++ b/entity-framework/core/modeling/value-conversions.md
@@ -3,7 +3,6 @@ title: Value Conversions - EF Core
 description: Configuring value converters in an Entity Framework Core model
 author: ajcvickers
 ms.date: 02/19/2018
-ms.assetid: 3154BF3C-1749-4C60-8D51-AE86773AA116
 uid: core/modeling/value-conversions
 ---
 # Value Conversions

--- a/entity-framework/core/providers/in-memory/index.md
+++ b/entity-framework/core/providers/in-memory/index.md
@@ -3,7 +3,6 @@ title: InMemory Database Provider - EF Core
 description: Information on the Entity Framework Core InMemory database provider
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: 9af0cba7-7605-4f8f-9cfa-dd616fcb880c
 uid: core/providers/in-memory/index
 ---
 # EF Core In-Memory Database Provider

--- a/entity-framework/core/providers/provider-log.md
+++ b/entity-framework/core/providers/provider-log.md
@@ -4,7 +4,6 @@ description: A log of changes in Entity Framework Core which impact providers
 author: ajcvickers
 ms.author: avickers
 ms.date: 08/08/2018
-ms.assetid: 7CEF496E-A5B0-4F5F-B68E-529609B23EF9
 ms.technology: entity-framework-core
 uid: core/providers/provider-log
 ---

--- a/entity-framework/core/providers/sqlite/index.md
+++ b/entity-framework/core/providers/sqlite/index.md
@@ -3,7 +3,6 @@ title: SQLite Database Provider - EF Core
 description: Information on the Entity Framework Core SQLite database provider
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: 3e2f7698-fec2-4cec-9e2d-2e3e0074120c
 uid: core/providers/sqlite/index
 ---
 # SQLite EF Core Database Provider

--- a/entity-framework/core/providers/sqlite/limitations.md
+++ b/entity-framework/core/providers/sqlite/limitations.md
@@ -3,7 +3,6 @@ title: SQLite Database Provider - Limitations - EF Core
 description: Limitations of the Entity Framework Core SQLite database provider as compared to other providers
 author: bricelam
 ms.date: 07/16/2020
-ms.assetid: 94ab4800-c460-4caa-a5e8-acdfee6e6ce2
 uid: core/providers/sqlite/limitations
 ---
 # SQLite EF Core Database Provider Limitations

--- a/entity-framework/core/providers/writing-a-provider.md
+++ b/entity-framework/core/providers/writing-a-provider.md
@@ -3,7 +3,6 @@ title: Writing a Database Provider - EF Core
 description: Information on writing a new Entity Framework Core provider
 author: anmiller
 ms.date: 10/27/2016
-ms.assetid: 1165e2ec-e421-43fc-92ab-d92f9ab3c494
 uid: core/providers/writing-a-provider
 ---
 

--- a/entity-framework/core/querying/client-eval.md
+++ b/entity-framework/core/querying/client-eval.md
@@ -3,7 +3,6 @@ title: Client vs. Server Evaluation - EF Core
 description: Client and server evaluation of queries with Entity Framework Core
 author: smitpatel
 ms.date: 10/03/2019
-ms.assetid: 8b6697cc-7067-4dc2-8007-85d80503d123
 uid: core/querying/client-eval
 ---
 # Client vs. Server Evaluation

--- a/entity-framework/core/querying/complex-query-operators.md
+++ b/entity-framework/core/querying/complex-query-operators.md
@@ -3,7 +3,6 @@ title: Complex Query Operators - EF Core
 description: In-depth information on the more complex LINQ query operators when using Entity Framework Core
 author: smitpatel
 ms.date: 10/03/2019
-ms.assetid: 2e187a2a-4072-4198-9040-aaad68e424fd
 uid: core/querying/complex-query-operators
 ---
 # Complex Query Operators

--- a/entity-framework/core/querying/how-query-works.md
+++ b/entity-framework/core/querying/how-query-works.md
@@ -3,7 +3,6 @@ title: How Queries Work - EF Core
 description: General information on how Entity Framework Core internally compiles and executes queries
 author: ajcvickers
 ms.date: 03/17/2020
-ms.assetid: de2e34cd-659b-4cab-b5ed-7a979c6bf120
 uid: core/querying/how-query-works
 ---
 

--- a/entity-framework/core/querying/index.md
+++ b/entity-framework/core/querying/index.md
@@ -3,7 +3,6 @@ title: Querying Data - EF Core
 description: Overview of information on querying in Entity Framework Core
 author: smitpatel
 ms.date: 10/03/2019
-ms.assetid: 7c65ec3e-46c8-48f8-8232-9e31f96c277b
 uid: core/querying/index
 ---
 # Querying Data

--- a/entity-framework/core/querying/raw-sql.md
+++ b/entity-framework/core/querying/raw-sql.md
@@ -3,7 +3,6 @@ title: Raw SQL Queries - EF Core
 description: Using raw SQL for queries in Entity Framework Core
 author: smitpatel
 ms.date: 10/08/2019
-ms.assetid: 70aae9b5-8743-4557-9c5d-239f688bf418
 uid: core/querying/raw-sql
 ---
 # Raw SQL Queries

--- a/entity-framework/core/querying/related-data.md
+++ b/entity-framework/core/querying/related-data.md
@@ -3,7 +3,6 @@ title: Loading Related Data - EF Core
 description: Different strategies for loading related data with Entity Framework Core
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: f9fb64e2-6699-4d70-a773-592918c04c19
 uid: core/querying/related-data
 ---
 

--- a/entity-framework/core/querying/tags.md
+++ b/entity-framework/core/querying/tags.md
@@ -3,7 +3,6 @@ title: Query Tags - EF Core
 description: Using query tags to help identify specific queries in log messages emitted by Entity Framework Core
 author: divega
 ms.date: 11/14/2018
-ms.assetid: 73C7A627-C8E9-452D-9CD5-AFCC8FEFE395
 uid: core/querying/tags
 ---
 

--- a/entity-framework/core/querying/tracking.md
+++ b/entity-framework/core/querying/tracking.md
@@ -3,7 +3,6 @@ title: Tracking vs. No-Tracking Queries - EF Core
 description: Information on tracking and no-tracking queries in Entity Framework Core
 author: smitpatel
 ms.date: 10/10/2019
-ms.assetid: e17e060c-929f-4180-8883-40c438fbcc01
 uid: core/querying/tracking
 ---
 # Tracking vs. No-Tracking Queries

--- a/entity-framework/core/saving/basic.md
+++ b/entity-framework/core/saving/basic.md
@@ -3,7 +3,6 @@ title: Basic Save - EF Core
 description: Basic information on adding, updating and removing data with Entity Framework Core
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: 850d842e-3fad-4ef2-be17-053768e97b9e
 uid: core/saving/basic
 ---
 # Basic Save

--- a/entity-framework/core/saving/cascade-delete.md
+++ b/entity-framework/core/saving/cascade-delete.md
@@ -3,7 +3,6 @@ title: Cascade Delete - EF Core
 description: Configuring delete behaviors for related entities when a principal entity is deleted
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: ee8e14ec-2158-4c9c-96b5-118715e2ed9e
 uid: core/saving/cascade-delete
 ---
 # Cascade Delete

--- a/entity-framework/core/saving/disconnected-entities.md
+++ b/entity-framework/core/saving/disconnected-entities.md
@@ -4,7 +4,6 @@ description: Working with disconnected, untracked entities across multiple conte
 author: ajcvickers
 ms.author: avickers
 ms.date: 10/27/2016
-ms.assetid: 2533b195-d357-4056-b0e0-8698971bc3b0
 uid: core/saving/disconnected-entities
 ---
 # Disconnected entities

--- a/entity-framework/core/saving/explicit-values-generated-properties.md
+++ b/entity-framework/core/saving/explicit-values-generated-properties.md
@@ -3,7 +3,6 @@ title: Setting Explicit Values for Generated Properties - EF Core
 description: Information on setting values explicitly for properties configured as generated with Entity Framework Core
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: 3f1993c2-cdf5-425b-bac2-a2665a20322b
 uid: core/saving/explicit-values-generated-properties
 ---
 

--- a/entity-framework/core/saving/index.md
+++ b/entity-framework/core/saving/index.md
@@ -3,7 +3,6 @@ title: Saving Data - EF Core
 description: Overview of saving data with Entity Framework Core
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: ef044629-feca-4fd1-a48f-d208daedaf92
 uid: core/saving/index
 ---
 # Saving Data

--- a/entity-framework/core/saving/related-data.md
+++ b/entity-framework/core/saving/related-data.md
@@ -3,7 +3,6 @@ title: Saving Related Data - EF Core
 description: Information on saving graphs of related entities and managing relationships in Entity Framework Core
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: 07b6680f-ffcf-412c-9857-f997486b386c
 uid: core/saving/related-data
 ---
 # Saving Related Data

--- a/entity-framework/core/saving/transactions.md
+++ b/entity-framework/core/saving/transactions.md
@@ -3,7 +3,6 @@ title: Transactions - EF Core
 description: Managing transactions for atomicity when saving data with Entity Framework Core
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: d3e6515b-8181-482c-a790-c4a6778748c1
 uid: core/saving/transactions
 ---
 # Using Transactions

--- a/entity-framework/core/what-is-new/ef-core-1.0.md
+++ b/entity-framework/core/what-is-new/ef-core-1.0.md
@@ -3,7 +3,6 @@ title: What is new in EF Core 1.0 - EF Core
 description: Changes and improvements in Entity Framework Core 1.0
 author: divega
 ms.date: 10/27/2016
-ms.assetid: 20A25111-AEBE-4BC2-83A5-3F651952DF72
 uid: core/what-is-new/ef-core-1.0
 ---
 # Features included in EF Core 1.0

--- a/entity-framework/core/what-is-new/ef-core-1.1.md
+++ b/entity-framework/core/what-is-new/ef-core-1.1.md
@@ -3,7 +3,6 @@ title: What is new in EF Core 1.1 - EF Core
 description: Changes and improvements in Entity Framework Core 1.1
 author: divega
 ms.date: 10/27/2016
-ms.assetid: C7FE8C85-445A-4F0C-97EC-CC3F7F1D6F5E
 uid: core/what-is-new/ef-core-1.1
 ---
 # New features in EF Core 1.1

--- a/entity-framework/core/what-is-new/ef-core-2.0/index.md
+++ b/entity-framework/core/what-is-new/ef-core-2.0/index.md
@@ -3,7 +3,6 @@ title: What is new in EF Core 2.0 - EF Core
 description: Changes and improvements in Entity Framework Core 2.0
 author: divega
 ms.date: 02/20/2018
-ms.assetid: 2CB5809E-0EFB-44F6-AF14-9D5BFFFBFF9D
 uid: core/what-is-new/ef-core-2.0
 ---
 

--- a/entity-framework/core/what-is-new/ef-core-2.0/upgrade.md
+++ b/entity-framework/core/what-is-new/ef-core-2.0/upgrade.md
@@ -3,7 +3,6 @@ title: Upgrading from previous versions to EF Core 2 - EF Core
 description: Instructions and notes for upgrading to Entity Framework Core 2.0
 author: divega
 ms.date: 08/13/2017
-ms.assetid: 8BD43C8C-63D9-4F3A-B954-7BC518A1B7DB
 uid: core/what-is-new/ef-core-2.0/upgrade
 ---
 

--- a/entity-framework/core/what-is-new/ef-core-2.1.md
+++ b/entity-framework/core/what-is-new/ef-core-2.1.md
@@ -3,7 +3,6 @@ title: What is new in EF Core 2.1 - EF Core
 description: Changes and improvements in Entity Framework Core 2.1
 author: divega
 ms.date: 02/20/2018
-ms.assetid: 585F90A3-4D5A-4DD1-92D8-5243B14E0FEC
 uid: core/what-is-new/ef-core-2.1
 ---
 

--- a/entity-framework/core/what-is-new/ef-core-2.2.md
+++ b/entity-framework/core/what-is-new/ef-core-2.2.md
@@ -3,7 +3,6 @@ title: What is new in EF Core 2.2 - EF Core
 description: Changes and improvements in Entity Framework Core 2.2
 author: divega
 ms.date: 11/14/2018
-ms.assetid: 998C04F3-676A-4FCF-8450-CFB0457B4198
 uid: core/what-is-new/ef-core-2.2
 ---
 

--- a/entity-framework/core/what-is-new/ef-core-3.x/index.md
+++ b/entity-framework/core/what-is-new/ef-core-3.x/index.md
@@ -3,7 +3,6 @@ title: New features in Entity Framework Core 3.x - EF Core
 description: Changes and improvements in Entity Framework Core 3.x
 author: divega
 ms.date: 09/05/2020
-ms.assetid: 2EBE2CCC-E52D-483F-834C-8877F5EB0C0C
 uid: core/what-is-new/ef-core-3.x/index
 ---
 

--- a/entity-framework/ef6/fundamentals/async.md
+++ b/entity-framework/ef6/fundamentals/async.md
@@ -3,7 +3,6 @@ title: Async query and save - EF6
 description: Async query and save in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: d56e6f1d-4bd1-4b50-9558-9a30e04a8ec3
 uid: ef6/fundamentals/async
 ---
 # Async query and save

--- a/entity-framework/ef6/fundamentals/configuring/code-based.md
+++ b/entity-framework/ef6/fundamentals/configuring/code-based.md
@@ -3,7 +3,6 @@ title: Code-based configuration - EF6
 description: Code-based configuration in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 13886d24-2c74-4a00-89eb-aa0dee328d83
 uid: ef6/fundamentals/configuring/code-based
 ---
 # Code-based configuration

--- a/entity-framework/ef6/fundamentals/configuring/config-file.md
+++ b/entity-framework/ef6/fundamentals/configuring/config-file.md
@@ -3,7 +3,6 @@ title: Configuration File Settings - EF6
 description: Configuration file settings in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 000044c6-1d32-4cf7-ae1f-ea21d86ebf8f
 uid: ef6/fundamentals/configuring/config-file
 ---
 # Configuration File Settings

--- a/entity-framework/ef6/fundamentals/configuring/connection-strings.md
+++ b/entity-framework/ef6/fundamentals/configuring/connection-strings.md
@@ -3,7 +3,6 @@ title: Connection strings and models - EF6
 description: Connection strings and models in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 294bb138-978f-4fe2-8491-fdf3cd3c60c4
 uid: ef6/fundamentals/configuring/connection-strings
 ---
 # Connection strings and models

--- a/entity-framework/ef6/fundamentals/configuring/dependency-resolution.md
+++ b/entity-framework/ef6/fundamentals/configuring/dependency-resolution.md
@@ -3,7 +3,6 @@ title: Dependency resolution - EF6
 description: Dependency resolution in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 32d19ac6-9186-4ae1-8655-64ee49da55d0
 uid: ef6/fundamentals/configuring/dependency-resolution
 ---
 # Dependency resolution

--- a/entity-framework/ef6/fundamentals/connection-management.md
+++ b/entity-framework/ef6/fundamentals/connection-management.md
@@ -3,7 +3,6 @@ title: Connection management - EF6
 description: Connection management in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: ecaa5a27-b19e-4bf9-8142-a3fb00642270
 uid: ef6/fundamentals/connection-management
 ---
 # Connection management

--- a/entity-framework/ef6/fundamentals/connection-resiliency/commit-failures.md
+++ b/entity-framework/ef6/fundamentals/connection-resiliency/commit-failures.md
@@ -3,7 +3,6 @@ title: Handling transaction commit failures - EF6
 description: Handling transaction commit failures in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 5b1f7a7d-1b24-4645-95ec-5608a31ef577
 uid: ef6/fundamentals/connection-resiliency/commit-failures
 ---
 # Handling transaction commit failures

--- a/entity-framework/ef6/fundamentals/connection-resiliency/retry-logic.md
+++ b/entity-framework/ef6/fundamentals/connection-resiliency/retry-logic.md
@@ -3,7 +3,6 @@ title: Connection resiliency and retry logic - EF6
 description: Connection resiliency and retry logic in Entity Framework 6
 author: AndriySvyryd
 ms.date: 11/20/2019
-ms.assetid: 47d68ac1-927e-4842-ab8c-ed8c8698dff2
 uid: ef6/fundamentals/connection-resiliency/retry-logic
 ---
 # Connection resiliency and retry logic

--- a/entity-framework/ef6/fundamentals/databinding/winforms.md
+++ b/entity-framework/ef6/fundamentals/databinding/winforms.md
@@ -3,7 +3,6 @@ title: Databinding with WinForms - EF6
 description: Databinding with WinForms in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 80fc5062-2f1c-4dbd-ab6e-b99496784b36
 uid: ef6/fundamentals/databinding/winforms
 ---
 # Databinding with WinForms

--- a/entity-framework/ef6/fundamentals/databinding/wpf.md
+++ b/entity-framework/ef6/fundamentals/databinding/wpf.md
@@ -3,7 +3,6 @@ title: Databinding with WPF - EF6
 description: Databinding with WPF in Entity Framework 6
 author: divega
 ms.date: 05/19/2020
-ms.assetid: e90d48e6-bea7785-47ef-b756-7b89cce4daf0
 uid: ef6/fundamentals/databinding/wpf
 ---
 # Databinding with WPF

--- a/entity-framework/ef6/fundamentals/disconnected-entities/index.md
+++ b/entity-framework/ef6/fundamentals/disconnected-entities/index.md
@@ -3,7 +3,6 @@ title: Working with disconnected entities - EF6
 description: Working with disconnected entities in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 12138003-a373-4817-b1b7-724130202f5f
 uid: ef6/fundamentals/disconnected-entities/index
 ---
 # Working with disconnected entities

--- a/entity-framework/ef6/fundamentals/disconnected-entities/self-tracking-entities/index.md
+++ b/entity-framework/ef6/fundamentals/disconnected-entities/self-tracking-entities/index.md
@@ -3,7 +3,6 @@ title: Self-tracking entities - EF6
 description: Self-tracking entities in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 5e60f5be-7bbb-4bf8-835e-0ac808d6c84a
 uid: ef6/fundamentals/disconnected-entities/self-tracking-entities/index
 ---
 # Self-tracking entities

--- a/entity-framework/ef6/fundamentals/disconnected-entities/self-tracking-entities/walkthrough.md
+++ b/entity-framework/ef6/fundamentals/disconnected-entities/self-tracking-entities/walkthrough.md
@@ -3,7 +3,6 @@ title: Self-Tracking Entities Walkthrough - EF6
 description: Self-tracking entities walkthrough for Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: b21207c9-1d95-4aa3-ae05-bc5fe300dab0
 uid: ef6/fundamentals/disconnected-entities/self-tracking-entities/walkthrough
 ---
 # Self-Tracking Entities Walkthrough

--- a/entity-framework/ef6/fundamentals/install.md
+++ b/entity-framework/ef6/fundamentals/install.md
@@ -3,7 +3,6 @@ title: Get Entity Framework - EF6
 description: Get Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 122c38a2-f9e8-4ecc-9c72-a83bc9af7814
 uid: ef6/fundamentals/install
 ---
 # Get Entity Framework

--- a/entity-framework/ef6/fundamentals/logging-and-interception.md
+++ b/entity-framework/ef6/fundamentals/logging-and-interception.md
@@ -3,7 +3,6 @@ title: Logging and intercepting database operations - EF6
 description: Logging and intercepting database operations in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: b5ee7eb1-88cc-456e-b53c-c67e24c3f8ca
 uid: ef6/fundamentals/logging-and-interception
 ---
 # Logging and intercepting database operations

--- a/entity-framework/ef6/fundamentals/performance/ngen.md
+++ b/entity-framework/ef6/fundamentals/performance/ngen.md
@@ -3,7 +3,6 @@ title: Improving startup performance with NGen - EF6
 description: Improving startup performance with NGen in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: dc6110a0-80a0-4370-8190-cea942841cee
 uid: ef6/fundamentals/performance/ngen
 ---
 # Improving startup performance with NGen

--- a/entity-framework/ef6/fundamentals/performance/perf-whitepaper.md
+++ b/entity-framework/ef6/fundamentals/performance/perf-whitepaper.md
@@ -3,7 +3,6 @@ title: Performance considerations for EF4, EF5, and EF6 - EF6
 description: Performance considerations for Entity Framework 4, 5, and 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: d6d5a465-6434-45fa-855d-5eb48c61a2ea
 uid: ef6/fundamentals/performance/perf-whitepaper
 ---
 # Performance considerations for EF 4, 5, and 6

--- a/entity-framework/ef6/fundamentals/performance/pre-generated-views.md
+++ b/entity-framework/ef6/fundamentals/performance/pre-generated-views.md
@@ -3,7 +3,6 @@ title: Pre-generated mapping views - EF6
 description: Pre-generated mapping views in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 917ba9c8-6ddf-4631-ab8c-c4fb378c2fcd
 uid: ef6/fundamentals/performance/pre-generated-views
 ---
 # Pre-generated mapping views

--- a/entity-framework/ef6/fundamentals/providers/index.md
+++ b/entity-framework/ef6/fundamentals/providers/index.md
@@ -3,7 +3,6 @@ title: Entity Framework Providers - EF6
 description: Entity Framework Providers in Entity Framework 6
 author: divega
 ms.date: 06/27/2018
-ms.assetid: 7BFB7763-CD6C-4520-93A2-7B265F5FA586
 uid: ef6/fundamentals/providers/index
 ---
 

--- a/entity-framework/ef6/fundamentals/providers/provider-model.md
+++ b/entity-framework/ef6/fundamentals/providers/provider-model.md
@@ -3,7 +3,6 @@ title: The Entity Framework 6 provider model - EF6
 description: The Entity Framework 6 provider model in Entity Framework 6
 author: divega
 ms.date: 06/27/2018
-ms.assetid: 066832F0-D51B-4655-8BE7-C983C557E0E4
 uid: ef6/fundamentals/providers/provider-model
 ---
 # The Entity Framework 6 provider model

--- a/entity-framework/ef6/fundamentals/providers/spatial-support.md
+++ b/entity-framework/ef6/fundamentals/providers/spatial-support.md
@@ -3,7 +3,6 @@ title: Provider Support for Spatial Types - EF6
 description: Provider support for spatial types in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 1097cb00-15f5-453d-90ed-bff9403d23e3
 uid: ef6/fundamentals/providers/spatial-support
 ---
 # Provider Support for Spatial Types

--- a/entity-framework/ef6/fundamentals/proxies.md
+++ b/entity-framework/ef6/fundamentals/proxies.md
@@ -3,7 +3,6 @@ title: Working with proxies - EF6
 description: Working with proxies in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 869ee4dc-06f1-471d-8e0e-0a1a2bc59c30
 uid: ef6/fundamentals/proxies
 ---
 # Working with proxies

--- a/entity-framework/ef6/fundamentals/relationships.md
+++ b/entity-framework/ef6/fundamentals/relationships.md
@@ -3,7 +3,6 @@ title: Relationships, navigation properties, and foreign keys - EF6
 description: Relationships, navigation properties, and foreign keys in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 8a21ae73-6d9b-4b50-838a-ec1fddffcf37
 uid: ef6/fundamentals/relationships
 ---
 # Relationships, navigation properties, and foreign keys

--- a/entity-framework/ef6/fundamentals/testing/mocking.md
+++ b/entity-framework/ef6/fundamentals/testing/mocking.md
@@ -3,7 +3,6 @@ title: Testing with a mocking framework - EF6
 description: Testing with a mocking framework in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: bd66a638-d245-44d4-8e71-b9c6cb335cc7
 uid: ef6/fundamentals/testing/mocking
 ---
 # Testing with a mocking framework

--- a/entity-framework/ef6/fundamentals/testing/testability-article.md
+++ b/entity-framework/ef6/fundamentals/testing/testability-article.md
@@ -3,7 +3,6 @@ title: Testability and Entity Framework 4.0 - EF6
 description: Testability and Entity Framework 4.0
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 9430e2ab-261c-4e8e-8545-2ebc52d7a247
 ---
 # Testability and Entity Framework 4.0
 Scott Allen

--- a/entity-framework/ef6/fundamentals/testing/writing-test-doubles.md
+++ b/entity-framework/ef6/fundamentals/testing/writing-test-doubles.md
@@ -3,7 +3,6 @@ title: Testing with your own test doubles - EF6
 description: Testing with your own test doubles in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 16a8b7c0-2d23-47f4-9cc0-e2eb2e738ca3
 uid: ef6/fundamentals/testing/writing-test-doubles
 ---
 # Testing with your own test doubles

--- a/entity-framework/ef6/fundamentals/working-with-dbcontext.md
+++ b/entity-framework/ef6/fundamentals/working-with-dbcontext.md
@@ -3,7 +3,6 @@ title: Working with DbContext - EF6
 description: Working with DbContext in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: b0e6bddc-8a87-4d51-b1cb-7756df938c23
 uid: ef6/fundamentals/working-with-dbcontext
 ---
 # Working with DbContext

--- a/entity-framework/ef6/get-started.md
+++ b/entity-framework/ef6/get-started.md
@@ -3,7 +3,6 @@ title: Get started with Entity Framework 6 - EF6
 description: Get started with Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 66ce9113-81d2-480f-8c16-d00ec405b2f7
 uid: ef6/get-started
 ---
 # Get started with Entity Framework 6

--- a/entity-framework/ef6/index.md
+++ b/entity-framework/ef6/index.md
@@ -3,7 +3,6 @@ title: Overview of Entity Framework 6 - EF6
 description: Overview of Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 8ae74d63-6bad-4686-b325-bbf9d68f3743
 uid: ef6/index
 ---
 # Entity Framework 6

--- a/entity-framework/ef6/modeling/code-first/conventions/built-in.md
+++ b/entity-framework/ef6/modeling/code-first/conventions/built-in.md
@@ -3,7 +3,6 @@ title: Code First Conventions - EF6
 description: Code First Conventions in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: bc644573-c2b2-4ed7-8745-3c37c41058ad
 uid: ef6/modeling/code-first/conventions/built-in
 ---
 # Code First Conventions

--- a/entity-framework/ef6/modeling/code-first/conventions/custom.md
+++ b/entity-framework/ef6/modeling/code-first/conventions/custom.md
@@ -3,7 +3,6 @@ title: Custom Code First Conventions - EF6
 description: Custom Code First Conventions in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: dd2bdbd9-ae9e-470a-aeb8-d0ba160499b7
 uid: ef6/modeling/code-first/conventions/custom
 ---
 # Custom Code First Conventions

--- a/entity-framework/ef6/modeling/code-first/conventions/model.md
+++ b/entity-framework/ef6/modeling/code-first/conventions/model.md
@@ -3,7 +3,6 @@ title: Model-Based Conventions - EF6
 description: Model-Based Conventions in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 0fc4eef8-29b8-4192-9c77-08fd33d3db3a
 uid: ef6/modeling/code-first/conventions/model
 ---
 # Model-Based Conventions

--- a/entity-framework/ef6/modeling/code-first/data-annotations.md
+++ b/entity-framework/ef6/modeling/code-first/data-annotations.md
@@ -3,7 +3,6 @@ title: Code First Data Annotations - EF6
 description: Code First Data Annotations in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 80abefbd-23c9-4fce-9cd3-520e5df9856e
 uid: ef6/modeling/code-first/data-annotations
 ---
 # Code First Data Annotations

--- a/entity-framework/ef6/modeling/code-first/data-types/enums.md
+++ b/entity-framework/ef6/modeling/code-first/data-types/enums.md
@@ -3,7 +3,6 @@ title: Enum Support - Code First - EF6
 description: Enum Support - Code First in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 77a42501-27c9-4f4b-96df-26c128021467
 uid: ef6/modeling/code-first/data-types/enums
 ---
 # Enum Support - Code First

--- a/entity-framework/ef6/modeling/code-first/data-types/spatial.md
+++ b/entity-framework/ef6/modeling/code-first/data-types/spatial.md
@@ -3,7 +3,6 @@ title: Spatial - Code First - EF6
 description: Spatial - Code First in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: d617aed1-15f2-48a9-b187-186991c666e3
 uid: ef6/modeling/code-first/data-types/spatial
 ---
 # Spatial - Code First

--- a/entity-framework/ef6/modeling/code-first/dbsets.md
+++ b/entity-framework/ef6/modeling/code-first/dbsets.md
@@ -3,7 +3,6 @@ title: Defining DbSets - EF6
 description: Defining DbSets in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 4528a509-ace7-4dfb-8065-1b833f5e03a0
 uid: ef6/modeling/code-first/dbsets
 ---
 # Defining DbSets

--- a/entity-framework/ef6/modeling/code-first/fluent/cud-stored-procedures.md
+++ b/entity-framework/ef6/modeling/code-first/fluent/cud-stored-procedures.md
@@ -3,7 +3,6 @@ title: Code First Insert, Update, and Delete Stored Procedures - EF6
 description: Code First Insert, Update, and Delete Stored Procedures in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 9a7ae7f9-4072-4843-877d-506dd7eef576
 uid: ef6/modeling/code-first/fluent/cud-stored-procedures
 ---
 # Code First Insert, Update, and Delete Stored Procedures

--- a/entity-framework/ef6/modeling/code-first/fluent/relationships.md
+++ b/entity-framework/ef6/modeling/code-first/fluent/relationships.md
@@ -3,7 +3,6 @@ title: Fluent API - Relationships - EF6
 description: Fluent API - Relationships in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: fd73b4f8-16d5-40f1-9640-885ceafe67a1
 uid: ef6/modeling/code-first/fluent/relationships
 ---
 # Fluent API - Relationships

--- a/entity-framework/ef6/modeling/code-first/fluent/types-and-properties.md
+++ b/entity-framework/ef6/modeling/code-first/fluent/types-and-properties.md
@@ -3,7 +3,6 @@ title: Fluent API - Configuring and Mapping Properties and Types - EF6
 description: Fluent API - Configuring and Mapping Properties and Types in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 648ed274-c501-4630-88e0-d728ab5c4057
 uid: ef6/modeling/code-first/fluent/types-and-properties
 ---
 # Fluent API - Configuring and Mapping Properties and Types

--- a/entity-framework/ef6/modeling/code-first/fluent/vb.md
+++ b/entity-framework/ef6/modeling/code-first/fluent/vb.md
@@ -3,7 +3,6 @@ title: Fluent API with VB.NET - EF6
 description: Fluent API with VB.NET in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 763dc6a2-764a-4600-896c-f6f13abf56ec
 uid: ef6/modeling/code-first/fluent/vb
 ---
 # Fluent API with VB.NET

--- a/entity-framework/ef6/modeling/code-first/migrations/automatic.md
+++ b/entity-framework/ef6/modeling/code-first/migrations/automatic.md
@@ -3,7 +3,6 @@ title: Automatic Code First Migrations - EF6
 description: Automatic Code First Migrations in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 0eb86787-2161-4cb4-9cb8-67c5d6e95650
 uid: ef6/modeling/code-first/migrations/automatic
 ---
 # Automatic Code First Migrations

--- a/entity-framework/ef6/modeling/code-first/migrations/existing-database.md
+++ b/entity-framework/ef6/modeling/code-first/migrations/existing-database.md
@@ -3,7 +3,6 @@ title: Code First Migrations with an existing database - EF6
 description: Code First Migrations with an existing database in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: f0cc4f93-67dd-4664-9753-0a9f913814db
 uid: ef6/modeling/code-first/migrations/existing-database
 ---
 # Code First Migrations with an existing database

--- a/entity-framework/ef6/modeling/code-first/migrations/history-customization.md
+++ b/entity-framework/ef6/modeling/code-first/migrations/history-customization.md
@@ -3,7 +3,6 @@ title: Customizing the migrations history table - EF6
 description: Customizing the migrations history table in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: ed5518f0-a9a6-454e-9e98-a4fa7748c8d0
 uid: ef6/modeling/code-first/migrations/history-customization
 ---
 # Customizing the migrations history table

--- a/entity-framework/ef6/modeling/code-first/migrations/index.md
+++ b/entity-framework/ef6/modeling/code-first/migrations/index.md
@@ -3,7 +3,6 @@ title: Code First Migrations - EF6
 description: Code First Migrations in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 36591d8f-36e1-4835-8a51-90f34f633d1e
 uid: ef6/modeling/code-first/migrations/index
 ---
 # Code First Migrations

--- a/entity-framework/ef6/modeling/code-first/migrations/migrate-exe.md
+++ b/entity-framework/ef6/modeling/code-first/migrations/migrate-exe.md
@@ -3,7 +3,6 @@ title: Using migrate.exe - EF6
 description: Using migrate.exe in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 989ea862-e936-4c85-926a-8cfbef5df5b8
 uid: ef6/modeling/code-first/migrations/migrate-exe
 ---
 # Using migrate.exe

--- a/entity-framework/ef6/modeling/code-first/migrations/teams.md
+++ b/entity-framework/ef6/modeling/code-first/migrations/teams.md
@@ -3,7 +3,6 @@ title: Code First Migrations in Team Environments - EF6
 description: Code First Migrations in Team Environments in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 4c2d9a95-de6f-4e97-9738-c1f8043eff69
 uid: ef6/modeling/code-first/migrations/teams
 ---
 # Code First Migrations in Team Environments

--- a/entity-framework/ef6/modeling/code-first/workflows/existing-database.md
+++ b/entity-framework/ef6/modeling/code-first/workflows/existing-database.md
@@ -3,7 +3,6 @@ title: Code First to an Existing Database - EF6
 description: Code First to an Existing Database in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: a7e60b74-973d-4480-868f-500a3899932e
 uid: ef6/modeling/code-first/workflows/existing-database
 ---
 # Code First to an Existing Database

--- a/entity-framework/ef6/modeling/code-first/workflows/new-database.md
+++ b/entity-framework/ef6/modeling/code-first/workflows/new-database.md
@@ -3,7 +3,6 @@ title: Code First to a New Database - EF6
 description: Code First to a New Database in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 2df6cb0a-7d8b-4e28-9d05-e2b9a90125af
 uid: ef6/modeling/code-first/workflows/new-database
 ---
 # Code First to a New Database

--- a/entity-framework/ef6/modeling/designer/advanced/defining-query.md
+++ b/entity-framework/ef6/modeling/designer/advanced/defining-query.md
@@ -3,7 +3,6 @@ title: Defining Query - EF Designer - EF6
 description: Defining Query - EF Designer in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: e52a297e-85aa-42f6-a922-ba960f8a4b22
 uid: ef6/modeling/designer/advanced/defining-query
 ---
 # Defining Query - EF Designer

--- a/entity-framework/ef6/modeling/designer/advanced/edmx/csdl-spec.md
+++ b/entity-framework/ef6/modeling/designer/advanced/edmx/csdl-spec.md
@@ -3,7 +3,6 @@ title: CSDL Specification - EF6
 description: CSDL Specification in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: c54255f4-253f-49eb-bec8-ad7927ac2fa3
 uid: ef6/modeling/designer/advanced/edmx/csdl-spec
 ---
 # CSDL Specification

--- a/entity-framework/ef6/modeling/designer/advanced/edmx/msl-spec.md
+++ b/entity-framework/ef6/modeling/designer/advanced/edmx/msl-spec.md
@@ -3,7 +3,6 @@ title: MSL Specification - EF6
 description: MSL Specification in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 13ae7bc1-74b4-4ee4-8d73-c337be841467
 uid: ef6/modeling/designer/advanced/edmx/msl-spec
 ---
 # MSL Specification

--- a/entity-framework/ef6/modeling/designer/advanced/edmx/ssdl-spec.md
+++ b/entity-framework/ef6/modeling/designer/advanced/edmx/ssdl-spec.md
@@ -3,7 +3,6 @@ title: SSDL Specification - EF6
 description: SSDL Specification in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: a4af4b1a-40f4-48cc-b2e0-fa8f5d9d5419
 uid: ef6/modeling/designer/advanced/edmx/ssdl-spec
 ---
 # SSDL Specification

--- a/entity-framework/ef6/modeling/designer/advanced/multiple-result-sets.md
+++ b/entity-framework/ef6/modeling/designer/advanced/multiple-result-sets.md
@@ -3,7 +3,6 @@ title: Stored Procedures with Multiple Result Sets - EF6
 description: Stored Procedures with Multiple Result Sets in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 1b3797f9-cd3d-4752-a55e-47b84b399dc1
 uid: ef6/modeling/designer/advanced/multiple-result-sets
 ---
 # Stored Procedures with Multiple Result Sets

--- a/entity-framework/ef6/modeling/designer/advanced/tvfs.md
+++ b/entity-framework/ef6/modeling/designer/advanced/tvfs.md
@@ -3,7 +3,6 @@ title: Table-Valued Functions (TVFs) - EF6
 description: Table-Valued Functions (TVFs) in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: f019c97b-87b0-4e93-98f4-2c539f77b2dc
 uid: ef6/modeling/designer/advanced/tvfs
 ---
 # Table-Valued Functions (TVFs)

--- a/entity-framework/ef6/modeling/designer/codegen/index.md
+++ b/entity-framework/ef6/modeling/designer/codegen/index.md
@@ -3,7 +3,6 @@ title: Designer Code Generation Templates - EF6
 description: Designer Code Generation Templates in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 56e00fa2-f9f0-48b3-8006-f8266ca7e74b
 uid: ef6/modeling/designer/codegen/index
 ---
 # Designer Code Generation Templates

--- a/entity-framework/ef6/modeling/designer/codegen/legacy-objectcontext.md
+++ b/entity-framework/ef6/modeling/designer/codegen/legacy-objectcontext.md
@@ -3,7 +3,6 @@ title: Reverting to ObjectContext in Entity Framework Designer - EF6
 description: Reverting to ObjectContext in Entity Framework Designer in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 36550569-a1de-47cb-ba6d-544794ffd500
 uid: ef6/modeling/designer/codegen/legacy-objectcontext
 ---
 # Reverting to ObjectContext in Entity Framework Designer

--- a/entity-framework/ef6/modeling/designer/data-types/complex-types.md
+++ b/entity-framework/ef6/modeling/designer/data-types/complex-types.md
@@ -3,7 +3,6 @@ title: Complex Types - EF Designer - EF6
 description: Complex Types - EF Designer in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 9a8228ef-acfd-4575-860d-769d2c0e18a1
 uid: ef6/modeling/designer/data-types/complex-types
 ---
 # Complex Types - EF Designer

--- a/entity-framework/ef6/modeling/designer/data-types/enums.md
+++ b/entity-framework/ef6/modeling/designer/data-types/enums.md
@@ -3,7 +3,6 @@ title: Enum Support - EF Designer - EF6
 description: Enum Support - EF Designer in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: c6ae6d8f-1ace-47db-ad47-b1718f1ba082
 uid: ef6/modeling/designer/data-types/enums
 ---
 # Enum Support - EF Designer

--- a/entity-framework/ef6/modeling/designer/data-types/spatial.md
+++ b/entity-framework/ef6/modeling/designer/data-types/spatial.md
@@ -3,7 +3,6 @@ title: Spatial - EF Designer - EF6
 description: Spatial - EF Designer in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 06baa6e1-d680-4a95-845b-81305c87a962
 uid: ef6/modeling/designer/data-types/spatial
 ---
 # Spatial - EF Designer

--- a/entity-framework/ef6/modeling/designer/entity-splitting.md
+++ b/entity-framework/ef6/modeling/designer/entity-splitting.md
@@ -3,7 +3,6 @@ title: Designer Entity Splitting - EF6
 description: Designer Entity Splitting in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: aa2dd48a-1f0e-49dd-863d-d6b4f5834832
 uid: ef6/modeling/designer/entity-splitting
 ---
 # Designer Entity Splitting

--- a/entity-framework/ef6/modeling/designer/inheritance/tph.md
+++ b/entity-framework/ef6/modeling/designer/inheritance/tph.md
@@ -3,7 +3,6 @@ title: Designer TPH Inheritance - EF6
 description: Designer TPH Inheritance in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 72d26a8e-20ab-4500-bd13-394a08e73394
 uid: ef6/modeling/designer/inheritance/tph
 ---
 # Designer TPH Inheritance

--- a/entity-framework/ef6/modeling/designer/inheritance/tpt.md
+++ b/entity-framework/ef6/modeling/designer/inheritance/tpt.md
@@ -3,7 +3,6 @@ title: Designer TPT Inheritance - EF6
 description: Designer TPT Inheritance in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: efc78c31-b4ea-4ea3-a0cd-c69eb507020e
 uid: ef6/modeling/designer/inheritance/tpt
 ---
 # Designer TPT Inheritance

--- a/entity-framework/ef6/modeling/designer/keyboard-shortcuts.md
+++ b/entity-framework/ef6/modeling/designer/keyboard-shortcuts.md
@@ -3,7 +3,6 @@ title: Entity Framework Designer Keyboard Shortcuts - EF6
 description: Entity Framework Designer Keyboard Shortcuts in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 3c76cdd5-17c5-4c54-a6a5-cf21b974636b
 ---
 # Entity Framework Designer Keyboard Shortcuts
 This page provides a list of keyboard shorcuts that are available in the various screens of the Entity Framework Tools for Visual Studio.

--- a/entity-framework/ef6/modeling/designer/multiple-diagrams.md
+++ b/entity-framework/ef6/modeling/designer/multiple-diagrams.md
@@ -3,7 +3,6 @@ title: Multiple Diagrams per Model - EF6
 description: Multiple Diagrams per Model in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: b95db5c8-de8d-43bd-9ccc-5df6a5e25e1b
 uid: ef6/modeling/designer/multiple-diagrams
 ---
 # Multiple Diagrams per Model

--- a/entity-framework/ef6/modeling/designer/relationships.md
+++ b/entity-framework/ef6/modeling/designer/relationships.md
@@ -3,7 +3,6 @@ title: Relationships - EF Designer - EF6
 description: Relationships - EF Designer in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 402fe960-754b-470f-976b-e5de3e9986b5
 uid: ef6/modeling/designer/relationships
 ---
 # Relationships - EF Designer

--- a/entity-framework/ef6/modeling/designer/select-runtime-version.md
+++ b/entity-framework/ef6/modeling/designer/select-runtime-version.md
@@ -3,7 +3,6 @@ title: Selecting Entity Framework Runtime Version for EF Designer Models - EF6
 description: Selecting Entity Framework Runtime Version for EF Designer Models in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 7ace90a6-46f8-4f55-a88c-7cad9620085c
 ---
 # Selecting Entity Framework Runtime Version for EF Designer Models
 > [!NOTE]

--- a/entity-framework/ef6/modeling/designer/stored-procedures/cud.md
+++ b/entity-framework/ef6/modeling/designer/stored-procedures/cud.md
@@ -3,7 +3,6 @@ title: Designer CUD Stored Procedures - EF6
 description: Designer CUD Stored Procedures in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 1e773972-2da5-45e0-85a2-3cf3fbcfa5cf
 uid: ef6/modeling/designer/stored-procedures/cud
 ---
 # Designer CUD Stored Procedures

--- a/entity-framework/ef6/modeling/designer/stored-procedures/query.md
+++ b/entity-framework/ef6/modeling/designer/stored-procedures/query.md
@@ -3,7 +3,6 @@ title: Designer Query Stored Procedures - EF6
 description: Designer Query Stored Procedures in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 9554ed25-c5c1-43be-acad-5da37739697f
 uid: ef6/modeling/designer/stored-procedures/query
 ---
 # Designer Query Stored Procedures

--- a/entity-framework/ef6/modeling/designer/table-splitting.md
+++ b/entity-framework/ef6/modeling/designer/table-splitting.md
@@ -3,7 +3,6 @@ title: Designer Table Splitting - EF6
 description: Designer Table Splitting in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 452f17c3-9f26-4de4-9894-8bc036e23b0f
 uid: ef6/modeling/designer/table-splitting
 ---
 # Designer Table Splitting

--- a/entity-framework/ef6/modeling/designer/workflows/database-first.md
+++ b/entity-framework/ef6/modeling/designer/workflows/database-first.md
@@ -3,7 +3,6 @@ title: Database First - EF6
 description: Database First in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: cc6ffdb3-388d-4e79-a201-01ec2577c949
 uid: ef6/modeling/designer/workflows/database-first
 ---
 # Database First

--- a/entity-framework/ef6/modeling/designer/workflows/model-first.md
+++ b/entity-framework/ef6/modeling/designer/workflows/model-first.md
@@ -3,7 +3,6 @@ title: Model First - EF6
 description: Model First in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: e1b9c319-bb8a-4417-ac94-7890f257e7f6
 uid: ef6/modeling/designer/workflows/model-first
 ---
 # Model First

--- a/entity-framework/ef6/modeling/index.md
+++ b/entity-framework/ef6/modeling/index.md
@@ -3,7 +3,6 @@ title: Creating a Model - EF6
 description: Creating a Model in Entity Framework 6
 author: divega
 ms.date: 07/05/2018
-ms.assetid: 4890228E-CEA1-4595-B8AD-CA81253F8767
 uid: ef6/modeling/index
 ---
 # Creating a Model

--- a/entity-framework/ef6/querying/index.md
+++ b/entity-framework/ef6/querying/index.md
@@ -3,7 +3,6 @@ title: Querying and Finding Entities - EF6
 description: Querying and Finding Entities in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 65bb3db2-2226-44af-8864-caa575cf1b46
 uid: ef6/querying/index
 ---
 # Querying and Finding Entities

--- a/entity-framework/ef6/querying/load-method.md
+++ b/entity-framework/ef6/querying/load-method.md
@@ -3,7 +3,6 @@ title: The Load Method - EF6
 description: The Load Method in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 03c5a069-b7b4-455f-a16f-ee3b96cc4e28
 uid: ef6/querying/load-method
 ---
 # The Load Method

--- a/entity-framework/ef6/querying/local-data.md
+++ b/entity-framework/ef6/querying/local-data.md
@@ -3,7 +3,6 @@ title: Local Data - EF6
 description: Local Data in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 2eda668b-1e5d-487d-9a8c-0e3beef03fcb
 uid: ef6/querying/local-data
 ---
 # Local Data

--- a/entity-framework/ef6/querying/no-tracking.md
+++ b/entity-framework/ef6/querying/no-tracking.md
@@ -3,7 +3,6 @@ title: No-Tracking Queries - EF6
 description: No-Tracking Queries in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: f80ac260-c2dc-484d-94a3-3424fd862f8b
 uid: ef6/querying/no-tracking
 ---
 # No-Tracking Queries

--- a/entity-framework/ef6/querying/raw-sql.md
+++ b/entity-framework/ef6/querying/raw-sql.md
@@ -3,7 +3,6 @@ title: Raw SQL Queries - EF6
 description: Raw SQL Queries in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 9e1ee76e-2499-408c-81e8-9b6c5d1945a0
 uid: ef6/querying/raw-sql
 ---
 # Raw SQL Queries (EF6)

--- a/entity-framework/ef6/querying/related-data.md
+++ b/entity-framework/ef6/querying/related-data.md
@@ -3,7 +3,6 @@ title: Loading Related Entities - EF6
 description: Loading Related Entities in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: c8417e18-a2ee-499c-9ce9-2a48cc5b468a
 uid: ef6/querying/related-data
 ---
 # Loading Related Entities

--- a/entity-framework/ef6/resources/blogs.md
+++ b/entity-framework/ef6/resources/blogs.md
@@ -3,7 +3,6 @@ title: Entity Framework Blogs - EF6
 description: Entity Framework 6 Blogs
 author: divega
 ms.date: 10/23/2016
-ms.assetid: f8fcfb34-35de-4e82-b419-8f99fd2eb92a
 ---
 # Entity Framework Blogs
 Besides the product documentation, these blogs can be a source of useful information on Entity Framework:

--- a/entity-framework/ef6/resources/case-studies.md
+++ b/entity-framework/ef6/resources/case-studies.md
@@ -3,7 +3,6 @@ title: Case Studies for Entity Framework - EF6
 description: Case Studies for Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: cd5d3ae3-717d-4095-a2ef-0e8fd72b1a2f
 ---
 # Microsoft Case Studies for Entity Framework
 The case studies on this page highlight a few real-world production projects that have employed Entity Framework.

--- a/entity-framework/ef6/resources/contribute.md
+++ b/entity-framework/ef6/resources/contribute.md
@@ -3,7 +3,6 @@ title: Contribute to Entity Framework - EF6
 description: Contribute to Entity Framework 6
 author: divega
 ms.date: 07/05/2018
-ms.assetid: EFA3C3F5-79A4-4A0A-BB37-035C31FC7372
 ---
 # Contribute to Entity Framework 6
 Entity Framework 6 is developed using an open source model on GitHub. Although the main focus of the Entity Framework Team at Microsoft is on adding new features to Entity Framework Core, and we don't expect any major features to be added to Entity Framework 6, we still accept contributions.

--- a/entity-framework/ef6/resources/get-help.md
+++ b/entity-framework/ef6/resources/get-help.md
@@ -3,7 +3,6 @@ title: Get Help Using Entity Framework - EF6
 description: Get Help Using Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 592cae61-02e1-485a-bbb0-a508ade9c67d
 uid: ef6/resources/get-help
 ---
 # Get Help Using Entity Framework

--- a/entity-framework/ef6/resources/glossary.md
+++ b/entity-framework/ef6/resources/glossary.md
@@ -3,7 +3,6 @@ title: Entity Framework Glossary - EF6
 description: Entity Framework 6 Glossary
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 3f05ffdd-49bc-499c-9732-4a368bf5d2d7
 uid: ef6/resources/glossary
 ---
 # Entity Framework Glossary

--- a/entity-framework/ef6/resources/licenses/ef5/chs.md
+++ b/entity-framework/ef6/resources/licenses/ef5/chs.md
@@ -3,7 +3,6 @@ title: Entity Framework 5 License (CHS) - EF6
 description: Entity Framework 5 License (CHS)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 72b83f2c-d892-4181-bc6a-290688d3d3f2
 ---
 # Entity Framework 5 License (CHS)
 **MICROSOFT 软件补充程序许可条款**

--- a/entity-framework/ef6/resources/licenses/ef5/cht.md
+++ b/entity-framework/ef6/resources/licenses/ef5/cht.md
@@ -3,7 +3,6 @@ title: Entity Framework 5 License (CHT) - EF6
 description: Entity Framework 5 License (CHT)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: f6b3fc39-a02a-46f5-9696-67f0ca8e7ec4
 ---
 # Entity Framework 5 License (CHT)
 **MICROSOFT 軟體增補程式授權條款**

--- a/entity-framework/ef6/resources/licenses/ef5/deu.md
+++ b/entity-framework/ef6/resources/licenses/ef5/deu.md
@@ -3,7 +3,6 @@ title: Entity Framework 5 License (DEU) - EF6
 description: Entity Framework 5 License (DEU)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 66089111-e0ab-4c64-af71-b77faff5f499
 ---
 # Entity Framework 5 License (DEU)
 **LIZENZBESTIMMUNGEN FÜR MICROSOFT-SOFTWAREERGÄNZUNG**

--- a/entity-framework/ef6/resources/licenses/ef5/enu.md
+++ b/entity-framework/ef6/resources/licenses/ef5/enu.md
@@ -3,7 +3,6 @@ title: Entity Framework 5 License - EF6
 description: Entity Framework 5 License
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 9f6150d8-8c26-42a1-b1c4-cb0175bb9efb
 ---
 # Entity Framework 5 License (ENU)
 **MICROSOFT SOFTWARE SUPPLEMENTAL LICENSE TERMS**

--- a/entity-framework/ef6/resources/licenses/ef5/esn.md
+++ b/entity-framework/ef6/resources/licenses/ef5/esn.md
@@ -3,7 +3,6 @@ title: Entity Framework 5 License (ESN) - EF6
 description: Entity Framework 5 License (ESN)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 637cccbb-5418-4562-8187-02f644f4c091
 ---
 # Entity Framework 5 License (ESN)
 **TÉRMINOS SUPLEMENTARIOS A LA LICENCIA DE USO DE SOFTWARE DE MICROSOFT**

--- a/entity-framework/ef6/resources/licenses/ef5/fra.md
+++ b/entity-framework/ef6/resources/licenses/ef5/fra.md
@@ -3,7 +3,6 @@ title: Entity Framework 5 License (FRA) - EF6
 description: Entity Framework 5 License (FRA)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 4fed93b8-10a4-4ac9-9eb4-8e24816034b0
 ---
 # Entity Framework 5 License (FRA)
 **TERMES DU CONTRAT DE LICENCE D'UN SUPPLÉMENT MICROSOFT**

--- a/entity-framework/ef6/resources/licenses/ef5/ita.md
+++ b/entity-framework/ef6/resources/licenses/ef5/ita.md
@@ -3,7 +3,6 @@ title: Entity Framework 5 License (ITA) - EF6
 description: Entity Framework 5 License (ITA)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 9ccb2adc-a631-4cc8-bd77-43abc2e7f812
 ---
 # Entity Framework 5 License (ITA)
 **CONTRATTO DI LICENZA SUPPLEMENTARE PER IL SOFTWARE MICROSOFT**

--- a/entity-framework/ef6/resources/licenses/ef5/jpn.md
+++ b/entity-framework/ef6/resources/licenses/ef5/jpn.md
@@ -3,7 +3,6 @@ title: Entity Framework 5 License (JPN) - EF6
 description: Entity Framework 5 License (JPN)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 5d1555a3-f3cf-4b25-84fa-a531fda0df0d
 ---
 # Entity Framework 5 License (JPN)
 **マイクロソフト ソフトウェア 追加ライセンス条項**

--- a/entity-framework/ef6/resources/licenses/ef5/kor.md
+++ b/entity-framework/ef6/resources/licenses/ef5/kor.md
@@ -3,7 +3,6 @@ title: Entity Framework 5 License (KOR) - EF6
 description: Entity Framework 5 License (KOR)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: b105993a-ebb3-466e-af76-a0ec0c651f82
 ---
 # Entity Framework 5 License (KOR)
 **MICROSOFT 소프트웨어 사용권 조항**

--- a/entity-framework/ef6/resources/licenses/ef5/rus.md
+++ b/entity-framework/ef6/resources/licenses/ef5/rus.md
@@ -3,7 +3,6 @@ title: Entity Framework 5 License (RUS) - EF6
 description: Entity Framework 5 License (RUS)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 01c78013-8b66-4bf2-9873-94c4ebdaae19
 ---
 # Entity Framework 5 License (RUS)
 **УСЛОВИЯ ДОПОЛНЕНИЯ К ЛИЦЕНЗИИ КОРПОРАЦИИ МАЙКРОСОФТ НА ИСПОЛЬЗОВАНИЕ ПРОГРАММНОГО ОБЕСПЕЧЕНИЯ**

--- a/entity-framework/ef6/resources/licenses/ef6/chs.md
+++ b/entity-framework/ef6/resources/licenses/ef6/chs.md
@@ -3,7 +3,6 @@ title: Entity Framework 6 Runtime License (CHS) - EF6
 description: Entity Framework 6 Runtime License (CHS)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 06214a30-0097-4bce-9e30-91586928f3a7
 ---
 # Entity Framework 6 Runtime License (CHS)
 **MICROSOFT 软件许可条款**

--- a/entity-framework/ef6/resources/licenses/ef6/cht.md
+++ b/entity-framework/ef6/resources/licenses/ef6/cht.md
@@ -3,7 +3,6 @@ title: Entity Framework 6 Runtime License (CHT) - EF6
 description: Entity Framework 6 Runtime License (CHT)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 88468c89-2a84-4c5b-a8d3-5e1d2bd0b457
 ---
 # Entity Framework 6 Runtime License (CHT)
 **MICROSOFT 軟體授權條款**

--- a/entity-framework/ef6/resources/licenses/ef6/deu.md
+++ b/entity-framework/ef6/resources/licenses/ef6/deu.md
@@ -3,7 +3,6 @@ title: Entity Framework 6 Runtime License (DEU) - EF6
 description: Entity Framework 6 Runtime License (DEU)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 0bafee16-ed55-4560-97f5-bc5b27e0df36
 ---
 # Entity Framework 6 Runtime License (DEU)
 **MICROSOFT-SOFTWARELIZENZBESTIMMUNGEN**

--- a/entity-framework/ef6/resources/licenses/ef6/enu.md
+++ b/entity-framework/ef6/resources/licenses/ef6/enu.md
@@ -3,7 +3,6 @@ title: Entity Framework 6 Runtime License - EF6
 description: Entity Framework 6 Runtime License
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 5bc55bf3-2404-4811-8d13-d2eed822cdc4
 ---
 # Entity Framework 6 Runtime License (ENU)
 **MICROSOFT SOFTWARE LICENSE TERMS**

--- a/entity-framework/ef6/resources/licenses/ef6/esn.md
+++ b/entity-framework/ef6/resources/licenses/ef6/esn.md
@@ -3,7 +3,6 @@ title: Entity Framework 6 Runtime License (ESN) - EF6
 description: Entity Framework 6 Runtime License (ESN)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 5e8d67b3-5c60-4a12-a86f-c7276bb8d9e7
 ---
 # Entity Framework 6 Runtime License (ESN)
 **TÉRMINOS DE LICENCIA DEL SOFTWARE DE MICROSOFT**

--- a/entity-framework/ef6/resources/licenses/ef6/fra.md
+++ b/entity-framework/ef6/resources/licenses/ef6/fra.md
@@ -3,7 +3,6 @@ title: Entity Framework 6 Runtime License (FRA) - EF6
 description: Entity Framework 6 Runtime License (FRA)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: b7066d9f-8b86-4218-9463-57665f391aaa
 ---
 # Entity Framework 6 Runtime License (FRA)
 **TERMES DU CONTRAT DE LICENCE LOGICIEL MICROSOFT**

--- a/entity-framework/ef6/resources/licenses/ef6/ita.md
+++ b/entity-framework/ef6/resources/licenses/ef6/ita.md
@@ -3,7 +3,6 @@ title: Entity Framework 6 Runtime License (ITA) - EF6
 description: Entity Framework 6 Runtime License (ITA)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: ea0b20c1-7a46-4349-af9d-641051f8cad2
 ---
 # Entity Framework 6 Runtime License (ITA)
 **CONDIZIONI DI LICENZA SOFTWARE MICROSOFT**

--- a/entity-framework/ef6/resources/licenses/ef6/jpn.md
+++ b/entity-framework/ef6/resources/licenses/ef6/jpn.md
@@ -3,7 +3,6 @@ title: Entity Framework 6 Runtime License (JPN) - EF6
 description: Entity Framework 6 Runtime License (JPN)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 8ecaca70-5ba7-4ef8-9540-1a98a57eeb22
 ---
 # Entity Framework 6 Runtime License (JPN)
 **マイクロソフト ソフトウェア ライセンス条項**

--- a/entity-framework/ef6/resources/licenses/ef6/kor.md
+++ b/entity-framework/ef6/resources/licenses/ef6/kor.md
@@ -3,7 +3,6 @@ title: Entity Framework 6 Runtime License (KOR) - EF6
 description: Entity Framework 6 Runtime License (KOR)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: fc90a6bf-0958-4d9a-a383-38f8e6d21640
 ---
 # Entity Framework 6 Runtime License (KOR)
 **MICROSOFT 소프트웨어 사용권 계약서**

--- a/entity-framework/ef6/resources/licenses/ef6/prerelease/alpha.md
+++ b/entity-framework/ef6/resources/licenses/ef6/prerelease/alpha.md
@@ -3,7 +3,6 @@ title: Entity Framework 6 Runtime Alpha License - EF6
 description: Entity Framework 6 Runtime Alpha License
 author: divega
 ms.date: 10/23/2016
-ms.assetid: bca98fb3-ebb2-4df3-afc8-6fd8f7341c9d
 ---
 # Entity Framework 6 Runtime Alpha License (ENU)
 **MICROSOFT PRE-RELEASE SOFTWARE LICENSE TERMS**

--- a/entity-framework/ef6/resources/licenses/ef6/prerelease/beta-rc.md
+++ b/entity-framework/ef6/resources/licenses/ef6/prerelease/beta-rc.md
@@ -3,7 +3,6 @@ title: Entity Framework 6 Runtime Beta/RC License - EF6
 description: Entity Framework 6 Runtime Beta/RC License
 author: divega
 ms.date: 10/23/2016
-ms.assetid: db123990-8290-41c8-a41f-494d3f2994f7
 ---
 # Entity Framework 6 Runtime Beta/RC License (ENU)
 **MICROSOFT PRE-RELEASE SOFTWARE LICENSE TERMS**

--- a/entity-framework/ef6/resources/licenses/ef6/rus.md
+++ b/entity-framework/ef6/resources/licenses/ef6/rus.md
@@ -3,7 +3,6 @@ title: Entity Framework 6 Runtime License (RUS) - EF6
 description: Entity Framework 6 Runtime License (RUS)
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 6326e9e8-15c6-4ce3-a5b4-6cb6a97c6bf4
 ---
 # Entity Framework 6 Runtime License (RUS)
 **УСЛОВИЯ ЛИЦЕНЗИИ НА ПРОГРАММНОЕ ОБЕСПЕЧЕНИЕ MICROSOFT**

--- a/entity-framework/ef6/resources/school-database.md
+++ b/entity-framework/ef6/resources/school-database.md
@@ -3,7 +3,6 @@ title: School Sample Database - EF6
 description: School Sample Database for Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: e83a6a06-e63b-4530-8656-614bf609b12b
 uid: ef6/resources/school-database
 ---
 # School Sample Database

--- a/entity-framework/ef6/resources/tools.md
+++ b/entity-framework/ef6/resources/tools.md
@@ -3,7 +3,6 @@ title: Tools & Extensions - EF6
 description: Tools & Extensions  in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 7f166290-d9f0-4eec-b4fd-e7a83068d977
 ---
 # Entity Framework Tools & Extensions
 > [!IMPORTANT]  

--- a/entity-framework/ef6/saving/change-tracking/auto-detect-changes.md
+++ b/entity-framework/ef6/saving/change-tracking/auto-detect-changes.md
@@ -3,7 +3,6 @@ title: Automatic detect changes - EF6
 description: Automatic detect changes in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: a8d1488d-9a54-4623-a76b-e81329ff2756
 uid: ef6/saving/change-tracking/auto-detect-changes
 ---
 # Automatic detect changes

--- a/entity-framework/ef6/saving/change-tracking/entity-state.md
+++ b/entity-framework/ef6/saving/change-tracking/entity-state.md
@@ -3,7 +3,6 @@ title: Working with entity states - EF6
 description: Working with entity states in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: acb27f46-3f3a-4179-874a-d6bea5d7120c
 uid: ef6/saving/change-tracking/entity-state
 ---
 # Working with entity states

--- a/entity-framework/ef6/saving/change-tracking/property-values.md
+++ b/entity-framework/ef6/saving/change-tracking/property-values.md
@@ -3,7 +3,6 @@ title: Working with property values - EF6
 description: Working with property values in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: e3278b4b-9378-4fdb-923d-f64d80aaae70
 uid: ef6/saving/change-tracking/property-values
 ---
 # Working with property values

--- a/entity-framework/ef6/saving/concurrency.md
+++ b/entity-framework/ef6/saving/concurrency.md
@@ -3,7 +3,6 @@ title: Handling Concurrency Conflicts - EF6
 description: Handling Concurrency Conflicts in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 2318e4d3-f561-4720-bbc3-921556806476
 uid: ef6/saving/concurrency
 ---
 # Handling Concurrency Conflicts (EF6)

--- a/entity-framework/ef6/saving/index.md
+++ b/entity-framework/ef6/saving/index.md
@@ -3,7 +3,6 @@ title: Saving Data - EF6
 description: Saving Data in Entity Framework 6
 author: divega
 ms.date: 07/05/2018
-ms.assetid: C7744A30-8655-4EF8-8657-F5B796D1EB7E
 ---
 
 # Saving Data with Entity Framework 6

--- a/entity-framework/ef6/saving/transactions.md
+++ b/entity-framework/ef6/saving/transactions.md
@@ -3,7 +3,6 @@ title: Working with Transactions - EF6
 description: Working with Transactions in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 0d0f1824-d781-4cb3-8fda-b7eaefced1cd
 uid: ef6/saving/transactions
 ---
 # Working with Transactions

--- a/entity-framework/ef6/saving/validation.md
+++ b/entity-framework/ef6/saving/validation.md
@@ -3,7 +3,6 @@ title: Validation - EF6
 description: Validation in Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 77d6a095-c0d0-471e-80b9-8f9aea6108b2
 ---
 # Data Validation
 > [!NOTE]

--- a/entity-framework/ef6/what-is-new/index.md
+++ b/entity-framework/ef6/what-is-new/index.md
@@ -3,7 +3,6 @@ title: What's new - EF6
 description: What's new in Entity Framework 6
 author: divega
 ms.date: 09/12/2019
-ms.assetid: 41d1f86b-ce66-4bf2-8963-48514406fb4c
 uid: ef6/what-is-new/index
 ---
 # What's new in EF6

--- a/entity-framework/ef6/what-is-new/past-releases.md
+++ b/entity-framework/ef6/what-is-new/past-releases.md
@@ -3,7 +3,6 @@ title: Past Releases of Entity Framework - EF6
 description: Past Releases of Entity Framework
 author: divega
 ms.date: 09/12/2019
-ms.assetid: 1060bb99-765f-4f32-aaeb-d6635d3dbd3e
 uid: ef6/what-is-new/past-releases
 ---
 # Past Releases of Entity Framework

--- a/entity-framework/ef6/what-is-new/upgrading-to-ef6.md
+++ b/entity-framework/ef6/what-is-new/upgrading-to-ef6.md
@@ -3,7 +3,6 @@ title: Upgrading to Entity Framework 6 - EF6
 description: Upgrading to Entity Framework 6
 author: divega
 ms.date: 10/23/2016
-ms.assetid: 29958ae5-85d3-4585-9ba6-550b8ec9393a
 uid: ef6/what-is-new/upgrading-to-ef6
 ---
 # Upgrading to Entity Framework 6

--- a/entity-framework/ef6/what-is-new/visual-studio.md
+++ b/entity-framework/ef6/what-is-new/visual-studio.md
@@ -3,7 +3,6 @@ title: Visual Studio Releases - EF6
 description: Visual Studio Releases and Entity Framework 6
 author: divega
 ms.date: 07/05/2018
-ms.assetid: 028FF890-4EDB-4F03-AE53-72F9C33EC92F
 uid: ef6/what-is-new/visual-studio
 ---
 # Visual Studio Releases

--- a/entity-framework/efcore-and-ef6/index.md
+++ b/entity-framework/efcore-and-ef6/index.md
@@ -3,7 +3,6 @@ title: Compare EF6 and EF Core
 description: Guidance on how to choose between EF6 and EF Core.
 author: ajcvickers
 ms.date: 01/23/2019
-ms.assetid: a6b9cd22-6803-4c6c-a4d4-21147c0a81cb
 uid: efcore-and-ef6/index
 ---
 

--- a/entity-framework/efcore-and-ef6/porting/index.md
+++ b/entity-framework/efcore-and-ef6/porting/index.md
@@ -3,7 +3,6 @@ title: Porting from EF6 to EF Core - EF
 description: General information on porting an application from Entity Framework 6 to Entity Framework Core
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: 826b58bd-77b0-4bbc-bfcd-24d1ed3a8f38
 uid: efcore-and-ef6/porting/index
 ---
 # Porting from EF6 to EF Core

--- a/entity-framework/efcore-and-ef6/porting/port-code.md
+++ b/entity-framework/efcore-and-ef6/porting/port-code.md
@@ -3,7 +3,6 @@ title: Porting from EF6 to EF Core - Porting a Code-Based Model - EF
 description: Specific information on porting an Entity Framework 6 code-based model application to Entity Framework Core
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: 2dce1a50-7d84-4856-abf6-2763dd9be99d
 uid: efcore-and-ef6/porting/port-code
 ---
 # Porting an EF6 Code-Based Model to EF Core

--- a/entity-framework/efcore-and-ef6/porting/port-edmx.md
+++ b/entity-framework/efcore-and-ef6/porting/port-edmx.md
@@ -3,7 +3,6 @@ title: Porting from EF6 to EF Core - Porting an EDMX-Based Model - EF
 description: Specific information on porting an Entity Framework 6 EDMX-based model application to Entity Framework Core
 author: rowanmiller
 ms.date: 10/27/2016
-ms.assetid: 63003709-f1ec-4bdc-8083-65a60c4826d2
 uid: efcore-and-ef6/porting/port-edmx
 ---
 # Porting an EF6 EDMX-Based Model to EF Core

--- a/entity-framework/efcore-and-ef6/side-by-side.md
+++ b/entity-framework/efcore-and-ef6/side-by-side.md
@@ -3,7 +3,6 @@ title: EF6 and EF Core - Using them in the Same Application
 description: Guidance on using both Entity Framework Core and Entity Framework 6 in the same application
 author: ajcvickers
 ms.date: 01/23/2019
-ms.assetid: a06e3c35-110c-4294-a1e2-32d2c31c90a7
 uid: efcore-and-ef6/side-by-side
 ---
 # Using EF Core and EF6 in the Same Application


### PR DESCRIPTION
The purpose of ms.assetid was to assign a unique ID to each doc page so when we need to look up for the same page in old publishing system (in case something did not migrate correctly), we can correlate and find out missing information from old system. (Generally missing blocks or code snippets)

They are rarely used. In case if need to use them, we can refer to this commit to find the assetid.