### PR TITLE
Remove DbContext Pooling from Miscellaneous TOC

### DIFF
--- a/entity-framework/toc.yml
+++ b/entity-framework/toc.yml
@@ -112,6 +112,8 @@
       items:
       - name: Overview
         href: core/dbcontext-configuration/index.md
+      - name: Context pooling
+        href: core/performance/advanced-performance-topics#dbcontext-pooling
 
     - name: Create a model
       items:
@@ -327,8 +329,6 @@
         href: core/miscellaneous/connection-resiliency.md
       - name: Connection strings
         href: core/miscellaneous/connection-strings.md
-      - name: Context pooling
-        href: core/miscellaneous/context-pooling.md
 
     - name: Database providers
       items:


### PR DESCRIPTION
DbContext Pooling used to be a page under Miscellaneous, but was moved to the Advanced Performance Topics page under Performance. A redirection is already in place, but the old TOC entry was left in place.