### PR TITLE
Use colons consistently for connection strings in UserSecrets

### DIFF
--- a/entity-framework/core/cli/dotnet.md
+++ b/entity-framework/core/cli/dotnet.md
@@ -218,8 +218,8 @@ dotnet ef dbcontext scaffold "Server=(localdb)\mssqllocaldb;Database=Blogging;Tr
 The following example reads the connection string from the project's configuration set using the [Secret Manager tool](/aspnet/core/security/app-secrets#secret-manager).
 
 ```dotnetcli
-dotnet user-secrets set ConnectionStrings.Blogging "Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=Blogging"
-dotnet ef dbcontext scaffold Name=ConnectionStrings.Blogging Microsoft.EntityFrameworkCore.SqlServer
+dotnet user-secrets set ConnectionStrings:Blogging "Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=Blogging"
+dotnet ef dbcontext scaffold Name=ConnectionStrings:Blogging Microsoft.EntityFrameworkCore.SqlServer
 ```
 
 ## dotnet ef dbcontext script

--- a/entity-framework/core/cli/powershell.md
+++ b/entity-framework/core/cli/powershell.md
@@ -206,7 +206,7 @@ Scaffold-DbContext "Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Conn
 The following example reads the connection string from the project's configuration possibly set using the [Secret Manager tool](/aspnet/core/security/app-secrets#secret-manager).
 
 ```powershell
-Scaffold-DbContext "Name=ConnectionStrings.Blogging" Microsoft.EntityFrameworkCore.SqlServer
+Scaffold-DbContext "Name=ConnectionStrings:Blogging" Microsoft.EntityFrameworkCore.SqlServer
 ```
 
 ## Script-DbContext

--- a/entity-framework/core/managing-schemas/scaffolding.md
+++ b/entity-framework/core/managing-schemas/scaffolding.md
@@ -42,8 +42,8 @@ If you have an ASP.NET Core project, you can use the `Name=<connection-string>` 
 This works well with the [Secret Manager tool](/aspnet/core/security/app-secrets#secret-manager) to keep your database password separate from your codebase.
 
 ```dotnetcli
-dotnet user-secrets set ConnectionStrings.Chinook "Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=Chinook"
-dotnet ef dbcontext scaffold Name=ConnectionStrings.Chinook Microsoft.EntityFrameworkCore.SqlServer
+dotnet user-secrets set ConnectionStrings:Chinook "Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=Chinook"
+dotnet ef dbcontext scaffold Name=ConnectionStrings:Chinook Microsoft.EntityFrameworkCore.SqlServer
 ```
 
 ## Provider name

--- a/entity-framework/core/miscellaneous/connection-strings.md
+++ b/entity-framework/core/miscellaneous/connection-strings.md
@@ -16,8 +16,8 @@ In ASP.NET Core the configuration system is very flexible, and the connection st
 For instance, you can use the [Secret Manager tool](/aspnet/core/security/app-secrets#secret-manager) to store your database password and then, in scaffolding, use a connection string that simply consists of `Name=<database-alias>`.
 
 ```dotnetcli
-dotnet user-secrets set ConnectionStrings.YourDatabaseAlias "Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=YourDatabase"
-dotnet ef dbcontext scaffold Name=ConnectionStrings.YourDatabaseAlias Microsoft.EntityFrameworkCore.SqlServer
+dotnet user-secrets set ConnectionStrings:YourDatabaseAlias "Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=YourDatabase"
+dotnet ef dbcontext scaffold Name=ConnectionStrings:YourDatabaseAlias Microsoft.EntityFrameworkCore.SqlServer
 ```
 
 Or the following example shows the connection string stored in `appsettings.json`.


### PR DESCRIPTION
Fixes #2805
Fixes #2995

I think I figured out the continual confusion here. The colon is always correct when reading from ASP.NET config JSON. However, when using UserSecrets, the secret can be stored as either `ConnectionString.Foo` or `ConnectionString:Foo`. We showed examples using periods, which then works when looking up with periods. But then this doesn't work for connection strings from configuration, even though the document makes the assumption that these things work the same.

The fix here is to use colons consistently. I also plan to update more of the connection strings documentation at a later time. But many people have hit this, so wanted to fix it now.