### PR TITLE
Fix to #2873 - ThenInclude required?

### DIFF
--- a/entity-framework/core/querying/related-data/eager.md
+++ b/entity-framework/core/querying/related-data/eager.md
@@ -41,6 +41,11 @@ You may want to include multiple related entities for one of the entities that i
 
 [!code-csharp[Main](../../../../samples/core/Querying/RelatedData/Program.cs#MultipleLeafIncludes)]
 
+> [!TIP]
+> You can also load multiple navigations using a single `Include` method. This is possible for navigation "chains" that are all references, or when they end with a single collection.
+
+[!code-csharp[Main](../../../../samples/core/Querying/RelatedData/Program.cs#IncludeMultipleNavigationsWithSingleInclude)]
+
 ## Filtered include
 
 > [!NOTE]

--- a/samples/core/Querying/RelatedData/Program.cs
+++ b/samples/core/Querying/RelatedData/Program.cs
@@ -65,6 +65,19 @@ namespace EFQuerying.RelatedData
             }
             #endregion
 
+            #region IncludeTree
+            using (var context = new BloggingContext())
+            {
+                var blogs = context.Blogs
+                    .Include(blog => blog.Posts)
+                        .ThenInclude(post => post.Author)
+                            .ThenInclude(author => author.Photo)
+                    .Include(blog => blog.Owner)
+                        .ThenInclude(owner => owner.Photo)
+                    .ToList();
+            }
+            #endregion
+
             #region MultipleLeafIncludes
             using (var context = new BloggingContext())
             {
@@ -77,15 +90,12 @@ namespace EFQuerying.RelatedData
             }
             #endregion
 
-            #region IncludeTree
+            #region IncludeMultipleNavigationsWithSingleInclude
             using (var context = new BloggingContext())
             {
                 var blogs = context.Blogs
-                    .Include(blog => blog.Posts)
-                        .ThenInclude(post => post.Author)
-                            .ThenInclude(author => author.Photo)
-                    .Include(blog => blog.Owner)
-                        .ThenInclude(owner => owner.Photo)
+                    .Include(blog => blog.Owner.AuthoredPosts)
+                        .ThenInclude(post => post.Blog.Owner.Photo)
                     .ToList();
             }
             #endregion


### PR DESCRIPTION
Added example for using single Include/ThenInclude method call to load multiple navigations.

Fixes #2873