### PR TITLE
New docs for context creation and initialization

### DIFF
--- a/entity-framework/core/dbcontext-configuration/index.md
+++ b/entity-framework/core/dbcontext-configuration/index.md
@@ -12,7 +12,7 @@ This article shows basic patterns for initialization and configuration of a <xre
 
 ## The DbContext lifetime
 
-The lifetime of a `DbContext` begins when the instance is created and ends when the instance is [disposed](https://docs.microsoft.com/dotnet/standard/garbage-collection/unmanaged). A `DbContext` instance is designed to be used for a _single_ [unit-of-work](https://www.martinfowler.com/eaaCatalog/unitOfWork.html). This means that the lifetime of a `DbContext` instance is usually very short.
+The lifetime of a `DbContext` begins when the instance is created and ends when the instance is [disposed](/dotnet/standard/garbage-collection/unmanaged). A `DbContext` instance is designed to be used for a _single_ [unit-of-work](https://www.martinfowler.com/eaaCatalog/unitOfWork.html). This means that the lifetime of a `DbContext` instance is usually very short.
 
 > [!TIP]
 > To quote Martin Fowler from the link above, "A Unit of Work keeps track of everything you do during a business transaction that can affect the database. When you're done, it figures out everything that needs to be done to alter the database as a result of your work."
@@ -21,7 +21,7 @@ A typical unit-of-work when using Entity Framework Core (EF Core) involves:
 
 - Creation of a `DbContext` instance
 - Tracking of entity instances by the context. Entities become tracked by
-  - Being [returned from a query](xref:core/saving/basic)
+  - Being [returned from a query](xref:core/querying/tracking)
   - Being [added or attached to the context](xref:core/saving/disconnected-entities)
 - Changes are made to the tracked entities as needed to implement the business rule
 - <xref:Microsoft.EntityFrameworkCore.DbContext.SaveChanges%2A> or <xref:Microsoft.EntityFrameworkCore.DbContext.SaveChangesAsync%2A> is called. EF Core detects the changes made and writes them to the database.
@@ -29,15 +29,15 @@ A typical unit-of-work when using Entity Framework Core (EF Core) involves:
 
 > [!IMPORTANT]
 >
-> - It is very important to dispose the `DbContext` after use. This ensures both that any unmanaged resources are freed, and that any events or other hooks are unregistered so as to prevent memory leaks.
-> - `DbContext` is **not thread-safe**. Do not share contexts between threads. Make sure to `await` all async calls before continuing to use the context instance.
-> - An `InvalidOperationException` thrown by EF Core code can put the context into an unrecoverable state. Such exceptions indicate a program error and are not designed to be recovered from.
+> - It is very important to dispose the <xref:Microsoft.EntityFrameworkCore.DbContext> after use. This ensures both that any unmanaged resources are freed, and that any events or other hooks are unregistered so as to prevent memory leaks in case the instance remains referenced.
+> - [DbContext is **not thread-safe**](#avoiding-dbcontext-threading-issues). Do not share contexts between threads. Make sure to [await](/dotnet/csharp/language-reference/operators/await) all async calls before continuing to use the context instance.
+> - An <xref:System.InvalidOperationException> thrown by EF Core code can put the context into an unrecoverable state. Such exceptions indicate a program error and are not designed to be recovered from.
 
 ## DbContext in dependency injection for ASP.NET Core
 
 In many web applications, each HTTP request corresponds to a single unit-of-work. This makes tying the context lifetime to that of the request a good default for web applications.
 
-ASP.NET Core applications are [configured using dependency injection](https://docs.microsoft.com/aspnet/core/fundamentals/startup).  EF Core can be added to this configuration using <xref:Microsoft.Extensions.DependencyInjection.EntityFrameworkServiceCollectionExtensions.AddDbContext%2A> in the [`ConfigurureServices`](https://docs.microsoft.com/aspnet/core/fundamentals/startup#the-configureservices-method) method of `Startup.cs`. For example:
+ASP.NET Core applications are [configured using dependency injection](/aspnet/core/fundamentals/startup). EF Core can be added to this configuration using <xref:Microsoft.Extensions.DependencyInjection.EntityFrameworkServiceCollectionExtensions.AddDbContext%2A> in the [`ConfigurureServices`](/aspnet/core/fundamentals/startup#the-configureservices-method) method of `Startup.cs`. For example:
 
 <!--
         public void ConfigureServices(IServiceCollection services)
@@ -82,9 +82,9 @@ The `ApplicationDbContext` class must expose a public constructor with a `DbCont
 
 The final result is an `ApplicationDbContext` instance created for each request and passed to the controller to perform a unit-of-work before being disposed when the request ends.
 
-Read further in this article to learn more about configuration options. In addition, see [App startup in ASP.NET Core](https://docs.microsoft.com/aspnet/core/fundamentals/startup) and [Dependency injection in ASP.NET Core](https://docs.microsoft.com/aspnet/core/fundamentals/dependency-injection) for more information on configuration and dependency injection in ASP.NET Core.
+Read further in this article to learn more about configuration options. In addition, see [App startup in ASP.NET Core](/aspnet/core/fundamentals/startup) and [Dependency injection in ASP.NET Core](/aspnet/core/fundamentals/dependency-injection) for more information on configuration and dependency injection in ASP.NET Core.
 
-<!-- See also [_Using dependency injection_](TODO) for advanced dependency injection configuration with EF Core. -->
+<!-- See also [Using Dependency Injection](TODO) for advanced dependency injection configuration with EF Core. -->
 
 ## Simple DbContext initialization with 'new'
 
@@ -147,9 +147,9 @@ The `DbContextOptions` can be created and the constructor can be called explicit
 
 ## Using a DbContext factory (e.g. for Blazor)
 
-Some application types (e.g. [ASP.NET Core Blazor](https://docs.microsoft.com/aspnet/core/blazor/)) use dependency injection but do not create a service scope that aligns with the desired `DbContext` lifetime. Even where such an alignment does exist, the application may need to perform multiple units-of-work within this scope--for example, multiple units-of-work within a single HTTP request.
+Some application types (e.g. [ASP.NET Core Blazor](/aspnet/core/blazor/)) use dependency injection but do not create a service scope that aligns with the desired `DbContext` lifetime. Even where such an alignment does exist, the application may need to perform multiple units-of-work within this scope. For example, multiple units-of-work within a single HTTP request.
 
-In these cases, `AddDbContextFactory<TContext>` <!-- Issue #2748 --> can be used to register a factory for creation of `DbContext` instances. For example:
+In these cases, <xref:Microsoft.Extensions.DependencyInjection.EntityFrameworkServiceCollectionExtensions.AddDbContextFactory%2A> can be used to register a factory for creation of `DbContext` instances. For example:
 
 <!--
         public void ConfigureServices(IServiceCollection services)
@@ -200,7 +200,7 @@ The injected factory can then be used to construct DbContext instances in the se
 
 Notice that the `DbContext` instances created in this way are **not** managed by the application's service provider and therefore must be disposed by the application.
 
-See [_ASP.NET Core Blazor Server with Entity Framework Core_](https://docs.microsoft.com/aspnet/core/blazor/blazor-server-ef-core) for more information on using EF Core with Blazor.
+See [ASP.NET Core Blazor Server with Entity Framework Core](/aspnet/core/blazor/blazor-server-ef-core) for more information on using EF Core with Blazor.
 
 ## DbContextOptions
 
@@ -214,7 +214,7 @@ Examples of each of these are shown in the preceding sections. The same configur
 
 ### Configuring the database provider
 
-Each `DbContext` instance must be configured to use one and only one database provider. (Different instances of a `DbContext` subtype can be used with different database providers, but a single instance must only use one.) A database provider is configured using a specific "UseProvider" call. For example, to use the SQL Server database provider:
+Each `DbContext` instance must be configured to use one and only one database provider. (Different instances of a `DbContext` subtype can be used with different database providers, but a single instance must only use one.) A database provider is configured using a specific `Use*`" call. For example, to use the SQL Server database provider:
 
 <!--
     public class ApplicationDbContext : DbContext
@@ -227,10 +227,10 @@ Each `DbContext` instance must be configured to use one and only one database pr
 -->
 [!code-csharp[ApplicationDbContext](../../../samples/core/Miscellaneous/ConfiguringDbContext/WithNew/ApplicationDbContext.cs?name=ApplicationDbContext)]
 
-These "UseProvider" methods are extension methods implemented by the database provider. This means that the database provider NuGet package must be installed before the extension method can be used.
+These `Use*`" methods are extension methods implemented by the database provider. This means that the database provider NuGet package must be installed before the extension method can be used.
 
 > [!TIP]
-> EF Core database providers make extensive use of [extension methods](https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/extension-methods). If the compiler indicates that a method cannot be found, then make sure that the provider's NuGet package is installed and that you have `using Microsoft.EntityFrameworkCore;` in your code.
+> EF Core database providers make extensive use of [extension methods](/dotnet/csharp/programming-guide/classes-and-structs/extension-methods). If the compiler indicates that a method cannot be found, then make sure that the provider's NuGet package is installed and that you have `using Microsoft.EntityFrameworkCore;` in your code.
 
 The following table contains examples for common database providers.
 
@@ -244,12 +244,12 @@ The following table contains examples for common database providers.
 | MySQL/MariaDB*               | `.UseMySql((connectionString)`                | [Pomelo.EntityFrameworkCore.MySql](https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql/)
 | Oracle*                      | `.UseOracle(connectionString)`                | [Oracle.EntityFrameworkCore](https://www.nuget.org/packages/Oracle.EntityFrameworkCore/)
 
-*These database providers are not shipped by Microsoft. See [_Database Providers_](xref:core/providers/index) for more information about database providers.
+*These database providers are not shipped by Microsoft. See [Database Providers](xref:core/providers/index) for more information about database providers.
 
 > [!WARNING]
-> The EF Core in-memory database is not designed for production use. In addition, it may not be the best choice even for testing. See [_Testing code that uses EF Core_](xref:core/testing/index) for more information.
+> The EF Core in-memory database is not designed for production use. In addition, it may not be the best choice even for testing. See [Testing Code That Uses EF Core](xref:core/testing/index) for more information.
 
-See [_Connection Strings_](xref:core/miscellaneous/connection-strings) for more information on using connection strings with EF Core.
+See [Connection Strings](xref:core/miscellaneous/connection-strings) for more information on using connection strings with EF Core.
 
 Optional configuration specific to the database provider is performed in an additional provider-specific builder. For example, using <xref:Microsoft.EntityFrameworkCore.Infrastructure.SqlServerDbContextOptionsBuilder.EnableRetryOnFailure%2A> to configure retries for connection resiliency when connecting to Azure SQL:
 
@@ -273,11 +273,11 @@ Optional configuration specific to the database provider is performed in an addi
 > [!TIP]
 > The same database provider is used for SQL Server and Azure SQL. However, it is recommended that [connection resiliency](xref:core/miscellaneous/connection-resiliency) be used when connecting to SQL Azure.
 
-See [_Database Providers_](xref:core/providers/index) for more information on provider-specific configuration.
+See [Database Providers](xref:core/providers/index) for more information on provider-specific configuration.
 
 ### Other DbContext configuration
 
-Other `DbContext` configuration can be chained either before or after (it makes no difference which) the "UseProvider" call. For example, to turn on sensitive-data logging:
+Other `DbContext` configuration can be chained either before or after (it makes no difference which) the `Use*` call. For example, to turn on sensitive-data logging:
 
 <!--
     public class ApplicationDbContext : DbContext
@@ -296,22 +296,22 @@ The following table contains examples of common methods called on `DbContextOpti
 
 | DbContextOptionsBuilder method                                                             | What it does                                                | Learn more
 |:-------------------------------------------------------------------------------------------|-------------------------------------------------------------|--------------
-| <xref:Microsoft.EntityFrameworkCore.DbContextOptionsBuilder.UseQueryTrackingBehavior%2A>   | Sets the default tracking behavior for queries              | [_Query Tracking Behavior_](xref:core/querying/tracking)
-| `LogTo()` <!-- Issue #2748 -->                                                               | A simple way to get EF Core logs (EF Core 5.0 and later)    | [_Logging, Events, and Diagnostics_](xref:core/logging-events-diagnostics/index)
-| <xref:Microsoft.EntityFrameworkCore.DbContextOptionsBuilder.UseLoggerFactory%2A>           | Registers an `Micrsofot.Extensions.Logging` factory         | [_Logging, Events, and Diagnostics_](xref:core/logging-events-diagnostics/index)
-| <xref:Microsoft.EntityFrameworkCore.DbContextOptionsBuilder.EnableSensitiveDataLogging%2A> | Includes application data in exceptions and logging         | [_Logging, Events, and Diagnostics_](xref:core/logging-events-diagnostics/index)
-| <xref:Microsoft.EntityFrameworkCore.DbContextOptionsBuilder.EnableDetailedErrors%2A>       | More detailed query errors (at the expense of performance)  | [_Logging, Events, and Diagnostics_](xref:core/logging-events-diagnostics/index)
-| <xref:Microsoft.EntityFrameworkCore.DbContextOptionsBuilder.ConfigureWarnings%2A>          | Ignore or throw for warnings and other events               | [_Logging, Events, and Diagnostics_](xref:core/logging-events-diagnostics/index)
-| <xref:Microsoft.EntityFrameworkCore.DbContextOptionsBuilder.AddInterceptors%2A>            | Registers EF Core interceptors                              | [_Logging, Events, and Diagnostics_](xref:core/logging-events-diagnostics/index)
-| <xref:Microsoft.EntityFrameworkCore.ProxiesExtensions.UseLazyLoadingProxies%2A>            | Use dynamic proxies for lazy-loading                        | [_Lazy Loading_)](xref:core/querying/related-data/lazy)
-| `UseChangeTrackingProxies()` <!-- Issue #2748 -->                                          | Use dynamic proxies for change-tracking                     | Coming soon...
+| <xref:Microsoft.EntityFrameworkCore.DbContextOptionsBuilder.UseQueryTrackingBehavior%2A>   | Sets the default tracking behavior for queries              | [Query Tracking Behavior](xref:core/querying/tracking)
+| <xref:Microsoft.EntityFrameworkCore.DbContextOptionsBuilder.LogTo%2A>                      | A simple way to get EF Core logs (EF Core 5.0 and later)    | [Logging, Events, and Diagnostics](xref:core/logging-events-diagnostics/index)
+| <xref:Microsoft.EntityFrameworkCore.DbContextOptionsBuilder.UseLoggerFactory%2A>           | Registers an `Micrsofot.Extensions.Logging` factory         | [Logging, Events, and Diagnostics](xref:core/logging-events-diagnostics/index)
+| <xref:Microsoft.EntityFrameworkCore.DbContextOptionsBuilder.EnableSensitiveDataLogging%2A> | Includes application data in exceptions and logging         | [Logging, Events, and Diagnostics](xref:core/logging-events-diagnostics/index)
+| <xref:Microsoft.EntityFrameworkCore.DbContextOptionsBuilder.EnableDetailedErrors%2A>       | More detailed query errors (at the expense of performance)  | [Logging, Events, and Diagnostics](xref:core/logging-events-diagnostics/index)
+| <xref:Microsoft.EntityFrameworkCore.DbContextOptionsBuilder.ConfigureWarnings%2A>          | Ignore or throw for warnings and other events               | [Logging, Events, and Diagnostics](xref:core/logging-events-diagnostics/index)
+| <xref:Microsoft.EntityFrameworkCore.DbContextOptionsBuilder.AddInterceptors%2A>            | Registers EF Core interceptors                              | [Logging, Events, and Diagnostics](xref:core/logging-events-diagnostics/index)
+| <xref:Microsoft.EntityFrameworkCore.ProxiesExtensions.UseLazyLoadingProxies%2A>            | Use dynamic proxies for lazy-loading                        | [Lazy Loading](xref:core/querying/related-data/lazy)
+| <xref:Microsoft.EntityFrameworkCore.ProxiesExtensions.UseChangeTrackingProxies%2A>         | Use dynamic proxies for change-tracking                     | Coming soon...
 
 > [!NOTE]
-> <xref:Microsoft.EntityFrameworkCore.ProxiesExtensions.UseLazyLoadingProxies%2A> and `UseChangeTrackingProxies()` <!-- Issue #2748 --> are extension methods from the [Microsoft.EntityFrameworkCore.Proxies](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Proxies/) NuGet package. This kind of ".UseSomething()" call is the recommended way to configure and/or use EF Core extensions contained in other packages.
+> <xref:Microsoft.EntityFrameworkCore.ProxiesExtensions.UseLazyLoadingProxies%2A> and <xref:Microsoft.EntityFrameworkCore.ProxiesExtensions.UseChangeTrackingProxies%2A> are extension methods from the [Microsoft.EntityFrameworkCore.Proxies](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Proxies/) NuGet package. This kind of ".UseSomething()" call is the recommended way to configure and/or use EF Core extensions contained in other packages.
 
 ### `DbContextOptions` verses `DbContextOptions<TContext>`
 
-Most `DbContext` subclasses that accept a `DbContextOptions` should use the [generic](https://docs.microsoft.com/dotnet/csharp/programming-guide/generics/) `DbContextOptions<TContext>` variation. For example:
+Most `DbContext` subclasses that accept a `DbContextOptions` should use the [generic](/dotnet/csharp/programming-guide/generics/) `DbContextOptions<TContext>` variation. For example:
 
 <!--
     public sealed class SealedApplicationDbContext : DbContext
@@ -327,7 +327,7 @@ Most `DbContext` subclasses that accept a `DbContextOptions` should use the [gen
 This ensures that the correct options for the specific `DbContext` subtype are resolved from dependency injection, even when multiple `DbContext` subtypes are registered.
 
 > [!TIP]
-> Your `DbContext` does not need to be sealed, but sealing is best practice to do so for classes not designed to be inherited from.
+> Your DbContext does not need to be sealed, but sealing is best practice to do so for classes not designed to be inherited from.
 
 However, if the `DbContext` subtype is itself intended to be inherited from, then it should expose a protected constructor taking a non-generic `DbContextOptions`. For example:
 
@@ -401,13 +401,13 @@ When concurrent access goes undetected, it can result in undefined behavior, app
 
 There are common mistakes that can inadvertently cause concurrent access on the same `DbContext` instance:
 
-### Forgetting to await the completion of an asynchronous operation before starting any other operation on the same DbContext
+### Asynchronous operation pitfalls
 
 Asynchronous methods enable EF Core to initiate operations that access the database in a non-blocking way. But if a caller does not await the completion of one of these methods, and proceeds to perform other operations on the `DbContext`, the state of the `DbContext` can be, (and very likely will be) corrupted.
 
 Always await EF Core asynchronous methods immediately.
 
-### Implicitly sharing DbContext instances across multiple threads via dependency injection
+### Implicitly sharing DbContext instances via dependency injection
 
 The [`AddDbContext`](/dotnet/api/microsoft.extensions.dependencyinjection.entityframeworkservicecollectionextensions.adddbcontext) extension method registers `DbContext` types with a [scoped lifetime](/aspnet/core/fundamentals/dependency-injection#service-lifetimes) by default.
 

--- a/samples/core/Miscellaneous/ConfiguringDbContext/AdditionalConfiguration/ApplicationDbContext.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/AdditionalConfiguration/ApplicationDbContext.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace AdditionalConfiguration
+{
+    #region ApplicationDbContext
+    public class ApplicationDbContext : DbContext
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder
+                .EnableSensitiveDataLogging()
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Test");
+        }
+    }
+    #endregion
+}

--- a/samples/core/Miscellaneous/ConfiguringDbContext/AdditionalProviderConfiguration/ApplicationDbContext.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/AdditionalProviderConfiguration/ApplicationDbContext.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace AdditionalProviderConfiguration
+{
+    #region ApplicationDbContext
+    public class ApplicationDbContext : DbContext
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder
+                .UseSqlServer(
+                    @"Server=(localdb)\mssqllocaldb;Database=Test",
+                    providerOptions =>
+                        {
+                            providerOptions.EnableRetryOnFailure();
+                        });
+        }
+    }
+    #endregion
+}

--- a/samples/core/Miscellaneous/ConfiguringDbContext/ConfiguringDbContext.csproj
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/ConfiguringDbContext.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <RootNamespace />
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0-rc.2.20475.6" />
+    </ItemGroup>
+
+</Project>

--- a/samples/core/Miscellaneous/ConfiguringDbContext/InheritDbContext/ApplicationDbContext.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/InheritDbContext/ApplicationDbContext.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace InheritDbContext
+{
+    #region SealedApplicationDbContext
+    public sealed class SealedApplicationDbContext : DbContext
+    {
+        public SealedApplicationDbContext(DbContextOptions<SealedApplicationDbContext> contextOptions)
+            : base(contextOptions)
+        {
+        }
+    }
+    #endregion
+
+    #region ApplicationDbContextBase
+    public abstract class ApplicationDbContextBase : DbContext
+    {
+        protected ApplicationDbContextBase(DbContextOptions contextOptions)
+            : base(contextOptions)
+        {
+        }
+    }
+    #endregion
+
+    #region ApplicationDbContext12
+    public sealed class ApplicationDbContext1 : ApplicationDbContextBase
+    {
+        public ApplicationDbContext1(DbContextOptions<ApplicationDbContext1> contextOptions)
+            : base(contextOptions)
+        {
+        }
+    }
+
+    public sealed class ApplicationDbContext2 : ApplicationDbContextBase
+    {
+        public ApplicationDbContext2(DbContextOptions<ApplicationDbContext2> contextOptions)
+            : base(contextOptions)
+        {
+        }
+    }
+    #endregion
+
+    #region ApplicationDbContext
+    public class ApplicationDbContext : DbContext
+    {
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> contextOptions)
+            : base(contextOptions)
+        {
+        }
+
+        protected ApplicationDbContext(DbContextOptions contextOptions)
+            : base(contextOptions)
+        {
+        }
+    }
+    #endregion
+}
+

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/ApplicationDbContext.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/ApplicationDbContext.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace WebApp
+{
+    #region ApplicationDbContext
+    public class ApplicationDbContext : DbContext
+    {
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+            : base(options)
+        {
+        }
+    }
+    #endregion
+}

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/Controllers/MyController.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/Controllers/MyController.cs
@@ -1,0 +1,14 @@
+﻿namespace WebApp.Controllers
+{
+    #region MyController
+    public class MyController
+    {
+        private readonly ApplicationDbContext _context;
+
+        public MyController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+    }
+    #endregion
+}

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/Program.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/Program.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using WebApp;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        CreateHostBuilder(args).Build().Run();
+    }
+
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
+}

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/Startup.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/Startup.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace WebApp
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        #region ConfigureServices
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+            
+            services.AddDbContext<ApplicationDbContext>(
+                options => options.UseSqlServer("name=ConnectionStrings:DefaultConnection"));
+        }
+        #endregion
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
+        }
+    }
+}

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/UseNewForWebApp.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/UseNewForWebApp.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace WebApp
+{
+    public static class UseNewForWebApp
+    {
+        public static void Example()
+        {
+            #region UseNewForWebApp
+            var contextOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Test")
+                .Options;
+
+            using var context = new ApplicationDbContext(contextOptions);
+            #endregion
+        }
+    }
+}

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/appsettings.Development.json
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/appsettings.Development.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=Test"
+  }
+}

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/appsettings.json
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=Test"
+  },
+  "AllowedHosts": "*"
+}

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WithContextFactory/FactoryServicesExample.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WithContextFactory/FactoryServicesExample.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using WebApp;
+
+namespace WithContextFactory
+{
+    public class FactoryServicesExample
+    {
+        #region ConfigureServices
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddDbContextFactory<ApplicationDbContext>(options =>
+                options.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Test"));
+        }
+        #endregion
+    }
+}

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WithContextFactory/MyController.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WithContextFactory/MyController.cs
@@ -1,0 +1,28 @@
+
+using Microsoft.EntityFrameworkCore;
+using WebApp;
+
+namespace WithContextFactory
+{
+    public class MyController
+    {
+        #region Construct
+        private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
+
+        public MyController(IDbContextFactory<ApplicationDbContext> contextFactory)
+        {
+            _contextFactory = contextFactory;
+        }
+        #endregion
+        
+        #region DoSomething
+        public void DoSomething()
+        {
+            using (var context = _contextFactory.CreateDbContext())
+            {
+                // ...
+            }
+        }
+        #endregion
+    }
+}

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WithNew/ApplicationDbContext.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WithNew/ApplicationDbContext.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace WithNew
+{
+    #region ApplicationDbContext
+    public class ApplicationDbContext : DbContext
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Test");
+        }
+    }
+    #endregion
+}

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WithNewAndArgs/ApplicationDbContext.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WithNewAndArgs/ApplicationDbContext.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace WithNewAndArgs
+{
+    #region ApplicationDbContext
+    public class ApplicationDbContext : DbContext
+    {
+        private readonly string _connectionString;
+
+        public ApplicationDbContext(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseSqlServer(_connectionString);
+        }
+    }
+    #endregion
+}

--- a/samples/core/Miscellaneous/Testing/ItemsWebApi/ItemsWebApi/ItemsContext.cs
+++ b/samples/core/Miscellaneous/Testing/ItemsWebApi/ItemsWebApi/ItemsContext.cs
@@ -4,7 +4,7 @@ namespace Items
 {
     public class ItemsContext : DbContext
     {
-        public ItemsContext(DbContextOptions options) 
+        public ItemsContext(DbContextOptions<ItemsContext> options) 
             : base(options)
         {
         }

--- a/samples/core/Samples.sln
+++ b/samples/core/Samples.sln
@@ -125,6 +125,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Events", "Miscellaneous\Eve
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiagnosticListeners", "Miscellaneous\DiagnosticListeners\DiagnosticListeners.csproj", "{AF719729-AED8-4DEB-B895-61D8EBB50A01}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfiguringDbContext", "Miscellaneous\ConfiguringDbContext\ConfiguringDbContext.csproj", "{73503DF2-CD85-4710-BE94-B83B87054709}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -339,6 +341,10 @@ Global
 		{AF719729-AED8-4DEB-B895-61D8EBB50A01}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AF719729-AED8-4DEB-B895-61D8EBB50A01}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AF719729-AED8-4DEB-B895-61D8EBB50A01}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73503DF2-CD85-4710-BE94-B83B87054709}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73503DF2-CD85-4710-BE94-B83B87054709}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73503DF2-CD85-4710-BE94-B83B87054709}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73503DF2-CD85-4710-BE94-B83B87054709}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -392,6 +398,7 @@ Global
 		{97BECA9A-A72B-4C77-ADDB-DCC84966570F} = {85AFD7F1-6943-40FE-B8EC-AA9DBB42CCA6}
 		{8138D0F5-D1A7-4908-8A52-08196FF46B69} = {85AFD7F1-6943-40FE-B8EC-AA9DBB42CCA6}
 		{AF719729-AED8-4DEB-B895-61D8EBB50A01} = {85AFD7F1-6943-40FE-B8EC-AA9DBB42CCA6}
+		{73503DF2-CD85-4710-BE94-B83B87054709} = {85AFD7F1-6943-40FE-B8EC-AA9DBB42CCA6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {20C98D35-54EF-46A6-8F3B-1855C1AE4F70}


### PR DESCRIPTION
Draft

Fixes #594
Part of #876
Fixes #1390
Fixes #1923
Fixes #2241
Part of #2523
Part of #2549
Part of #1832

Let's discuss where this page should go and what goes underneath it. We had previously decided to keep this in Miscellaneous, but I now believe this would be better as a top-level item with the following subsections to go into more detail:

- DbContext lifetime, configuration and initialization
  - Overview
  - Connection strings
  - Using dependency injection
  - Connection resiliency
  - Context pooling