### PR TITLE
chore: Add paths filtering for markdownlint CI

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,6 +1,20 @@
 name: Markdownlint
 
-on: pull_request
+on:
+  push:
+    paths:
+      - "**/*.md"
+      - "!entity-framework/ef6/**"
+      - ".markdownlint.json"
+      - ".github/workflows/markdownlint.yml"
+      - ".github/workflows/markdownlint-problem-matcher.json"
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "!entity-framework/ef6/**"
+      - ".markdownlint.json"
+      - ".github/workflows/markdownlint.yml"
+      - ".github/workflows/markdownlint-problem-matcher.json"
 
 jobs:
   lint:


### PR DESCRIPTION
Only triggers this job if Markdown files are touched, and not when the files under `entity-framework/ef6/` are changed