### PR TITLE
Updates the extensions documentation page for SimplerSoftware.SqlServer.NodaTime.

### DIFF
--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -218,7 +218,7 @@ This will automatically make all your table and column names have snake_case, al
 
 ### SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime
 
-Adds native support to EntityFrameworkCore for SQL Server for the NodaTime types. For EF Core: 3, 5.
+Adds native support to EntityFrameworkCore for SQL Server for the NodaTime types. For EF Core: 3, 5, 6.
 
 [GitHub repository](https://github.com/StevenRasmussen/EFCore.SqlServer.NodaTime)
 


### PR DESCRIPTION
Updates the extensions page so that it reflects support for EF Core 6 for SimplerSoftware.EFCore.SqlServer.NodaTime.

See NuGet [here](https://www.nuget.org/packages/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime)