### PR TITLE
ForSqliteHasSrid() method is Obsolete

### DIFF
--- a/entity-framework/core/providers/sqlite/spatial.md
+++ b/entity-framework/core/providers/sqlite/spatial.md
@@ -42,11 +42,11 @@ DYLD_LIBRARY_PATH=/usr/local/opt/sqlite/lib
 
 ## Configuring SRID
 
-In SpatiaLite, columns need to specify an SRID per column. The default SRID is `0`. Specify a different SRID using the ForSqliteHasSrid method.
+In SpatiaLite, columns need to specify an SRID per column. The default SRID is `0`. Specify a different SRID using the HasSrid method.
 
 ```csharp
 modelBuilder.Entity<City>().Property(c => c.Location)
-    .ForSqliteHasSrid(4326);
+    .HasSrid(4326);
 ```
 
 > [!NOTE]


### PR DESCRIPTION
In the "Configuring SRID" section of the SQLite Spatial documentation there is an example that uses the "ForSqliteHasSrid()" method. According to the [.NET API Browser](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.sqlitepropertybuilderextensions.forsqlitehassrid?view=efcore-3.1) this method is obsolete and has been replaced with the "HasSrid()" method in EF Core 5.0. This change replaces the references to the obsolete method with references to the current method.