### PR TITLE
Improve link to Property Bags documentation page for What's New in EF Core 5.0 page

### DIFF
--- a/entity-framework/core/what-is-new/ef-core-5.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-5.0/whatsnew.md
@@ -213,7 +213,7 @@ public class ProductsContext : DbContext
 }
 ```
 
-These entities can then be queried and updated just like normal entity types with their own, dedicated CLR type. More information can be found in the documentation on [property bags](xref:core/modeling/shadow-properties).
+These entities can then be queried and updated just like normal entity types with their own, dedicated CLR type. More information can be found in the documentation on [property bags](xref:core/modeling/shadow-properties#property-bag-entity-types).
 
 ## Required 1:1 dependents
 


### PR DESCRIPTION
Hi, 

I believe that the link to "Property Bags" can be improved by an anchor to the "Property bag entity types" section. 
If I'm wrong, please reject this pull request. 