### PR TITLE
chore: Markdownlint cleanups

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,7 +3,6 @@
     "MD013": false,
     "MD024": false,
     "MD025": { "front_matter_title": "" },
-    "MD027": false,
     "MD028": false,
     "MD033": { "allowed_elements": ["sup", "sub", "nobr", "span", "a"] }
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -4,5 +4,9 @@
     "MD024": false,
     "MD025": { "front_matter_title": "" },
     "MD028": false,
-    "MD033": { "allowed_elements": ["sup", "sub", "nobr", "span", "a"] }
+    "MD033": { "allowed_elements": ["sup", "sub", "nobr", "span", "a"] },
+    "MD036": false,
+    "MD046": {
+        "style": "fenced"
+    }
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,9 @@
 {
     "default": true,
     "MD013": false,
-    "MD024": false,
+    "MD024": {
+        "allow_different_nesting": true
+    },
     "MD025": { "front_matter_title": "" },
     "MD028": false,
     "MD033": { "allowed_elements": ["sup", "sub", "nobr", "span", "a"] },

--- a/entity-framework/core/managing-schemas/migrations/index.md
+++ b/entity-framework/core/managing-schemas/migrations/index.md
@@ -112,6 +112,8 @@ Since this isn't the project's first migration, EF Core now compares your update
 
 You can now apply your migration as before:
 
+<!--markdownlint-disable MD024-->
+
 #### [.NET Core CLI](#tab/dotnet-core-cli)
 
 ```dotnetcli
@@ -123,6 +125,8 @@ dotnet ef database update
 ```powershell
 Update-Database
 ```
+
+<!--markdownlint-enable MD024-->
 
 ***
 

--- a/entity-framework/core/managing-schemas/migrations/managing.md
+++ b/entity-framework/core/managing-schemas/migrations/managing.md
@@ -44,21 +44,17 @@ The timestamp in the filename helps keep them ordered chronologically so you can
 
 You are free to move Migrations files and change their namespace manually. New migrations are created as siblings of the last migration. Alternatively, you can specify the namespace at generation time as follows:
 
-<!--markdownlint-disable MD024-->
-
-### [.NET Core CLI](#tab/dotnet-core-cli)
+#### [.NET Core CLI](#tab/dotnet-core-cli)
 
 ```dotnetcli
 dotnet ef migrations add InitialCreate --namespace Your.Namespace
 ```
 
-### [Visual Studio](#tab/vs)
+#### [Visual Studio](#tab/vs)
 
 ```powershell
 Add-Migration InitialCreate -Namespace Your.Namespace
 ```
-
-<!--markdownlint-enable MD024-->
 
 ***
 

--- a/entity-framework/core/managing-schemas/migrations/managing.md
+++ b/entity-framework/core/managing-schemas/migrations/managing.md
@@ -44,6 +44,8 @@ The timestamp in the filename helps keep them ordered chronologically so you can
 
 You are free to move Migrations files and change their namespace manually. New migrations are created as siblings of the last migration. Alternatively, you can specify the namespace at generation time as follows:
 
+<!--markdownlint-disable MD024-->
+
 ### [.NET Core CLI](#tab/dotnet-core-cli)
 
 ```dotnetcli
@@ -55,6 +57,8 @@ dotnet ef migrations add InitialCreate --namespace Your.Namespace
 ```powershell
 Add-Migration InitialCreate -Namespace Your.Namespace
 ```
+
+<!--markdownlint-enable MD024-->
 
 ***
 


### PR DESCRIPTION

Inline disabled in the case of old tab style headings