### PR TITLE
Added Hyperlink

### DIFF
--- a/entity-framework/core/get-started/index.md
+++ b/entity-framework/core/get-started/index.md
@@ -8,7 +8,7 @@ uid: core/get-started/index
 
 # Getting Started with EF Core
 
-In this tutorial, you create a .NET Core console app that performs data access against a <a href="https://www.sqlite.org/" data-linktype="external">SQLite</a> database using Entity Framework Core.
+In this tutorial, you create a .NET Core console app that performs data access against a [SQLite](https://www.sqlite.org/) database using Entity Framework Core.
 
 You can follow the tutorial by using Visual Studio on Windows, or by using the .NET Core CLI on Windows, macOS, or Linux.
 

--- a/entity-framework/core/get-started/index.md
+++ b/entity-framework/core/get-started/index.md
@@ -8,7 +8,7 @@ uid: core/get-started/index
 
 # Getting Started with EF Core
 
-In this tutorial, you create a .NET Core console app that performs data access against a SQLite database using Entity Framework Core.
+In this tutorial, you create a .NET Core console app that performs data access against a <a href="https://www.sqlite.org/" data-linktype="external">SQLite</a> database using Entity Framework Core.
 
 You can follow the tutorial by using Visual Studio on Windows, or by using the .NET Core CLI on Windows, macOS, or Linux.
 


### PR DESCRIPTION
Hi - In below line, , Hyperlink to SQLite is not available. This can be added.

"In this tutorial, you create a .NET Core console app that performs data access against a [SQLite](https://www.sqlite.org/) database using Entity Framework Core."

https://www.sqlite.org/

Thanks,
Ashish