### PR TITLE
Remove "ConnectRetryCount", no longer needed due to added overload of SqlConnection.Open being used.

### DIFF
--- a/samples/core/Benchmarks/AverageBlogRanking.cs
+++ b/samples/core/Benchmarks/AverageBlogRanking.cs
@@ -85,7 +85,7 @@ namespace Benchmarks
             public DbSet<Blog> Blogs { get; set; }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Integrated Security=True");
+                => optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True");
 
             public void SeedData(int numblogs)
             {

--- a/samples/core/Benchmarks/DynamicallyConstructedQueries.cs
+++ b/samples/core/Benchmarks/DynamicallyConstructedQueries.cs
@@ -81,7 +81,7 @@ namespace Benchmarks
             public DbSet<Post> Posts { get; set; }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Integrated Security=True");
+                => optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True");
         }
 
         public class Blog

--- a/samples/core/Benchmarks/Inheritance.cs
+++ b/samples/core/Benchmarks/Inheritance.cs
@@ -55,7 +55,7 @@ namespace Benchmarks
             public DbSet<Root> Roots { get; set; }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Integrated Security=True");
+                => optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True");
 
             public void SeedData(int rowsPerEntityType)
             {

--- a/samples/core/Benchmarks/QueryTrackingBehavior.cs
+++ b/samples/core/Benchmarks/QueryTrackingBehavior.cs
@@ -48,7 +48,7 @@ namespace Benchmarks
             public DbSet<Post> Posts { get; set; }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Integrated Security=True");
+                => optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True");
 
             public static void SeedData(int numBlogs, int numPostsPerBlog)
             {

--- a/samples/core/CascadeDeletes/IntroOptionalSamples.cs
+++ b/samples/core/CascadeDeletes/IntroOptionalSamples.cs
@@ -159,7 +159,7 @@ namespace IntroOptional
         {
             optionsBuilder
                 .EnableSensitiveDataLogging()
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;ConnectRetryCount=0");
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;Trusted_Connection=True");
             //.UseSqlite("DataSource=test.db");
 
             if (!_quiet)

--- a/samples/core/CascadeDeletes/IntroRequiredSamples.cs
+++ b/samples/core/CascadeDeletes/IntroRequiredSamples.cs
@@ -176,7 +176,7 @@ namespace IntroRequired
         {
             optionsBuilder
                 .EnableSensitiveDataLogging()
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;ConnectRetryCount=0");
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;Trusted_Connection=True");
             //.UseSqlite("DataSource=test.db");
 
             if (!_quiet)

--- a/samples/core/CascadeDeletes/OptionalDependentsSamples.cs
+++ b/samples/core/CascadeDeletes/OptionalDependentsSamples.cs
@@ -187,7 +187,7 @@ namespace Optional
                 optionsBuilder
                     .EnableServiceProviderCaching(false)
                     .EnableSensitiveDataLogging()
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;ConnectRetryCount=0");
+                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;Trusted_Connection=True");
                 //.UseSqlite("DataSource=test.db");
 
                 if (!_quiet)

--- a/samples/core/CascadeDeletes/RequiredDependentsSamples.cs
+++ b/samples/core/CascadeDeletes/RequiredDependentsSamples.cs
@@ -192,7 +192,7 @@ namespace Required
                 optionsBuilder
                     .EnableServiceProviderCaching(false)
                     .EnableSensitiveDataLogging()
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;ConnectRetryCount=0");
+                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;Trusted_Connection=True");
                 //.UseSqlite("DataSource=test.db");
 
                 if (!_quiet)

--- a/samples/core/CascadeDeletes/WithDatabaseCycleSamples.cs
+++ b/samples/core/CascadeDeletes/WithDatabaseCycleSamples.cs
@@ -169,7 +169,7 @@ namespace DatabaseCycles
         {
             optionsBuilder
                 .EnableSensitiveDataLogging()
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;ConnectRetryCount=0");
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;Trusted_Connection=True");
             //.UseSqlite("DataSource=test.db");
 
             if (!_quiet)

--- a/samples/core/CompiledQueries/Model/AdventureWorksContext.cs
+++ b/samples/core/CompiledQueries/Model/AdventureWorksContext.cs
@@ -7,7 +7,7 @@ namespace Samples.Model
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                "data source=(localdb)\\mssqllocaldb;initial catalog=AdventureWorks2014;integrated security=True;MultipleActiveResultSets=True");
+                "data source=(localdb)\\mssqllocaldb;initial catalog=AdventureWorks2014;Trusted_Connection=True;MultipleActiveResultSets=True");
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/samples/core/CompiledQueries/Model/AdventureWorksContext.cs
+++ b/samples/core/CompiledQueries/Model/AdventureWorksContext.cs
@@ -7,7 +7,7 @@ namespace Samples.Model
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                "data source=(localdb)\\mssqllocaldb;initial catalog=AdventureWorks2014;integrated security=True;MultipleActiveResultSets=True;ConnectRetryCount=0");
+                "data source=(localdb)\\mssqllocaldb;initial catalog=AdventureWorks2014;integrated security=True;MultipleActiveResultSets=True");
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/samples/core/DbContextPooling/Program.cs
+++ b/samples/core/DbContextPooling/Program.cs
@@ -38,7 +38,7 @@ namespace Samples
     public class Startup
     {
         private const string ConnectionString
-            = @"Server=(localdb)\mssqllocaldb;Database=Demo.ContextPooling;Integrated Security=True";
+            = @"Server=(localdb)\mssqllocaldb;Database=Demo.ContextPooling;Trusted_Connection=True";
 
         public void ConfigureServices(IServiceCollection services)
         {

--- a/samples/core/DbContextPooling/Program.cs
+++ b/samples/core/DbContextPooling/Program.cs
@@ -38,7 +38,7 @@ namespace Samples
     public class Startup
     {
         private const string ConnectionString
-            = @"Server=(localdb)\mssqllocaldb;Database=Demo.ContextPooling;Integrated Security=True;ConnectRetryCount=0";
+            = @"Server=(localdb)\mssqllocaldb;Database=Demo.ContextPooling;Integrated Security=True";
 
         public void ConfigureServices(IServiceCollection services)
         {

--- a/samples/core/Intro/Model.cs
+++ b/samples/core/Intro/Model.cs
@@ -11,7 +11,7 @@ namespace Intro
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=Blogging;Integrated Security=True");
+                @"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True");
         }
     }
 

--- a/samples/core/KeylessEntityTypes/Program.cs
+++ b/samples/core/KeylessEntityTypes/Program.cs
@@ -103,7 +103,7 @@ namespace Samples
         {
             optionsBuilder
                 .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=Sample.KeylessEntityTypes;Trusted_Connection=True;ConnectRetryCount=0;")
+                    @"Server=(localdb)\mssqllocaldb;Database=Sample.KeylessEntityTypes;Trusted_Connection=True")
                 .UseLoggerFactory(_loggerFactory);
         }
 

--- a/samples/core/Miscellaneous/Async/Program.cs
+++ b/samples/core/Miscellaneous/Async/Program.cs
@@ -30,7 +30,7 @@ namespace EFAsync
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFAsync;Trusted_Connection=True;ConnectRetryCount=0");
+            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFAsync;Trusted_Connection=True");
         }
     }
 

--- a/samples/core/Miscellaneous/AsyncWithSystemInteractive/Program.cs
+++ b/samples/core/Miscellaneous/AsyncWithSystemInteractive/Program.cs
@@ -29,7 +29,7 @@ namespace EFAsync
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFAsync;Trusted_Connection=True;ConnectRetryCount=0");
+            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFAsync;Trusted_Connection=True");
         }
     }
 

--- a/samples/core/Miscellaneous/Collations/Program.cs
+++ b/samples/core/Miscellaneous/Collations/Program.cs
@@ -30,7 +30,7 @@ namespace EFCollations
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFCollations;Trusted_Connection=True;ConnectRetryCount=0");
+            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFCollations;Trusted_Connection=True");
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/samples/core/Miscellaneous/CommandInterception/BlogsContext.cs
+++ b/samples/core/Miscellaneous/CommandInterception/BlogsContext.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 public abstract class BlogsContext : DbContext
 {
-    private const string ConnectionString = @"Server=(localdb)\mssqllocaldb;Database=InterceptionTest;ConnectRetryCount=0";
+    private const string ConnectionString = @"Server=(localdb)\mssqllocaldb;Database=InterceptionTest;Trusted_Connection=True";
 
     protected BlogsContext()
         : base(

--- a/samples/core/Miscellaneous/ConnectionInterception/BlogsContext.cs
+++ b/samples/core/Miscellaneous/ConnectionInterception/BlogsContext.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 public class BlogsContext : DbContext
 {
-    private const string ConnectionString = @"Server=(localdb)\mssqllocaldb;Database=InterceptionTest;ConnectRetryCount=0";
+    private const string ConnectionString = @"Server=(localdb)\mssqllocaldb;Database=InterceptionTest;Trusted_Connection=True";
 
     private static readonly AadAuthenticationInterceptor _interceptor
         = new AadAuthenticationInterceptor();

--- a/samples/core/Miscellaneous/ConnectionResiliency/Program.cs
+++ b/samples/core/Miscellaneous/ConnectionResiliency/Program.cs
@@ -136,7 +136,7 @@ namespace EFConnectionResiliency
         {
             optionsBuilder
                 .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFMiscellanous.ConnectionResiliency;Trusted_Connection=True;ConnectRetryCount=0",
+                    @"Server=(localdb)\mssqllocaldb;Database=EFMiscellanous.ConnectionResiliency;Trusted_Connection=True",
                     options => options.EnableRetryOnFailure());
         }
         #endregion

--- a/samples/core/Miscellaneous/Logging/Logging/BloggingContext.cs
+++ b/samples/core/Miscellaneous/Logging/Logging/BloggingContext.cs
@@ -17,7 +17,7 @@ namespace EFLogging
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
                 .UseLoggerFactory(MyLoggerFactory)
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFLogging");
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFLogging;Trusted_Connection=True");
         #endregion
     }
 

--- a/samples/core/Miscellaneous/Logging/Logging/BloggingContext.cs
+++ b/samples/core/Miscellaneous/Logging/Logging/BloggingContext.cs
@@ -17,7 +17,7 @@ namespace EFLogging
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
                 .UseLoggerFactory(MyLoggerFactory)
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFLogging;ConnectRetryCount=0");
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFLogging");
         #endregion
     }
 

--- a/samples/core/Miscellaneous/Logging/Logging/BloggingContextWithFiltering.cs
+++ b/samples/core/Miscellaneous/Logging/Logging/BloggingContextWithFiltering.cs
@@ -26,7 +26,7 @@ namespace EFLogging
             => optionsBuilder
                 .UseLoggerFactory(MyLoggerFactory) // Warning: Do not create a new ILoggerFactory instance each time
                 .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFLogging;Trusted_Connection=True;ConnectRetryCount=0");
+                    @"Server=(localdb)\mssqllocaldb;Database=EFLogging;Trusted_Connection=True");
         #endregion
     }
 }

--- a/samples/core/Miscellaneous/NullableReferenceTypes/NullableReferenceTypesContext.cs
+++ b/samples/core/Miscellaneous/NullableReferenceTypes/NullableReferenceTypesContext.cs
@@ -11,7 +11,7 @@ namespace NullableReferenceTypes
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
                 .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFNullableReferenceTypes;Trusted_Connection=True;ConnectRetryCount=0");
+                    @"Server=(localdb)\mssqllocaldb;Database=EFNullableReferenceTypes;Trusted_Connection=True");
     }
     #endregion
 }

--- a/samples/core/Miscellaneous/Testing/BusinessLogic/BloggingContext.cs
+++ b/samples/core/Miscellaneous/Testing/BusinessLogic/BloggingContext.cs
@@ -46,7 +46,7 @@ namespace BusinessLogic
             if (!optionsBuilder.IsConfigured)
             {
                 optionsBuilder.UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFProviders.InMemory;Trusted_Connection=True;ConnectRetryCount=0");
+                    @"Server=(localdb)\mssqllocaldb;Database=EFProviders.InMemory;Trusted_Connection=True");
             }
         }
         #endregion

--- a/samples/core/Miscellaneous/Testing/ItemsWebApi/ItemsWebApi/Startup.cs
+++ b/samples/core/Miscellaneous/Testing/ItemsWebApi/ItemsWebApi/Startup.cs
@@ -23,7 +23,7 @@ namespace Items
 
             services.AddDbContext<ItemsContext>(
                 b => b.UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFTestSample"));
+                    @"Server=(localdb)\mssqllocaldb;Database=EFTestSample;Trusted_Connection=True"));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/core/Miscellaneous/Testing/ItemsWebApi/ItemsWebApi/Startup.cs
+++ b/samples/core/Miscellaneous/Testing/ItemsWebApi/ItemsWebApi/Startup.cs
@@ -23,7 +23,7 @@ namespace Items
 
             services.AddDbContext<ItemsContext>(
                 b => b.UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFTestSample;ConnectRetryCount=0"));
+                    @"Server=(localdb)\mssqllocaldb;Database=EFTestSample"));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/core/Miscellaneous/Testing/ItemsWebApi/SharedDatabaseTests/SharedDatabaseFixture.cs
+++ b/samples/core/Miscellaneous/Testing/ItemsWebApi/SharedDatabaseTests/SharedDatabaseFixture.cs
@@ -14,7 +14,7 @@ namespace SharedDatabaseTests
 
         public SharedDatabaseFixture()
         {
-            Connection = new SqlConnection(@"Server=(localdb)\mssqllocaldb;Database=EFTestSample;ConnectRetryCount=0");
+            Connection = new SqlConnection(@"Server=(localdb)\mssqllocaldb;Database=EFTestSample;Trusted_Connection=True");
 
             Seed();
 

--- a/samples/core/Miscellaneous/Testing/ItemsWebApi/Tests/SqlServerItemsControllerTest.cs
+++ b/samples/core/Miscellaneous/Testing/ItemsWebApi/Tests/SqlServerItemsControllerTest.cs
@@ -8,7 +8,7 @@ namespace Tests
         public SqlServerItemsControllerTest()
             : base(
                 new DbContextOptionsBuilder<ItemsContext>()
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFTestSample;ConnectRetryCount=0")
+                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFTestSample;Trusted_Connection=True")
                     .Options)
         {
         }

--- a/samples/core/Modeling/Conventions/EntityTypes.cs
+++ b/samples/core/Modeling/Conventions/EntityTypes.cs
@@ -62,7 +62,7 @@ namespace EFModeling.Conventions.EntityTypes
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFModeling.EntityTypeToFunctionMapping;Trusted_Connection=True;ConnectRetryCount=0");
+                @"Server=(localdb)\mssqllocaldb;Database=EFModeling.EntityTypeToFunctionMapping;Trusted_Connection=True");
         }
     }
 }

--- a/samples/core/Modeling/DataSeeding/DataSeedingContext.cs
+++ b/samples/core/Modeling/DataSeeding/DataSeedingContext.cs
@@ -9,7 +9,7 @@ namespace EFModeling.DataSeeding
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFDataSeeding;Trusted_Connection=True;ConnectRetryCount=0");
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFDataSeeding;Trusted_Connection=True");
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/samples/core/Modeling/OwnedEntities/OwnedEntityContext.cs
+++ b/samples/core/Modeling/OwnedEntities/OwnedEntityContext.cs
@@ -9,7 +9,7 @@ namespace EFModeling.OwnedEntities
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFOwnedEntity;Trusted_Connection=True;ConnectRetryCount=0");
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFOwnedEntity;Trusted_Connection=True");
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/samples/core/Modeling/TableSplitting/TableSplittingContext.cs
+++ b/samples/core/Modeling/TableSplitting/TableSplittingContext.cs
@@ -9,7 +9,7 @@ namespace EFModeling.TableSplitting
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFTableSplitting;Trusted_Connection=True;ConnectRetryCount=0");
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFTableSplitting;Trusted_Connection=True");
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/samples/core/Modeling/ValueConversions/CaseInsensitiveStrings.cs
+++ b/samples/core/Modeling/ValueConversions/CaseInsensitiveStrings.cs
@@ -81,7 +81,7 @@ namespace EFModeling.ValueConversions
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
                     .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=CaseInsensitiveStrings;Integrated Security=True")
+                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=CaseInsensitiveStrings;Trusted_Connection=True")
                     .EnableSensitiveDataLogging();
         }
 

--- a/samples/core/Modeling/ValueConversions/EncryptPropertyValues.cs
+++ b/samples/core/Modeling/ValueConversions/EncryptPropertyValues.cs
@@ -50,7 +50,7 @@ namespace EFModeling.ValueConversions
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
                     .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EncryptPropertyValues;Integrated Security=True")
+                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EncryptPropertyValues;Trusted_Connection=True")
                     .EnableSensitiveDataLogging();
         }
 

--- a/samples/core/Modeling/ValueConversions/EnumToStringConversions.cs
+++ b/samples/core/Modeling/ValueConversions/EnumToStringConversions.cs
@@ -296,7 +296,7 @@ namespace EFModeling.ValueConversions
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
                     .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EnumConversions;Integrated Security=True")
+                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EnumConversions;Trusted_Connection=True")
                     .EnableSensitiveDataLogging();
         }
 

--- a/samples/core/Modeling/ValueConversions/FixedLengthStrings.cs
+++ b/samples/core/Modeling/ValueConversions/FixedLengthStrings.cs
@@ -87,7 +87,7 @@ namespace EFModeling.ValueConversions
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
                     .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=FixedLengthStrings;Integrated Security=True")
+                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=FixedLengthStrings;Trusted_Connection=True")
                     .EnableSensitiveDataLogging();
         }
 

--- a/samples/core/Modeling/ValueConversions/PreserveDateTimeKind.cs
+++ b/samples/core/Modeling/ValueConversions/PreserveDateTimeKind.cs
@@ -84,7 +84,7 @@ namespace EFModeling.ValueConversions
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
                     .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=PreserveDateTimeKind;Integrated Security=True")
+                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=PreserveDateTimeKind;Trusted_Connection=True")
                     .EnableSensitiveDataLogging();
         }
 

--- a/samples/core/Modeling/ValueConversions/ULongConcurrency.cs
+++ b/samples/core/Modeling/ValueConversions/ULongConcurrency.cs
@@ -80,7 +80,7 @@ namespace EFModeling.ValueConversions
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
                     .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=ULongConcurrency;Integrated Security=True")
+                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=ULongConcurrency;Trusted_Connection=True")
                     .EnableSensitiveDataLogging();
         }
 

--- a/samples/core/Modeling/ValueConversions/WithMappingHints.cs
+++ b/samples/core/Modeling/ValueConversions/WithMappingHints.cs
@@ -63,7 +63,7 @@ namespace EFModeling.ValueConversions
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
                     .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=WithMappingHints;Integrated Security=True")
+                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=WithMappingHints;Trusted_Connection=True")
                     .EnableSensitiveDataLogging();
         }
 

--- a/samples/core/Performance/BatchTweakingContext.cs
+++ b/samples/core/Performance/BatchTweakingContext.cs
@@ -8,7 +8,7 @@ namespace Performance
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=Blogging;Integrated Security=True",
+                @"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True",
                 o => o
                     .MinBatchSize(1)
                     .MaxBatchSize(100));

--- a/samples/core/Performance/BloggingContext.cs
+++ b/samples/core/Performance/BloggingContext.cs
@@ -14,7 +14,7 @@ namespace Performance
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Integrated Security=True")
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
                 .LogTo(Console.WriteLine, LogLevel.Information);
         }
         #endregion

--- a/samples/core/Performance/EmployeeContext.cs
+++ b/samples/core/Performance/EmployeeContext.cs
@@ -11,7 +11,7 @@ namespace Performance
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Integrated Security=True")
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
                 .LogTo(Console.WriteLine, LogLevel.Information);
         }
     }

--- a/samples/core/Performance/ExtensionsLoggingContext.cs
+++ b/samples/core/Performance/ExtensionsLoggingContext.cs
@@ -12,7 +12,7 @@ namespace Performance
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Integrated Security=True")
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
                 .UseLoggerFactory(ContextLoggerFactory);
         }
         #endregion

--- a/samples/core/Performance/LazyLoading/LazyBloggingContext.cs
+++ b/samples/core/Performance/LazyLoading/LazyBloggingContext.cs
@@ -12,7 +12,7 @@ namespace Performance.LazyLoading
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Integrated Security=True")
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
                 .LogTo(Console.WriteLine, LogLevel.Information)
                 .UseLazyLoadingProxies();
     }

--- a/samples/core/Querying/ClientEvaluation/BloggingContext.cs
+++ b/samples/core/Querying/ClientEvaluation/BloggingContext.cs
@@ -17,7 +17,7 @@ namespace EFQuerying.ClientEvaluation
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.ClientEvaluation;Trusted_Connection=True;ConnectRetryCount=0");
+                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.ClientEvaluation;Trusted_Connection=True");
         }
     }
 }

--- a/samples/core/Querying/ComplexQuery/BloggingContext.cs
+++ b/samples/core/Querying/ComplexQuery/BloggingContext.cs
@@ -103,7 +103,7 @@ namespace EFQuerying.ComplexQuery
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.ComplexQuery;Trusted_Connection=True;ConnectRetryCount=0");
+                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.ComplexQuery;Trusted_Connection=True");
         }
     }
 }

--- a/samples/core/Querying/Overview/BloggingContext.cs
+++ b/samples/core/Querying/Overview/BloggingContext.cs
@@ -17,7 +17,7 @@ namespace EFQuerying.Overview
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.Overview;Trusted_Connection=True;ConnectRetryCount=0");
+                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.Overview;Trusted_Connection=True");
         }
     }
 }

--- a/samples/core/Querying/QueryFilters/AnimalContext.cs
+++ b/samples/core/Querying/QueryFilters/AnimalContext.cs
@@ -12,7 +12,7 @@ namespace EFQuerying.QueryFilters
         {
             optionsBuilder
                 .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=Querying.QueryFilters.Animals;Trusted_Connection=True;ConnectRetryCount=0;");
+                    @"Server=(localdb)\mssqllocaldb;Database=Querying.QueryFilters.Animals;Trusted_Connection=True");
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/samples/core/Querying/QueryFilters/BloggingContext.cs
+++ b/samples/core/Querying/QueryFilters/BloggingContext.cs
@@ -19,7 +19,7 @@ namespace EFQuerying.QueryFilters
         {
             optionsBuilder
                 .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=Querying.QueryFilters.Blogging;Trusted_Connection=True;ConnectRetryCount=0;");
+                    @"Server=(localdb)\mssqllocaldb;Database=Querying.QueryFilters.Blogging;Trusted_Connection=True");
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/samples/core/Querying/QueryFilters/FilteredBloggingContextRequired.cs
+++ b/samples/core/Querying/QueryFilters/FilteredBloggingContextRequired.cs
@@ -11,7 +11,7 @@ namespace EFQuerying.QueryFilters
         {
             optionsBuilder
                 .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=Querying.QueryFilters.BloggingRequired;Trusted_Connection=True;ConnectRetryCount=0;");
+                    @"Server=(localdb)\mssqllocaldb;Database=Querying.QueryFilters.BloggingRequired;Trusted_Connection=True");
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/samples/core/Querying/RawSQL/BloggingContext.cs
+++ b/samples/core/Querying/RawSQL/BloggingContext.cs
@@ -52,7 +52,7 @@ namespace EFQuerying.RawSQL
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.RawSQL;Trusted_Connection=True;ConnectRetryCount=0");
+                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.RawSQL;Trusted_Connection=True");
         }
     }
 }

--- a/samples/core/Querying/RelatedData/BloggingContext.cs
+++ b/samples/core/Querying/RelatedData/BloggingContext.cs
@@ -103,7 +103,7 @@ namespace EFQuerying.RelatedData
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.ComplexQuery;Trusted_Connection=True;ConnectRetryCount=0");
+                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.ComplexQuery;Trusted_Connection=True");
         }
     }
 }

--- a/samples/core/Querying/RelatedData/SplitQueriesBloggingContext.cs
+++ b/samples/core/Querying/RelatedData/SplitQueriesBloggingContext.cs
@@ -9,7 +9,7 @@ namespace EFQuerying.RelatedData
         {
             optionsBuilder
                 .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFQuerying;Trusted_Connection=True;ConnectRetryCount=0",
+                    @"Server=(localdb)\mssqllocaldb;Database=EFQuerying;Trusted_Connection=True",
                     o => o.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery));
         }
         #endregion

--- a/samples/core/Querying/Tags/SpatialContext.cs
+++ b/samples/core/Querying/Tags/SpatialContext.cs
@@ -24,7 +24,7 @@ namespace EFQuerying.Tags
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.Tags;Trusted_Connection=True;ConnectRetryCount=0",
+                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.Tags;Trusted_Connection=True",
                 b => b.UseNetTopologySuite());
         }
     }

--- a/samples/core/Querying/Tracking/BloggingContext.cs
+++ b/samples/core/Querying/Tracking/BloggingContext.cs
@@ -17,7 +17,7 @@ namespace EFQuerying.Tracking
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.Tracking;Trusted_Connection=True;ConnectRetryCount=0");
+                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.Tracking;Trusted_Connection=True");
         }
     }
 }

--- a/samples/core/Querying/UserDefinedFunctionMapping/Model.cs
+++ b/samples/core/Querying/UserDefinedFunctionMapping/Model.cs
@@ -214,7 +214,7 @@ namespace EFQuerying.UserDefinedFunctionMapping
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.UserDefinedFunctionMapping;Trusted_Connection=True;ConnectRetryCount=0");
+                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.UserDefinedFunctionMapping;Trusted_Connection=True");
         }
     }
 }

--- a/samples/core/Saving/Basics/BloggingContext.cs
+++ b/samples/core/Saving/Basics/BloggingContext.cs
@@ -10,7 +10,7 @@ namespace EFSaving.Basics
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Basics;Trusted_Connection=True;ConnectRetryCount=0");
+                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Basics;Trusted_Connection=True");
         }
     }
 }

--- a/samples/core/Saving/CascadeDelete/BloggingContext.cs
+++ b/samples/core/Saving/CascadeDelete/BloggingContext.cs
@@ -32,7 +32,7 @@ namespace EFSaving.CascadeDelete
                 .ReplaceService<IModelCacheKeyFactory, DeleteBehaviorCacheKeyFactory>()
                 .EnableSensitiveDataLogging()
                 .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.CascadeDelete;Trusted_Connection=True;ConnectRetryCount=0",
+                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.CascadeDelete;Trusted_Connection=True",
                     b => b.MaxBatchSize(1));
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/samples/core/Saving/Concurrency/Sample.cs
+++ b/samples/core/Saving/Concurrency/Sample.cs
@@ -79,7 +79,7 @@ namespace EFSaving.Concurrency
             {
                 // Requires NuGet package Microsoft.EntityFrameworkCore.SqlServer
                 optionsBuilder.UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Concurrency;Trusted_Connection=True;ConnectRetryCount=0");
+                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Concurrency;Trusted_Connection=True");
             }
         }
 

--- a/samples/core/Saving/Disconnected/BloggingContext.cs
+++ b/samples/core/Saving/Disconnected/BloggingContext.cs
@@ -10,7 +10,7 @@ namespace EFSaving.Disconnected
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Disconnected;Trusted_Connection=True;ConnectRetryCount=0");
+                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Disconnected;Trusted_Connection=True");
         }
     }
 }

--- a/samples/core/Saving/RelatedData/Sample.cs
+++ b/samples/core/Saving/RelatedData/Sample.cs
@@ -75,7 +75,7 @@ namespace EFSaving.RelatedData
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
                 optionsBuilder.UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.RelatedData;Trusted_Connection=True;ConnectRetryCount=0");
+                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.RelatedData;Trusted_Connection=True");
             }
         }
 

--- a/samples/core/Saving/Transactions/AmbientTransaction.cs
+++ b/samples/core/Saving/Transactions/AmbientTransaction.cs
@@ -10,7 +10,7 @@ namespace EFSaving.Transactions
         public static void Run()
         {
             var connectionString =
-                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True;ConnectRetryCount=0";
+                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True";
 
             using (var context = new BloggingContext(
                 new DbContextOptionsBuilder<BloggingContext>()

--- a/samples/core/Saving/Transactions/CommitableTransaction.cs
+++ b/samples/core/Saving/Transactions/CommitableTransaction.cs
@@ -10,7 +10,7 @@ namespace EFSaving.Transactions
         public static void Run()
         {
             var connectionString =
-                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True;ConnectRetryCount=0";
+                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True";
 
             using (var context = new BloggingContext(
                 new DbContextOptionsBuilder<BloggingContext>()

--- a/samples/core/Saving/Transactions/ControllingTransaction.cs
+++ b/samples/core/Saving/Transactions/ControllingTransaction.cs
@@ -48,7 +48,7 @@ namespace EFSaving.Transactions
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
                 optionsBuilder.UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True;ConnectRetryCount=0");
+                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True");
             }
         }
 

--- a/samples/core/Saving/Transactions/ExternalDbTransaction.cs
+++ b/samples/core/Saving/Transactions/ExternalDbTransaction.cs
@@ -9,7 +9,7 @@ namespace EFSaving.Transactions
         public static void Run()
         {
             var connectionString =
-                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True;ConnectRetryCount=0";
+                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True";
 
             using (var context = new BloggingContext(
                 new DbContextOptionsBuilder<BloggingContext>()

--- a/samples/core/Saving/Transactions/ManagingSavepoints.cs
+++ b/samples/core/Saving/Transactions/ManagingSavepoints.cs
@@ -47,7 +47,7 @@ namespace EFSaving.Transactions
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
                 optionsBuilder.UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True;ConnectRetryCount=0");
+                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True");
             }
         }
 

--- a/samples/core/Saving/Transactions/SharingTransaction.cs
+++ b/samples/core/Saving/Transactions/SharingTransaction.cs
@@ -11,7 +11,7 @@ namespace EFSaving.Transactions
         public static void Run()
         {
             var connectionString =
-                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True;ConnectRetryCount=0";
+                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True";
 
             using (var context = new BloggingContext(
                 new DbContextOptionsBuilder<BloggingContext>()

--- a/samples/core/SqlServer/ValueGeneration/ExplicitIdentityValues.cs
+++ b/samples/core/SqlServer/ValueGeneration/ExplicitIdentityValues.cs
@@ -8,7 +8,7 @@ namespace SqlServer.ValueGeneration
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Basics");
+                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Basics;Trusted_Connection=True");
     }
 
     public class ExplicitIdentityValues

--- a/samples/core/SqlServer/ValueGeneration/ExplicitIdentityValues.cs
+++ b/samples/core/SqlServer/ValueGeneration/ExplicitIdentityValues.cs
@@ -8,7 +8,7 @@ namespace SqlServer.ValueGeneration
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Basics;Trusted_Connection=True;ConnectRetryCount=0");
+                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Basics");
     }
 
     public class ExplicitIdentityValues


### PR DESCRIPTION
Standardize dummy connection strings

fixes #2703