### PR TITLE
Update keyless-entity-types.md: Note about ToView()

### DIFF
--- a/entity-framework/core/modeling/keyless-entity-types.md
+++ b/entity-framework/core/modeling/keyless-entity-types.md
@@ -57,7 +57,7 @@ Some of the main usage scenarios for keyless entity types are:
 Mapping a keyless entity type to a database object is achieved using the `ToTable` or `ToView` fluent API. From the perspective of EF Core, the database object specified in this method is a _view_, meaning that it is treated as a read-only query source and cannot be the target of update, insert or delete operations. However, this does not mean that the database object is actually required to be a database view. It can alternatively be a database table that will be treated as read-only. Conversely, for regular entity types, EF Core assumes that a database object specified in the `ToTable` method can be treated as a _table_, meaning that it can be used as a query source but also targeted by update, delete and insert operations. In fact, you can specify the name of a database view in `ToTable` and everything should work fine as long as the view is configured to be updatable on the database.
 
 > [!NOTE]
-> `ToView` assumes that the object already exists in the database and it won't be created by migrations.
+> Until EF Core 5.0 `ToView` assumed that the object already exists in the database and it won't be created by migrations. In EF Core 5.0 and later use modelBuilder.Entity<ViewType>().ToTable("ViewNameInDatabase", t => t.ExcludeFromMigrations()) to exclude the object from migrations, see [ToView() is treated differently by migrations](xref:core/what-is-new/ef-core-5.0/breaking-changes#toview).
 
 ## Example
 


### PR DESCRIPTION
I think the sentence "`ToView` assumes that the object already exists in the database and it won't be created by migrations." is old / misleading.