### PR TITLE
Correct SQL in many-to-many scaffold sample

### DIFF
--- a/entity-framework/core/what-is-new/ef-core-6.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-6.0/whatsnew.md
@@ -1285,16 +1285,14 @@ CREATE TABLE [Posts] (
     [Contents] nvarchar(max) NOT NULL,
     [PostedOn] datetime2 NOT NULL,
     [UpdatedOn] datetime2 NULL,
-    [BlogId] int NOT NULL,
-    CONSTRAINT [PK_Posts] PRIMARY KEY ([Id]),
-    CONSTRAINT [FK_Posts_Blogs_BlogId] FOREIGN KEY ([BlogId]) REFERENCES [Blogs] ([Id]));
+    CONSTRAINT [PK_Posts] PRIMARY KEY ([Id]));
 
 CREATE TABLE [PostTag] (
     [PostsId] int NOT NULL,
     [TagsId] int NOT NULL,
     CONSTRAINT [PK_PostTag] PRIMARY KEY ([PostsId], [TagsId]),
-    CONSTRAINT [FK_PostTag_Posts_TagsId] FOREIGN KEY ([TagsId]) REFERENCES [Posts] ([Id]) ON DELETE CASCADE,
-    CONSTRAINT [FK_PostTag_Tags_PostsId] FOREIGN KEY ([PostsId]) REFERENCES [Tags] ([Id]) ON DELETE CASCADE);
+    CONSTRAINT [FK_PostTag_Posts_TagsId] FOREIGN KEY ([TagsId]) REFERENCES [Tags] ([Id]) ON DELETE CASCADE,
+    CONSTRAINT [FK_PostTag_Tags_PostsId] FOREIGN KEY ([PostsId]) REFERENCES [Posts] ([Id]) ON DELETE CASCADE);
 ```
 
 These tables can be scaffolded from the command line. For example:


### PR DESCRIPTION
Constraints on PostTag where referencing wrong tables based on name
Posts table also included a reference to Blog table not listed in example