### PR TITLE
Update ManyToManyShared.cs with fix for PostTag entity

### DIFF
--- a/samples/core/Modeling/FluentAPI/Relationships/ManyToManyShared.cs
+++ b/samples/core/Modeling/FluentAPI/Relationships/ManyToManyShared.cs
@@ -44,7 +44,7 @@ namespace EFModeling.FluentAPI.Relationships.ManyToManyShared
                 .HasData(new Tag { TagId = "ef" });
 
             modelBuilder
-                .Entity<Post>()
+                .Entity<PostTag>()
                 .HasMany(p => p.Tags)
                 .WithMany(p => p.Posts)
                 .UsingEntity(j => j.HasData(new { PostsPostId = 1, TagsTagId = "ef" }));


### PR DESCRIPTION
There are two Post entity references in the modelBuilder in the OnModelCreating method and the second one should be reference PostTag since it has both the PostId and TagId references.