### PR TITLE
Fix small type errors

### DIFF
--- a/entity-framework/ef6/fundamentals/databinding/wpf.md
+++ b/entity-framework/ef6/fundamentals/databinding/wpf.md
@@ -232,7 +232,7 @@ The **Products** property on the **Category** class and **Category** property on
 
 EF gives you an option of loading related entities from the database automatically the first time you access the navigation property. With this type of loading (called lazy loading), be aware that the first time you access each navigation property a separate query will be executed against the database if the contents are not already in the context.
 
-When using POCO entity types, EF achieves lazy loading by creating instances of derived proxy types during runtime and then overriding virtual properties in your classes to add the loading hook. To get lazy loading of related objects, you must declare navigation property getters as **public** and **virtual** (**Overridable** in Visual Basic), and you class must not be **sealed** (**NotOverridable** in Visual Basic). When using Database First navigation properties are automatically made virtual to enable lazy loading. In the Code First section we chose to make the navigation properties virtual for the same reason
+When using POCO entity types, EF achieves lazy loading by creating instances of derived proxy types during runtime and then overriding virtual properties in your classes to add the loading hook. To get lazy loading of related objects, you must declare navigation property getters as **public** and **virtual** (**Overridable** in Visual Basic), and your class must not be **sealed** (**NotOverridable** in Visual Basic). When using Database First navigation properties are automatically made virtual to enable lazy loading. In the Code First section we chose to make the navigation properties virtual for the same reason.
 
 ## Bind Object to Controls
 


### PR DESCRIPTION
I fixed a word based on the context (`you` > `your`) and added a dot (`.`) at the end of a paragraph.