### PR TITLE
Emphasize Lazy Loading does not work well with context pooling

### DIFF
--- a/entity-framework/core/performance/advanced-performance-topics.md
+++ b/entity-framework/core/performance/advanced-performance-topics.md
@@ -52,7 +52,7 @@ The `poolSize` parameter of the `PooledDbContextFactory` constructor sets the ma
 `DbContext` pooling has a few limitations on what can be done in the `OnConfiguring` method of the context.
 
 > [!WARNING]
-> Avoid using context pooling in apps that maintain state. For example, private fields in the context that shouldn't be shared across requests. EF Core only resets the state that it is aware of before adding a context instance to the pool.
+> Avoid using context pooling in apps that maintain state. For example, private fields in the context that shouldn't be shared across requests. This also includes the use of Lazy Loading through `UseLazyLoadingProxies()`. EF Core only resets the state that it is aware of before adding a context instance to the pool.
 
 Context pooling works by reusing the same context instance across requests. This means that it's effectively registered as a [Singleton](/aspnet/core/fundamentals/dependency-injection#service-lifetimes) in terms of the instance itself so that it's able to persist.
 


### PR DESCRIPTION
I added this small remark as I did not make the link between Lazy Loading and state when we first added Context Pooling. Adding ever-increasing memory usage.