### PR TITLE
Add a note on querying shared columns

### DIFF
--- a/entity-framework/core/modeling/inheritance.md
+++ b/entity-framework/core/modeling/inheritance.md
@@ -56,7 +56,7 @@ By default, when two sibling entity types in the hierarchy have a property with 
 [!code-csharp[Main](../../../samples/core/Modeling/FluentAPI/SharedTPHColumns.cs?name=SharedTPHColumns&highlight=9,13)]
 
 > [!NOTE]
-> Some database providers, such as SQL Server, will not automatically use the discriminator predicate when querying shared columns using a cast. The query `Url = (blob as RssBlog).Url` would also return the `Url` value for the sibling `Blog` rows. To restrict the query to `RssBlog` entities in the hierarchy you need to add a filter manually on the discriminator, such as `Url = blob is RssBlog ? (blob as RssBlog).Url : null`.
+> Relational database providers, such as SQL Server, will not automatically use the discriminator predicate when querying shared columns when using a cast. The query `Url = (blob as RssBlog).Url` would also return the `Url` value for the sibling `Blog` rows. To restrict the query to `RssBlog` entities you need to manually add a filter on the discriminator, such as `Url = blob is RssBlog ? (blob as RssBlog).Url : null`.
 
 ## Table-per-type configuration
 

--- a/entity-framework/core/modeling/inheritance.md
+++ b/entity-framework/core/modeling/inheritance.md
@@ -55,6 +55,9 @@ By default, when two sibling entity types in the hierarchy have a property with 
 
 [!code-csharp[Main](../../../samples/core/Modeling/FluentAPI/SharedTPHColumns.cs?name=SharedTPHColumns&highlight=9,13)]
 
+> [!NOTE]
+> Some database providers, such as SQL Server, will not automatically use the discriminator predicate when querying shared columns using a cast. The query `Url = (blob as RssBlog).Url` would also return the `Url` value for the sibling `Blog` rows. To restrict the query to `RssBlog` entities in the hierarchy you need to add a filter manually on the discriminator, such as `Url = blob is RssBlog ? (blob as RssBlog).Url : null`.
+
 ## Table-per-type configuration
 
 > [!NOTE]


### PR DESCRIPTION
From https://github.com/dotnet/efcore/issues/25210, suggestion to add a note in the section on shared columns that some providers do not filter results by discriminator when casting a base entity to a child entity.

ping @AndriySvyryd