### PR TITLE
Updating Xamarin sample with proper linker settings

### DIFF
--- a/entity-framework/core/get-started/xamarin.md
+++ b/entity-framework/core/get-started/xamarin.md
@@ -68,6 +68,9 @@ The following sections will walk you through the code in the sample project that
 
 It is assumed that you are familiar with the Xamarin.Forms topics of [displaying data](/xamarin/xamarin-forms/app-fundamentals/data-binding/) and [navigating between pages](/xamarin/xamarin-forms/app-fundamentals/navigation/).
 
+> [!IMPORTANT]
+> The linker behavior on Xamarin.iOS must be set to **Don't Link** in order to run applications with Entity Framework Core. [This article explains more about the linker](/xamarin/ios/deploy-test/linker) including how to set the behavior on Xamarin.iOS.
+
 ## Entity Framework Core NuGet packages
 
 To create Xamarin.Forms apps with EF Core, you install the package for the EF Core database provider(s) you want to target into all of the projects in the Xamarin.Forms solution. This tutorial uses the SQLite provider.

--- a/entity-framework/core/get-started/xamarin.md
+++ b/entity-framework/core/get-started/xamarin.md
@@ -69,7 +69,12 @@ The following sections will walk you through the code in the sample project that
 It is assumed that you are familiar with the Xamarin.Forms topics of [displaying data](/xamarin/xamarin-forms/app-fundamentals/data-binding/) and [navigating between pages](/xamarin/xamarin-forms/app-fundamentals/navigation/).
 
 > [!IMPORTANT]
-> The linker behavior on Xamarin.iOS must be set to **Don't Link** in order to run applications with Entity Framework Core. [This article explains more about the linker](/xamarin/ios/deploy-test/linker) including how to set the behavior on Xamarin.iOS.
+> Entity Framework Core uses reflection to invoke functions which the Xamarin.iOS linker may strip out while in **Release** mode configurations. You can avoid that in one of two ways.
+> 
+> * The first is to add `--linkskip System.Core` to the **Additional mtouch arguments** in the **iOS Build** options.
+> * Alternatively set the Xamarin.iOS **Linker behavior** to `Don't Link` in the **iOS Build** options.
+> [This article explains more about the Xamarin.iOS linker](/xamarin/ios/deploy-test/linker) including how to set the behavior on Xamarin.iOS.
+> 
 
 ## Entity Framework Core NuGet packages
 

--- a/samples/core/Xamarin/EFGetStarted.iOS/EFGetStarted.iOS.csproj
+++ b/samples/core/Xamarin/EFGetStarted.iOS/EFGetStarted.iOS.csproj
@@ -35,9 +35,10 @@
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <MtouchLink>None</MtouchLink>
+    <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>x86_64</MtouchArch>
     <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchExtraArgs>--linkskip System.Core</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -64,7 +65,8 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <CodesignExtraArgs>--interpreter</CodesignExtraArgs>
-    <MtouchLink>None</MtouchLink>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchExtraArgs>--linkskip System.Core</MtouchExtraArgs>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />

--- a/samples/core/Xamarin/EFGetStarted.iOS/EFGetStarted.iOS.csproj
+++ b/samples/core/Xamarin/EFGetStarted.iOS/EFGetStarted.iOS.csproj
@@ -27,6 +27,7 @@
     <MtouchArch>x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
+    <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>
@@ -63,6 +64,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <CodesignExtraArgs>--interpreter</CodesignExtraArgs>
+    <MtouchLink>None</MtouchLink>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />

--- a/samples/core/Xamarin/EFGetStarted.iOS/Main.cs
+++ b/samples/core/Xamarin/EFGetStarted.iOS/Main.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using Foundation;
 using UIKit;
 
+
+
 namespace EFGetStarted.iOS
 {
     public class Application
@@ -15,6 +17,7 @@ namespace EFGetStarted.iOS
             // if you want to use a different Application Delegate class from "AppDelegate"
             // you can specify it here.
             UIApplication.Main(args, null, "AppDelegate");
+            
         }
     }
 }


### PR DESCRIPTION
Xamarin.iOS requires the linker behavior to be set to `Don't Link`. Updating the sample to have the linker set to that value for all build configurations and updating the readme to note that as well.