### PR TITLE
Add ForeignKey attribute for the sake of completion

### DIFF
--- a/samples/core/Modeling/DataAnnotations/Relationships/InverseProperty.cs
+++ b/samples/core/Modeling/DataAnnotations/Relationships/InverseProperty.cs
@@ -17,9 +17,11 @@ namespace EFModeling.DataAnnotations.Relationships.InverseProperty
         public string Title { get; set; }
         public string Content { get; set; }
 
+        [ForeignKey]
         public int AuthorUserId { get; set; }
         public User Author { get; set; }
 
+        [ForeignKey]
         public int ContributorUserId { get; set; }
         public User Contributor { get; set; }
     }


### PR DESCRIPTION
In the example provided under the _Manual configuration section > Data Annotations_ of the [Relationships page](https://github.com/dotnet/EntityFramework.Docs/blob/master/entity-framework/core/modeling/relationships.md#manual-configuration) a note making reference to the `ForeignKey` attribute is shown, but this attribute is never introduced to the reader, I think the attribute is missing.