### PR TITLE
Format identifiers as code

### DIFF
--- a/entity-framework/ef6/fundamentals/async.md
+++ b/entity-framework/ef6/fundamentals/async.md
@@ -131,12 +131,12 @@ Now that we have an EF model, let's write some code that uses it to perform some
     }
 ```
 
-This code calls the **PerformDatabaseOperations** method which saves a new **Blog** to the database and then retrieves all **Blogs** from the database and prints them to the **Console**. After this, the program writes a quote of the day to the **Console**.
+This code calls the `PerformDatabaseOperations` method which saves a new **Blog** to the database and then retrieves all **Blogs** from the database and prints them to the **Console**. After this, the program writes a quote of the day to the **Console**.
 
 Since the code is synchronous, we can observe the following execution flow when we run the program:
 
-1.  **SaveChanges** begins to push the new **Blog** to the database
-2.  **SaveChanges** completes
+1.  `SaveChanges` begins to push the new **Blog** to the database
+2.  `SaveChanges` completes
 3.  Query for all **Blogs** is sent to the database
 4.  Query returns and results are written to **Console**
 5.  Quote of the day is written to **Console**
@@ -149,14 +149,14 @@ Since the code is synchronous, we can observe the following execution flow when 
 
 Now that we have our program up and running, we can begin making use of the new async and await keywords. We've made the following changes to Program.cs
 
-1.  Line 2: The using statement for the **System.Data.Entity** namespace gives us access to the EF async extension methods.
-2.  Line 4: The using statement for the **System.Threading.Tasks** namespace allows us to use the **Task** type.
-3.  Line 12 & 18: We are capturing as task that monitors the progress of **PerformSomeDatabaseOperations** (line 12) and then blocking program execution for this task to complete once all the work for the program is done (line 18).
-4.  Line 25: We've update **PerformSomeDatabaseOperations** to be marked as **async** and return a **Task**.
-5.  Line 35: We're now calling the Async version of SaveChanges and awaiting it's completion.
-6.  Line 42: We're now calling the Async version of ToList and awaiting on the result.
+1.  Line 2: The using statement for the `System.Data.Entity` namespace gives us access to the EF async extension methods.
+2.  Line 4: The using statement for the `System.Threading.Tasks` namespace allows us to use the `Task` type.
+3.  Line 12 & 18: We are capturing as task that monitors the progress of `PerformSomeDatabaseOperations` (line 12) and then blocking program execution for this task to complete once all the work for the program is done (line 18).
+4.  Line 25: We've update `PerformSomeDatabaseOperations` to be marked as `async` and return a `Task`.
+5.  Line 35: We're now calling the Async version of `SaveChanges` and awaiting it's completion.
+6.  Line 42: We're now calling the Async version of `ToList` and awaiting on the result.
 
-For a comprehensive list of available extension methods in the System.Data.Entity namespace, refer to the QueryableExtensions class. *You’ll also need to add “using System.Data.Entity” to your using statements.*
+For a comprehensive list of available extension methods in the `System.Data.Entity` namespace, refer to the `QueryableExtensions` class. *You’ll also need to add `using System.Data.Entity` to your using statements.*
 
 ``` csharp
     using System;
@@ -216,11 +216,11 @@ For a comprehensive list of available extension methods in the System.Data.Entit
 
 Now that the code is asynchronous, we can observe a different execution flow when we run the program:
 
-1. **SaveChanges** begins to push the new **Blog** to the database  
-    *Once the command is sent to the database no more compute time is needed on the current managed thread. The **PerformDatabaseOperations** method returns (even though it hasn't finished executing) and program flow in the Main method continues.*
+1. `SaveChanges` begins to push the new **Blog** to the database  
+    *Once the command is sent to the database no more compute time is needed on the current managed thread. The `PerformDatabaseOperations` method returns (even though it hasn't finished executing) and program flow in the Main method continues.*
 2. **Quote of the day is written to Console**  
-    *Since there is no more work to do in the Main method, the managed thread is blocked on the Wait call until the database operation completes. Once it completes, the remainder of our **PerformDatabaseOperations** will be executed.*
-3.  **SaveChanges** completes  
+    *Since there is no more work to do in the Main method, the managed thread is blocked on the `Wait` call until the database operation completes. Once it completes, the remainder of our `PerformDatabaseOperations` will be executed.*
+3.  `SaveChanges` completes  
 4.  Query for all **Blogs** is sent to the database  
     *Again, the managed thread is free to do other work while the query is processed in the database. Since all other execution has completed, the thread will just halt on the Wait call though.*
 5.  Query returns and results are written to **Console**  

--- a/entity-framework/ef6/fundamentals/proxies.md
+++ b/entity-framework/ef6/fundamentals/proxies.md
@@ -10,7 +10,7 @@ When creating instances of POCO entity types, Entity Framework often creates ins
 
 ## Disabling proxy creation  
 
-Sometimes it is useful to prevent Entity Framework from creating proxy instances. For example, serializing non-proxy instances is considerably easier than serializing proxy instances. Proxy creation can be turned off by clearing the ProxyCreationEnabled flag. One place you could do this is in the constructor of your context. For example:  
+Sometimes it is useful to prevent Entity Framework from creating proxy instances. For example, serializing non-proxy instances is considerably easier than serializing proxy instances. Proxy creation can be turned off by clearing the `ProxyCreationEnabled` flag. One place you could do this is in the constructor of your context. For example:  
 
 ``` csharp
 public class BloggingContext : DbContext
@@ -29,7 +29,7 @@ Note that the EF will not create proxies for types where there is nothing for th
 
 ## Explicitly creating an instance of a proxy  
 
-A proxy instance will not be created if you create an instance of an entity using the new operator. This may not be a problem, but if you need to create a proxy instance (for example, so that lazy loading or proxy change tracking will work) then you can do so using the Create method of DbSet. For example:  
+A proxy instance will not be created if you create an instance of an entity using the new operator. This may not be a problem, but if you need to create a proxy instance (for example, so that lazy loading or proxy change tracking will work) then you can do so using the `Create` method of `DbSet`. For example:  
 
 ``` csharp
 using (var context = new BloggingContext())
@@ -38,7 +38,7 @@ using (var context = new BloggingContext())
 }
 ```  
 
-The generic version of Create can be used if you want to create an instance of a derived entity type. For example:  
+The generic version of `Create` can be used if you want to create an instance of a derived entity type. For example:  
 
 ``` csharp
 using (var context = new BloggingContext())
@@ -47,17 +47,19 @@ using (var context = new BloggingContext())
 }
 ```  
 
-Note that the Create method does not add or attach the created entity to the context.  
+Note that the `Create` method does not add or attach the created entity to the context.  
 
-Note that the Create method will just create an instance of the entity type itself if creating a proxy type for the entity would have no value because it would not do anything. For example, if the entity type is sealed and/or has no virtual properties then Create will just create an instance of the entity type.  
+Note that the `Create` method will just create an instance of the entity type itself if creating a proxy type for the entity would have no value because it would not do anything. For example, if the entity type is sealed and/or has no virtual properties then `Create` will just create an instance of the entity type.  
 
 ## Getting the actual entity type from a proxy type  
 
 Proxy types have names that look something like this:  
 
-System.Data.Entity.DynamicProxies.Blog_5E43C6C196972BF0754973E48C9C941092D86818CD94005E9A759B70BF6E48E6  
+```
+System.Data.Entity.DynamicProxies.Blog_5E43C6C196972BF0754973E48C9C941092D86818CD94005E9A759B70BF6E48E6
+```
 
-You can find the entity type for this proxy type using the GetObjectType method from ObjectContext. For example:  
+You can find the entity type for this proxy type using the `GetObjectType` method from `ObjectContext`. For example:  
 
 ``` csharp
 using (var context = new BloggingContext())
@@ -67,4 +69,4 @@ using (var context = new BloggingContext())
 }
 ```  
 
-Note that if the type passed to GetObjectType is an instance of an entity type that is not a proxy type then the type of entity is still returned. This means you can always use this method to get the actual entity type without any other checking to see if the type is a proxy type or not.  
+Note that if the type passed to `GetObjectType` is an instance of an entity type that is not a proxy type then the type of entity is still returned. This means you can always use this method to get the actual entity type without any other checking to see if the type is a proxy type or not.  


### PR DESCRIPTION
When identifiers are not formatted as code it causes issues with localization (https://github.com/MicrosoftDocs/feedback/issues/2083)