### PR TITLE
chore: Disable CS0169 warning

### DIFF
--- a/samples/core/Querying/QueryFilters/Entities.cs
+++ b/samples/core/Querying/QueryFilters/Entities.cs
@@ -5,9 +5,9 @@ namespace EFQuerying.QueryFilters
     #region Entities
     public class Blog
     {
-#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable IDE0051, CS0169 // Remove unused private members
         private string _tenantId;
-#pragma warning restore IDE0051 // Remove unused private members
+#pragma warning restore IDE0051, CS0169 // Remove unused private members
 
         public int BlogId { get; set; }
         public string Name { get; set; }


### PR DESCRIPTION
Can't say that this should actually be suppressed, but there was an existing suppression that wasn't working for the problem matcher in CI, and was showing warnings on each PR that touched the samples