### PR TITLE
End of life 2.1

### DIFF
--- a/entity-framework/core/change-tracking/miscellaneous.md
+++ b/entity-framework/core/change-tracking/miscellaneous.md
@@ -2,7 +2,7 @@
 title: Additional Change Tracking Features - EF Core
 description: Miscellaneous features and scenarios involving EF Core change tracking
 author: ajcvickers
-ms.date: 12/30/2020
+ms.date: 11/15/2021
 uid: core/change-tracking/miscellaneous
 ---
 
@@ -93,7 +93,7 @@ Notice that <xref:Microsoft.EntityFrameworkCore.DbContext.Set%60%601(System.Stri
 
 ## Property versus field access
 
-Starting with EF Core 3.0, access to entity properties uses the backing field of the property by default. This is efficient and avoids triggering side effects from calling property getters and setters. For example, this is how lazy-loading is able to avoid triggering infinite loops. See [Backing Fields](xref:core/modeling/backing-field) for more information on configuring backing fields in the model.
+Access to entity properties uses the backing field of the property by default. This is efficient and avoids triggering side effects from calling property getters and setters. For example, this is how lazy-loading is able to avoid triggering infinite loops. See [Backing Fields](xref:core/modeling/backing-field) for more information on configuring backing fields in the model.
 
 Sometimes it may be desirable for EF Core to generate side-effects when it modifies property values. For example, when data binding to entities, setting a property may generate notifications to the U.I. which do not happen when setting the field directly. This can be achieved by changing the <xref:Microsoft.EntityFrameworkCore.PropertyAccessMode> for:
 
@@ -106,9 +106,9 @@ Property access modes `Field` and `PreferField` will cause EF Core to access the
 
 If `Field` or `Property` are used and EF Core cannot access the value through the field or property getter/setter respectively, then EF Core will throw an exception. This ensures EF Core is always using field/property access when you think it is.
 
-On the other hand, the `PreferField` and `PreferProperty` modes will fall back to using the property or backing field respectively if it is not possible to use the preferred access. `PreferField` is the default from EF Core 3.0 onwards. This means EF Core will use fields whenever it can, but will not fail if a property must be accessed through its getter or setter instead.
+On the other hand, the `PreferField` and `PreferProperty` modes will fall back to using the property or backing field respectively if it is not possible to use the preferred access. `PreferField` is the default. This means EF Core will use fields whenever it can, but will not fail if a property must be accessed through its getter or setter instead.
 
-`FieldDuringConstruction` and `PreferFieldDuringConstruction` configure EF Core to use of backing fields _only when creating entity instances_. This allows queries to be executed without getter and setter side effects, while later property changes by EF Core will cause these side effects. `PreferFieldDuringConstruction` was the default prior to EF Core 3.0.
+`FieldDuringConstruction` and `PreferFieldDuringConstruction` configure EF Core to use of backing fields _only when creating entity instances_. This allows queries to be executed without getter and setter side effects, while later property changes by EF Core will cause these side effects.
 
 The different property access modes are summarized in the following table:
 

--- a/entity-framework/core/cli/dotnet.md
+++ b/entity-framework/core/cli/dotnet.md
@@ -2,7 +2,7 @@
 title: EF Core tools reference (.NET CLI) - EF Core
 description: Reference guide for the Entity Framework Core .NET Core CLI tools
 author: bricelam
-ms.date: 11/02/2021
+ms.date: 11/15/2021
 uid: core/cli/dotnet
 ---
 
@@ -257,7 +257,7 @@ dotnet ef dbcontext scaffold "Server=(localdb)\mssqllocaldb;Database=Blogging;Us
 
 ## `dotnet ef dbcontext script`
 
-Generates a SQL script from the DbContext. Bypasses any migrations. Added in EF Core 3.0.
+Generates a SQL script from the DbContext. Bypasses any migrations.
 
 Options:
 

--- a/entity-framework/core/cli/powershell.md
+++ b/entity-framework/core/cli/powershell.md
@@ -2,7 +2,7 @@
 title: EF Core tools reference (Package Manager Console) - EF Core
 description: Reference guide for the Entity Framework Core Visual Studio Package Manager Console
 author: bricelam
-ms.date: 11/02/2021
+ms.date: 11/15/2021
 uid: core/cli/powershell
 ---
 # Entity Framework Core tools reference - Package Manager Console in Visual Studio
@@ -254,7 +254,7 @@ Scaffold-DbContext "Name=ConnectionStrings:Blogging" Microsoft.EntityFrameworkCo
 
 ## Script-DbContext
 
-Generates a SQL script from the DbContext. Bypasses any migrations. Added in EF Core 3.0.
+Generates a SQL script from the DbContext. Bypasses any migrations.
 
 Parameters:
 

--- a/entity-framework/core/logging-events-diagnostics/index.md
+++ b/entity-framework/core/logging-events-diagnostics/index.md
@@ -2,7 +2,7 @@
 title: Overview of logging and interception - EF Core
 description: Overview of logging, events, interceptors, and diagnostics for EF Core
 author: ajcvickers
-ms.date: 10/01/2020
+ms.date: 11/15/2021
 uid: core/logging-events-diagnostics/index
 ---
 
@@ -61,7 +61,7 @@ See [.NET Events in EF Core](xref:core/logging-events-diagnostics/events) for mo
 ## Interception
 
 > [!NOTE]
-> This feature was introduced in EF Core 3.0. Additional interceptors were introduced in EF Core 5.0.
+> Additional interceptors were introduced in EF Core 5.0.
 
 EF Core interceptors enable interception, modification, and/or suppression of EF Core operations. This includes low-level database operations such as executing a command, as well as higher-level operations, such as calls to SaveChanges.
 

--- a/entity-framework/core/logging-events-diagnostics/interceptors.md
+++ b/entity-framework/core/logging-events-diagnostics/interceptors.md
@@ -2,7 +2,7 @@
 title: Interceptors - EF Core
 description: Interception for database operations and other events
 author: ajcvickers
-ms.date: 10/08/2020
+ms.date: 11/15/2021
 uid: core/logging-events-diagnostics/interceptors
 ---
 
@@ -51,7 +51,7 @@ Every interceptor instance must implement one or more interface derived from <xr
 ## Database interception
 
 > [!NOTE]
-> Database interception was introduced in EF Core 3.0 and is only available for relational database providers.
+> Database interception is only available for relational database providers.
 > Savepoint support was introduced in EF Core 5.0.
 
 Low-level database interception is split into the three interfaces shown in the following table.

--- a/entity-framework/core/miscellaneous/platforms.md
+++ b/entity-framework/core/miscellaneous/platforms.md
@@ -2,7 +2,7 @@
 title: Supported .NET implementations - EF Core
 description: Information on supported platforms across Entity Framework Core versions
 author: bricelam
-ms.date: 06/26/2020
+ms.date: 11/15/2021
 uid: core/miscellaneous/platforms
 ---
 
@@ -14,17 +14,17 @@ We want EF Core to be available to developers on all modern .NET implementations
 
 The following table provides guidance for each .NET implementation:
 
-| EF Core                       | 2.1 and 3.1 | 5.0             |
-|:------------------------------|:------------|:----------------|
-| .NET Standard                 | 2.0         | 2.1             |
-| .NET Core                     | 2.0         | 3.0             |
-| .NET Framework<sup>(1)</sup>  | 4.7.2       | (not supported) |
-| Mono                          | 5.4         | 6.4             |
-| Xamarin.iOS<sup>(2)</sup>     | 10.14       | 12.16           |
-| Xamarin.Mac<sup>(2)</sup>     | 3.8         | 5.16            |
-| Xamarin.Android<sup>(2)</sup> | 8.0         | 10.0            |
-| UWP<sup>(3)</sup>             | 10.0.16299  | TBD             |
-| Unity<sup>(4)</sup>           | 2018.1      | TBD             |
+| EF Core                       | 3.1        | 5.0             |
+|:------------------------------|:-----------|:----------------|
+| .NET Standard                 | 2.0        | 2.1             |
+| .NET Core                     | 2.0        | 3.0             |
+| .NET Framework<sup>(1)</sup>  | 4.7.2      | (not supported) |
+| Mono                          | 5.4        | 6.4             |
+| Xamarin.iOS<sup>(2)</sup>     | 10.14      | 12.16           |
+| Xamarin.Mac<sup>(2)</sup>     | 3.8        | 5.16            |
+| Xamarin.Android<sup>(2)</sup> | 8.0        | 10.0            |
+| UWP<sup>(3)</sup>             | 10.0.16299 | TBD             |
+| Unity<sup>(4)</sup>           | 2018.1     | TBD             |
 
 <sup>(1)</sup> See the [.NET Framework](#net-framework) section below.
 

--- a/entity-framework/core/modeling/backing-field.md
+++ b/entity-framework/core/modeling/backing-field.md
@@ -2,7 +2,7 @@
 title: Backing Fields - EF Core
 description: Configuring backing fields for properties in an Entity Framework Core model
 author: ajcvickers
-ms.date: 10/27/2016
+ms.date: 11/15/2021
 uid: core/modeling/backing-field
 ---
 # Backing Fields
@@ -43,9 +43,6 @@ By default, EF will always read and write to the backing field - assuming one ha
 [!code-csharp[Main](../../../samples/core/Modeling/BackingFields/FluentAPI/BackingFieldAccessMode.cs?name=BackingFieldAccessMode&highlight=6)]
 
 See the [PropertyAccessMode enum](/dotnet/api/microsoft.entityframeworkcore.propertyaccessmode) for the complete set of supported options.
-
-> [!NOTE]
-> With EF Core 3.0, the default property access mode changed from `PreferFieldDuringConstruction` to `PreferField`.
 
 ## Field-only properties
 

--- a/entity-framework/core/modeling/keyless-entity-types.md
+++ b/entity-framework/core/modeling/keyless-entity-types.md
@@ -2,13 +2,13 @@
 title: Keyless Entity Types - EF Core
 description: How to configure keyless entity types using Entity Framework Core
 author: AndriySvyryd
-ms.date: 9/13/2019
+ms.date: 11/15/2021
 uid: core/modeling/keyless-entity-types
 ---
 # Keyless Entity Types
 
 > [!NOTE]
-> This feature was added under the name of query types. In EF Core 3.0 the concept was renamed to keyless entity types. The `[Keyless]` Data Annotation became available in EFCore 5.0.
+> This feature was added under the name of query types. It was later renamed to keyless entity types. The `[Keyless]` Data Annotation became available in EFCore 5.0.
 
 In addition to regular entity types, an EF Core model can contain _keyless entity types_, which can be used to carry out database queries against data that doesn't contain key values.
 

--- a/entity-framework/core/modeling/relationships.md
+++ b/entity-framework/core/modeling/relationships.md
@@ -2,7 +2,7 @@
 title: Relationships - EF Core
 description: How to configure relationships between entity types when using Entity Framework Core
 author: AndriySvyryd
-ms.date: 10/01/2020
+ms.date: 11/15/2021
 uid: core/modeling/relationships
 ---
 # Relationships
@@ -77,9 +77,6 @@ In this example the highlighted properties will be used to configure the relatio
 
 > [!NOTE]
 > If the property is the primary key or is of a type not compatible with the principal key then it won't be configured as the foreign key.
-
-> [!NOTE]
-> Before EF Core 3.0, the property named exactly the same as the principal key property [was also matched as the foreign key](https://github.com/dotnet/efcore/issues/13274)
 
 ### No foreign key property
 

--- a/entity-framework/core/modeling/spatial.md
+++ b/entity-framework/core/modeling/spatial.md
@@ -2,13 +2,10 @@
 title: Spatial Data - EF Core
 description: Using spatial data in an Entity Framework Core model
 author: bricelam
-ms.date: 10/02/2020
+ms.date: 11/15/2021
 uid: core/modeling/spatial
 ---
 # Spatial Data
-
-> [!NOTE]
-> This feature was introduced in EF Core 2.2.
 
 Spatial data represents the physical location and the shape of objects. Many databases provide support for this type of data so it can be indexed and queried alongside other data. Common scenarios include querying for objects within a given distance from a location, or selecting the object whose border contains a given location. EF Core supports mapping to spatial data types using the NetTopologySuite spatial library.
 

--- a/entity-framework/core/modeling/table-splitting.md
+++ b/entity-framework/core/modeling/table-splitting.md
@@ -2,7 +2,7 @@
 title: Table Splitting - EF Core
 description: How to configure table splitting using Entity Framework Core
 author: AndriySvyryd
-ms.date: 01/03/2020
+ms.date: 11/15/2021
 uid: core/modeling/table-splitting
 ---
 # Table Splitting
@@ -35,9 +35,6 @@ Saving and querying entities using table splitting is done in the same way as ot
 [!code-csharp[Usage](../../../samples/core/Modeling/TableSplitting/Program.cs?name=Usage)]
 
 ## Optional dependent entity
-
-> [!NOTE]
-> This feature was introduced in EF Core 3.0.
 
 If all of the columns used by a dependent entity are `NULL` in the database, then no instance for it will be created when queried. This allows modeling an optional dependent entity, where the relationship property on the principal would be null. Note that this would also happen if all of the dependent's properties are optional and set to `null`, which might not be expected.
 

--- a/entity-framework/core/modeling/value-comparers.md
+++ b/entity-framework/core/modeling/value-comparers.md
@@ -2,14 +2,11 @@
 title: Value Comparers - EF Core
 description: Using value comparers to control how EF Core compares property values
 author: ajcvickers
-ms.date: 01/16/2021
+ms.date: 11/15/2021
 uid: core/modeling/value-comparers
 ---
 
 # Value Comparers
-
-> [!NOTE]
-> This feature was introduced in EF Core 3.0.
 
 > [!TIP]
 > The code in this document can be found on GitHub as a [runnable sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/ValueConversions/).

--- a/entity-framework/core/providers/cosmos/index.md
+++ b/entity-framework/core/providers/cosmos/index.md
@@ -2,13 +2,10 @@
 title: Azure Cosmos DB Provider - EF Core
 description: Documentation for the database provider that allows Entity Framework Core to be used with the Azure Cosmos DB SQL API
 author: AndriySvyryd
-ms.date: 10/09/2020
+ms.date: 11/15/2021
 uid: core/providers/cosmos/index
 ---
 # EF Core Azure Cosmos DB Provider
-
-> [!NOTE]
-> This provider was introduced in EF Core 3.0.
 
 This database provider allows Entity Framework Core to be used with Azure Cosmos DB. The provider is maintained as part of the [Entity Framework Core Project](https://github.com/dotnet/efcore).
 

--- a/entity-framework/core/providers/sql-server/functions.md
+++ b/entity-framework/core/providers/sql-server/functions.md
@@ -2,7 +2,7 @@
 title: Function Mappings - Microsoft SQL Server Database Provider - EF Core
 description: Function Mappings of the Microsoft SQL Server database provider
 author: bricelam
-ms.date: 6/28/2021
+ms.date: 11/15/2021
 uid: core/providers/sql-server/functions
 ---
 # Function Mappings of the Microsoft SQL Server Provider
@@ -72,7 +72,7 @@ dateTime.Millisecond                                        | DATEPART(milliseco
 dateTime.Minute                                             | DATEPART(minute, @dateTime)
 dateTime.Month                                              | DATEPART(month, @dateTime)
 dateTime.Second                                             | DATEPART(second, @dateTime)
-dateTime.TimeOfDay                                          | CONVERT(time, @dateTime)                              | EF Core 2.2
+dateTime.TimeOfDay                                          | CONVERT(time, @dateTime)
 dateTime.Year                                               | DATEPART(year, @dateTime)
 DateTimeOffset.Now                                          | SYSDATETIMEOFFSET()
 DateTimeOffset.UtcNow                                       | SYSUTCDATETIME()
@@ -91,7 +91,7 @@ dateTimeOffset.Millisecond                                  | DATEPART(milliseco
 dateTimeOffset.Minute                                       | DATEPART(minute, @dateTimeOffset)
 dateTimeOffset.Month                                        | DATEPART(month, @dateTimeOffset)
 dateTimeOffset.Second                                       | DATEPART(second, @dateTimeOffset)
-dateTimeOffset.TimeOfDay                                    | CONVERT(time, @dateTimeOffset)                        | EF Core 2.2
+dateTimeOffset.TimeOfDay                                    | CONVERT(time, @dateTimeOffset)
 dateTimeOffset.Year                                         | DATEPART(year, @dateTimeOffset)
 EF.Functions.DateDiffDay(start, end)                        | DATEDIFF(day, @start, @end)
 EF.Functions.DateDiffHour(start, end)                       | DATEDIFF(hour, @start, @end)
@@ -107,7 +107,7 @@ EF.Functions.DateFromParts(year, month, day)                | DATEFROMPARTS(@yea
 EF.Functions.DateTime2FromParts(year, month, day, ...)      | DATETIME2FROMPARTS(@year, @month, @day, ...)         | EF Core 5.0
 EF.Functions.DateTimeFromParts(year, month, day, ...)       | DATETIMEFROMPARTS(@year, @month, @day, ...)          | EF Core 5.0
 EF.Functions.DateTimeOffsetFromParts(year, month, day, ...) | DATETIMEOFFSETFROMPARTS(@year, @month, @day, ...)    | EF Core 5.0
-EF.Functions.IsDate(expression)                             | ISDATE(@expression)                                  | EF Core 3.0
+EF.Functions.IsDate(expression)                             | ISDATE(@expression)
 EF.Functions.SmallDateTimeFromParts(year, month, day, ...)  | SMALLDATETIMEFROMPARTS(@year, @month, @day, ...)     | EF Core 5.0
 EF.Functions.TimeFromParts(hour, minute, second, ...)       | TIMEFROMPARTS(@hour, @minute, @second, ...)          | EF Core 5.0
 timeSpan.Hours                                              | DATEPART(hour, @timeSpan)                            | EF Core 5.0
@@ -166,8 +166,8 @@ MathF.Truncate(x)        | ROUND(@x, 0, 1)      | EF Core 6.0
 .NET                                                                    | SQL                                                                    | Added in
 ----------------------------------------------------------------------- | ---------------------------------------------------------------------- | --------
 EF.Functions.Collate(operand, collation)                                | @operand COLLATE @collation                                            | EF Core 5.0
-EF.Functions.Contains(propertyReference, searchCondition)               | CONTAINS(@propertyReference, @searchCondition)                         | EF Core 2.2
-EF.Functions.Contains(propertyReference, searchCondition, languageTerm) | CONTAINS(@propertyReference, @searchCondition, LANGUAGE @languageTerm) | EF Core 2.2
+EF.Functions.Contains(propertyReference, searchCondition)               | CONTAINS(@propertyReference, @searchCondition)
+EF.Functions.Contains(propertyReference, searchCondition, languageTerm) | CONTAINS(@propertyReference, @searchCondition, LANGUAGE @languageTerm)
 EF.Functions.FreeText(propertyReference, freeText)                      | FREETEXT(@propertyReference, @freeText)
 EF.Functions.FreeText(propertyReference, freeText, languageTerm)        | FREETEXT(@propertyReference, @freeText, LANGUAGE @languageTerm)
 EF.Functions.IsNumeric(expression)                                      | ISNUMERIC(@expression)                                                 | EF Core 6.0
@@ -196,9 +196,9 @@ stringValue.TrimStart()                                                 | LTRIM(
 
 ## Miscellaneous functions
 
-.NET                                     | SQL                                | Added in
----------------------------------------- | ---------------------------------- | --------
-collection.Contains(item)                | @item IN @collection               | EF Core 3.0
+.NET                                     | SQL
+---------------------------------------- | ---
+collection.Contains(item)                | @item IN @collection
 enumValue.HasFlag(flag)                  | @enumValue & @flag = @flag
 Guid.NewGuid()                           | NEWID()
 nullable.GetValueOrDefault()             | COALESCE(@nullable, 0)

--- a/entity-framework/core/providers/sql-server/index.md
+++ b/entity-framework/core/providers/sql-server/index.md
@@ -2,7 +2,7 @@
 title: Microsoft SQL Server Database Provider - EF Core
 description: Documentation for the database provider that allows Entity Framework Core to be used with Microsoft SQL Server
 author: AndriySvyryd
-ms.date: 11/05/2019
+ms.date: 11/15/2021
 uid: core/providers/sql-server/index
 ---
 # Microsoft SQL Server EF Core Database Provider
@@ -28,10 +28,10 @@ Install-Package Microsoft.EntityFrameworkCore.SqlServer
 ***
 
 > [!NOTE]
-> Since version 3.0.0, the provider references Microsoft.Data.SqlClient (previous versions depended on System.Data.SqlClient). If your project takes a direct dependency on SqlClient, make sure it references the Microsoft.Data.SqlClient package.
+> The provider references Microsoft.Data.SqlClient (not System.Data.SqlClient). If your project takes a direct dependency on SqlClient, make sure it references the Microsoft.Data.SqlClient package.
 
 >[!TIP]
-> The Microsoft.Data.SqlClient package ships more frequently than the EF Core provider. If you would like to take advantage of new features and bug fixes, you can add a direct package reference to the latest version of Microsoft.Data.SqlClient.  
+> The Microsoft.Data.SqlClient package ships more frequently than the EF Core provider. If you would like to take advantage of new features and bug fixes, you can add a direct package reference to the latest version of Microsoft.Data.SqlClient.
 
 ## Supported Database Engines
 

--- a/entity-framework/core/providers/sql-server/value-generation.md
+++ b/entity-framework/core/providers/sql-server/value-generation.md
@@ -2,7 +2,7 @@
 title: Microsoft SQL Server Database Provider - Value Generation - EF Core
 description: Value Generation Patterns Specific to the SQL Server Entity Framework Core Database Provider
 author: roji
-ms.date: 1/10/2020
+ms.date: 11/15/2021
 uid: core/providers/sql-server/value-generation
 ---
 # SQL Server Value Generation
@@ -18,9 +18,6 @@ By convention, numeric columns that are configured to have their values generate
 By default, IDENTITY columns start off at 1 (the seed), and increment by 1 each time a row is added (the increment). You can configure a different seed and increment as follows:
 
 [!code-csharp[Main](../../../../samples/core/SqlServer/ValueGeneration/IdentityOptionsContext.cs?name=IdentityOptions&highlight=5)]
-
-> [!NOTE]
-> The ability to configure IDENTITY seed and increment was introduced in EF Core 3.0.
 
 ### Inserting explicit values into IDENTITY columns
 

--- a/entity-framework/core/providers/sqlite/functions.md
+++ b/entity-framework/core/providers/sqlite/functions.md
@@ -2,7 +2,7 @@
 title: Function Mappings - SQLite Database Provider - EF Core
 description: Function Mappings of the SQLite EF Core database provider
 author: bricelam
-ms.date: 6/28/2021
+ms.date: 11/15/2021
 uid: core/providers/sqlite/functions
 ---
 # Function Mappings of the SQLite EF Core Provider
@@ -59,23 +59,23 @@ DateTime.Today                  | datetime('now', 'localtime', 'start of day')
 DateTime.UtcNow                 | datetime('now')
 dateTime.AddDays(value)         | datetime(@dateTime, @value \|\| ' days')
 dateTime.AddHours(value)        | datetime(@dateTime, @d \|\| ' hours')
-dateTime.AddMilliseconds(value) | datetime(@dateTime, (@value / 1000.0) \|\| ' seconds')                   | EF Core 2.2
+dateTime.AddMilliseconds(value) | datetime(@dateTime, (@value / 1000.0) \|\| ' seconds')
 dateTime.AddMinutes(value)      | datetime(@dateTime, @value \|\| ' minutes')
 dateTime.AddMonths(months)      | datetime(@dateTime, @months \|\| ' months')
 dateTime.AddSeconds(value)      | datetime(@dateTime, @value \|\| ' seconds')
-dateTime.AddTicks(value)        | datetime(@dateTime, (@value / 10000000.0) \|\| ' seconds')               | EF Core 2.2
+dateTime.AddTicks(value)        | datetime(@dateTime, (@value / 10000000.0) \|\| ' seconds')
 dateTime.AddYears(value)        | datetime(@dateTime, @value \|\| ' years')
 dateTime.Date                   | datetime(@dateTime, 'start of day')
 dateTime.Day                    | strftime('%d', @dateTime)
-dateTime.DayOfWeek              | strftime('%w', @dateTime)                                                | EF Core 2.2
+dateTime.DayOfWeek              | strftime('%w', @dateTime)
 dateTime.DayOfYear              | strftime('%j', @dateTime)
 dateTime.Hour                   | strftime('%H', @dateTime)
 dateTime.Millisecond            | (strftime('%f', @dateTime) * 1000) % 1000
 dateTime.Minute                 | strftime('%M', @dateTime)
 dateTime.Month                  | strftime('%m', @dateTime)
 dateTime.Second                 | strftime('%S', @dateTime)
-dateTime.Ticks                  | (julianday(@dateTime) - julianday('0001-01-01 00:00:00')) * 864000000000 | EF Core 2.2
-dateTime.TimeOfDay              | time(@dateTime)                                                          | EF Core 3.0
+dateTime.Ticks                  | (julianday(@dateTime) - julianday('0001-01-01 00:00:00')) * 864000000000
+dateTime.TimeOfDay              | time(@dateTime)
 dateTime.Year                   | strftime('%Y', @dateTime)
 
 > [!NOTE]
@@ -152,9 +152,9 @@ stringValue.TrimStart(trimChar)                              | ltrim(@stringValu
 
 ## Miscellaneous functions
 
-.NET                                     | SQL                                | Added in
----------------------------------------- | ---------------------------------- | --------
-collection.Contains(item)                | @item IN @collection               | EF Core 3.0
+.NET                                     | SQL
+---------------------------------------- | ---
+collection.Contains(item)                | @item IN @collection
 enumValue.HasFlag(flag)                  | @enumValue & @flag = @flag
 nullable.GetValueOrDefault()             | coalesce(@nullable, 0)
 nullable.GetValueOrDefault(defaultValue) | coalesce(@nullable, @defaultValue)

--- a/entity-framework/core/providers/sqlite/limitations.md
+++ b/entity-framework/core/providers/sqlite/limitations.md
@@ -2,7 +2,7 @@
 title: SQLite Database Provider - Limitations - EF Core
 description: Limitations of the Entity Framework Core SQLite database provider as compared to other providers
 author: bricelam
-ms.date: 09/24/2020
+ms.date: 11/15/2021
 uid: core/providers/sqlite/limitations
 ---
 # SQLite EF Core Database Provider Limitations
@@ -58,7 +58,7 @@ A rebuild will be attempted in order to perform certain operations. Rebuilds are
 | DropPrimaryKey       | ✔ (rebuild) | 5.0              |
 | DropTable            | ✔           |                  |
 | DropUniqueConstraint | ✔ (rebuild) | 5.0              |
-| RenameColumn         | ✔           | 2.2              |
+| RenameColumn         | ✔           |                  |
 | RenameIndex          | ✔ (rebuild) |                  |
 | RenameTable          | ✔           |                  |
 | EnsureSchema         | ✔ (no-op)   |                  |

--- a/entity-framework/core/querying/raw-sql.md
+++ b/entity-framework/core/querying/raw-sql.md
@@ -2,7 +2,7 @@
 title: Raw SQL Queries - EF Core
 description: Using raw SQL for queries in Entity Framework Core
 author: smitpatel
-ms.date: 10/08/2019
+ms.date: 11/15/2021
 uid: core/querying/raw-sql
 ---
 # Raw SQL Queries
@@ -36,9 +36,6 @@ The following example passes a single parameter to a stored procedure by includi
 [!code-csharp[Main](../../../samples/core/Querying/RawSQL/Program.cs#FromSqlRawStoredProcedureParameter)]
 
 `FromSqlInterpolated` is similar to `FromSqlRaw` but allows you to use string interpolation syntax. Just like `FromSqlRaw`, `FromSqlInterpolated` can only be used on query roots. As with the previous example, the value is converted to a `DbParameter` and isn't vulnerable to SQL injection.
-
-> [!NOTE]
-> Prior to version 3.0, `FromSqlRaw` and `FromSqlInterpolated` were two overloads named `FromSql`. For more information, see the [previous versions section](#previous-versions).
 
 [!code-csharp[Main](../../../samples/core/Querying/RawSQL/Program.cs#FromSqlInterpolatedStoredProcedureParameter)]
 
@@ -100,7 +97,3 @@ There are a few limitations to be aware of when using raw SQL queries:
 - The SQL query must return data for all properties of the entity type.
 - The column names in the result set must match the column names that properties are mapped to. Note this behavior is different from EF6. EF6 ignored property to column mapping for raw SQL queries and result set column names had to match the property names.
 - The SQL query can't contain related data. However, in many cases you can compose on top of the query using the `Include` operator to return related data (see [Including related data](#including-related-data)).
-
-## Previous versions
-
-EF Core version 2.2 and earlier had two overloads of method named `FromSql`, which behaved in the same way as the newer `FromSqlRaw` and `FromSqlInterpolated`. It was easy to accidentally call the raw string method when the intent was to call the interpolated string method, and the other way around. Calling wrong overload accidentally could result in queries not being parameterized when they should have been.

--- a/entity-framework/core/querying/tracking.md
+++ b/entity-framework/core/querying/tracking.md
@@ -2,7 +2,7 @@
 title: Tracking vs. No-Tracking Queries - EF Core
 description: Information on tracking and no-tracking queries in Entity Framework Core
 author: smitpatel
-ms.date: 11/09/2020
+ms.date: 11/15/2021
 uid: core/querying/tracking
 ---
 # Tracking vs. No-Tracking Queries
@@ -35,7 +35,7 @@ You can also change the default tracking behavior at the context instance level:
 
 ## Identity resolution
 
-Since a tracking query uses the change tracker, EF Core will do identity resolution in a tracking query. When materializing an entity, EF Core will return the same entity instance from the change tracker if it's already being tracked. If the result contains the same entity multiple times, you get back same instance for each occurrence. No-tracking queries don't use the change tracker and don't do identity resolution. So you get back a new instance of the entity even when the same entity is contained in the result multiple times. This behavior was different in versions before EF Core 3.0, see [previous versions](#previous-versions).
+Since a tracking query uses the change tracker, EF Core will do identity resolution in a tracking query. When materializing an entity, EF Core will return the same entity instance from the change tracker if it's already being tracked. If the result contains the same entity multiple times, you get back same instance for each occurrence. No-tracking queries don't use the change tracker and don't do identity resolution. So you get back a new instance of the entity even when the same entity is contained in the result multiple times.
 
 Starting with EF Core 5.0, you can combine both of the above behaviors in same query. That is, you can have a no tracking query, which will do identity resolution in the results. Just like `AsNoTracking()` queryable operator, we've added another operator `AsNoTrackingWithIdentityResolution()`. There's also associated entry added in the <xref:Microsoft.EntityFrameworkCore.QueryTrackingBehavior> enum. When you configure the query to use identity resolution with no tracking, we use a stand-alone change tracker in the background when generating query results so each instance is materialized only once. Since this change tracker is different from the one in the context, the results are not tracked by the context. After the query is enumerated fully, the change tracker goes out of scope and garbage collected as required.
 
@@ -62,8 +62,6 @@ If the result set doesn't contain any entity types, then no tracking is done. In
 [!code-csharp[Main](../../../samples/core/Querying/Tracking/Program.cs#ClientMethod)]
 
 EF Core doesn't track the keyless entity instances contained in the result. But EF Core tracks all the other instances of entity types with a key according to rules above.
-
-Some of the above rules worked differently before EF Core 3.0. For more information, see [previous versions](#previous-versions).
 
 ## Previous versions
 

--- a/entity-framework/toc.yml
+++ b/entity-framework/toc.yml
@@ -73,14 +73,14 @@
           href: core/what-is-new/ef-core-3.x/index.md
         - name: Breaking changes
           href: core/what-is-new/ef-core-3.x/breaking-changes.md
-      - name: EF Core 2.1
-        href: core/what-is-new/ef-core-2.1.md
       - name: Out of support
         items:
         - name: EF Core 3.0
           href: core/what-is-new/ef-core-3.0.md
         - name: EF Core 2.2
           href: core/what-is-new/ef-core-2.2.md
+        - name: EF Core 2.1
+          href: core/what-is-new/ef-core-2.1.md
         - name: EF Core 2.0
           items:
             - name: New features


### PR DESCRIPTION
I took a pretty extreme approach of removing all irrelevant information about unsupported versions from the main docs. Mostly because I hope that everyone has already upgraded to a supported version and isn't still actively developing on these older versions.

Please push back on any information that you still think is still relevant to readers.