### PR TITLE
Added an extensions entry for EntityFrameworkCore.Projectables

### DIFF
--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -164,7 +164,7 @@ NCache Entity Framework Core Provider is a distributed second level cache provid
 
 ### EntityFrameworkCore.Projectables
 
-Flexible projection magic for EFCore. Use properties, methods, and extension methods in your query without client evaluation. For EF Core 3 and 5.
+Flexible projection magic for EF Core. Use properties, methods, and extension methods in your query without client evaluation. For EF Core 3, 5.
 
 [GitHub repository](https://github.com/koenbeuk/EntityFrameworkCore.Projectables)
 

--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -162,6 +162,12 @@ NCache Entity Framework Core Provider is a distributed second level cache provid
 
 [Website](https://www.alachisoft.com/ncache/ef-core-cache.html)
 
+### EntityFrameworkCore.Projectables
+
+Flexible projection magic for EFCore. Use properties, methods, and extension methods in your query without client evaluation. For EF Core 3 and 5.
+
+[GitHub repository](https://github.com/koenbeuk/EntityFrameworkCore.Projectables)
+
 ### EntityFrameworkCore.Triggered
 
 Triggers for EF Core. Respond to changes in your DbContext before and after they are committed to the database. Triggers are fully asynchronous and support dependency injection, inheritance, cascading and more. For EF Core: 3, 5.


### PR DESCRIPTION
[EntityFrameworkCore.Projectables](https://github.com/koenbeuk/EntityFrameworkCore.Projectables) enables a way to use normal properties and methods within your linq query while having it still generate proper sql. Similar to Expressionify, it uses a code generator to create companion expressions of any property/method that is marked with an attribute. I've been using this technique for a while now and have recently published this library as a generic implementation. It has quite a few differences from Expressionify as it first allows Expanding on much more than just extension methods as well as it integrates with EFCore and actually improves performance for query compilation (currently exposed in the Benchmark but I'll add a blog post on this topic soon too).

It would be great if this can be listed on the Extensions page docs. If there are concerns that this project is still in 'preview' (currently v0.4.0). I expect a proper release within the next couple of days.