### PR TITLE
Add config logging

### DIFF
--- a/entity-framework/core/logging-events-diagnostics/index.md
+++ b/entity-framework/core/logging-events-diagnostics/index.md
@@ -42,6 +42,8 @@ Logging configuration is commonly provided by the `Logging` section of *appsetti
 }
 ```
 
+With the preceding JSON, SQL statements are displayed on the command line and in the Visual Studio output window.
+
 For more information on configuring logging in .NET, see [Configure logging in .NET](/dotnet/core/extensions/logging#configure-logging) and [Configure logging in ASP.NET Core](/aspnet/core/fundamentals/logging#configure-logging).
 
 ## Simple logging

--- a/entity-framework/core/logging-events-diagnostics/index.md
+++ b/entity-framework/core/logging-events-diagnostics/index.md
@@ -16,6 +16,7 @@ The table below provides a quick reference for the differences between the mecha
 
 | Mechanism |  Async | Scope | Registered | Intended use
 |:----------|--------|-------|------------|-------------
+| Configuration Logging | ? | ? | Configuration system | Development-time logging
 | Simple Logging | No | Per context | Context configuration | Development-time logging
 | Microsoft.Extensions.Logging | No | Per context* | D.I. or context configuration | Production logging
 | Events | No | Per context | Any time | Reacting to EF events
@@ -23,6 +24,25 @@ The table below provides a quick reference for the differences between the mecha
 | Diagnostics listeners | No | Process | Globally | Application diagnostics
 
 *Typically `Microsoft.Extensions.Logging` is configured per-application via dependency injection However, at the EF level, each context _can_ be configured with a different logger if needed.
+
+## Configuration Logging
+
+Logging configuration is commonly provided by the `Logging` section of *appsettings*.`{Environment}`*.json* files. To log SQL statements in development, add `"Microsoft.EntityFrameworkCore.Database.Command": "Information"` to the *appsettings.Development.json* file:
+
+```json
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Information"
+    }
+  }
+}
+```
+
+For more information on configuring logging in .NET, see [Configure logging in .NET](/dotnet/core/extensions/logging#configure-logging) and [Configure logging in ASP.NET Core](/aspnet/core/fundamentals/logging#configure-logging).
 
 ## Simple logging
 

--- a/entity-framework/core/logging-events-diagnostics/index.md
+++ b/entity-framework/core/logging-events-diagnostics/index.md
@@ -16,7 +16,7 @@ The table below provides a quick reference for the differences between the mecha
 
 | Mechanism |  Async | Scope | Registered | Intended use
 |:----------|--------|-------|------------|-------------
-| Configuration Logging | ? | ? | Configuration system | Development-time logging
+| Configuration Logging | No | Per context | Configuration system | Development-time logging
 | Simple Logging | No | Per context | Context configuration | Development-time logging
 | Microsoft.Extensions.Logging | No | Per context* | D.I. or context configuration | Production logging
 | Events | No | Per context | Any time | Reacting to EF events
@@ -44,7 +44,7 @@ Logging configuration is commonly provided by the `Logging` section of *appsetti
 
 With the preceding JSON, SQL statements are displayed on the command line and in the Visual Studio output window.
 
-For more information on configuring logging in .NET, see [Configure logging in .NET](/dotnet/core/extensions/logging#configure-logging) and [Configure logging in ASP.NET Core](/aspnet/core/fundamentals/logging#configure-logging).
+For more information on configuring logging, see [Configure logging in .NET](/dotnet/core/extensions/logging#configure-logging) and [Configure logging in ASP.NET Core](/aspnet/core/fundamentals/logging#configure-logging).
 
 ## Simple logging
 


### PR DESCRIPTION
~Fixes~  Partially addresses  #1331
Fixes  #3208

[Internal review URL](https://review.docs.microsoft.com/en-us/ef/core/logging-events-diagnostics/?branch=pr-en-us-3240)

The config logging can be used for more than dev. Should I add a note that it can be used in test and production when a problem cannot be reproduced in a dev environment.  Setting `"Microsoft.EntityFrameworkCore.Database.Command": `  to `"Information"` in production can have negative performance impacts.

> Simple Logging

https://microsoft-ce-csi.acrolinx.cloud/htmldata/en/rules/help/avoid_simply.html
Avoid "simple/simply"
It's generally a good idea to avoid describing instructions with simple or simply as the reader might not find it so simple.

Can I change simple to basic?

> Entity Framework Core (EF Core) simple logging can be used to easily obtain logs whil

Ditto for easily