### PR TITLE
IDbContextFactory<TContext> Instead

### DIFF
--- a/entity-framework/core/dbcontext-configuration/index.md
+++ b/entity-framework/core/dbcontext-configuration/index.md
@@ -176,9 +176,9 @@ The `ApplicationDbContext` class must expose a public constructor with a `DbCont
 The `DbContextFactory` factory can then be used in other services through constructor injection. For example:
 
 <!--
-        private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
+        private readonly IDesignTimeDbContextFactory<ApplicationDbContext> _contextFactory;
 
-        public MyController(IDbContextFactory<ApplicationDbContext> contextFactory)
+        public MyController(IDesignTimeDbContextFactory<ApplicationDbContext> contextFactory)
         {
             _contextFactory = contextFactory;
         }

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WithContextFactory/MyController.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WithContextFactory/MyController.cs
@@ -6,9 +6,9 @@ namespace WithContextFactory
     public class MyController
     {
         #region Construct
-        private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
+        private readonly IDesignTimeDbContextFactory<ApplicationDbContext> _contextFactory;
 
-        public MyController(IDbContextFactory<ApplicationDbContext> contextFactory)
+        public MyController(IDesignTimeDbContextFactory<ApplicationDbContext> contextFactory)
         {
             _contextFactory = contextFactory;
         }


### PR DESCRIPTION
IDbContextFactory is used in EF or early version of EF Core.
Please use IDesignTimeDbContextFactory<TContext> Interface to instead of  it.
[ref](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.infrastructure.idbcontextfactory-1?view=efcore-2.2)