### PR TITLE
Fix broken links in porting guide

### DIFF
--- a/entity-framework/efcore-and-ef6/porting/index.md
+++ b/entity-framework/efcore-and-ef6/porting/index.md
@@ -11,7 +11,7 @@ uid: efcore-and-ef6/porting/index
 Entity Framework Core, or EF Core for short, is a total rewrite of Entity Framework for modern application architectures. Due to fundamental changes, there is not a direct upgrade path. The purpose of this documentation is to provide an end-to-end guide for porting your EF6 applications to EF Core.
 
 > [!IMPORTANT]
-> Before you start the porting process it is important to validate that EF Core meets the data access requirements for your application. You can find everything you need in the [EF Core documentation](/ef/core/).
+> Before you start the porting process it is important to validate that EF Core meets the data access requirements for your application. You can find everything you need in the [EF Core documentation](xref:core/index).
 
 > [!IMPORTANT]
 > There is a known issue ([microsoft/dotnet-apiport #993](https://github.com/microsoft/dotnet-apiport/issues/993)) with the [portability analyzer](/dotnet/standard/analyzers/portability-analyzer) that erroneously reports EF Core as incompatible with .NET 5 and .NET 6. These warnings can be safely ignored as EF Core is 100% compatible with .NET 5 and .NET 6 target frameworks.
@@ -20,8 +20,8 @@ Entity Framework Core, or EF Core for short, is a total rewrite of Entity Framew
 
 All new Entity Framework development is happening in EF Core. There are no plans to backport any new features to EF6. EF Core runs on the latest .NET runtimes and takes full advantage of runtime, platform-specific (such as ASP.NET Core or WPF) and language-specific features. Here are a few of the benefits you gain from upgrading:
 
-- Take advantage of the ongoing **performance improvements** in EF Core. For example, one customer who migrated from EF6 to EF Core 6 saw a 40x reduction in use of a heavy query due to the [query splitting feature](/ef/core/querying/single-split-queries/). Many customers report enormous performance gains simply by moving to the latest EF Core.
-- Use **new features** in EF Core. There will be no new features added to EF6. All of the new functionality, for example the [Azure Cosmos DB provider](/ef/core/providers/cosmos/) and [`DbContextFactory`](/ef/core/what-is-new/ef-core-5.0/whatsnew#dbcontextfactory), will only be added to EF Core. For a full comparison of EF6 to EF Core, including several features exclusive to EF Core, see: [Compare EF Core & EF6](/ef/efcore-and-ef6/).
+- Take advantage of the ongoing **performance improvements** in EF Core. For example, one customer who migrated from EF6 to EF Core 6 saw a 40x reduction in use of a heavy query due to the [query splitting feature](xref:core/querying/single-split-queries). Many customers report enormous performance gains simply by moving to the latest EF Core.
+- Use **new features** in EF Core. There will be no new features added to EF6. All of the new functionality, for example the [Azure Cosmos DB provider](xref:core/providers/cosmos/index) and [`DbContextFactory`](xref:core/what-is-new/ef-core-5.0/whatsnew#dbcontextfactory), will only be added to EF Core. For a full comparison of EF6 to EF Core, including several features exclusive to EF Core, see: [Compare EF Core & EF6](xref:efcore-and-ef6/index).
 - **Modernize your application stack** by using dependency injection and seamlessly integrate your data access with technologies like gRPC and GraphQL.
 
 ## A note on migrations

--- a/entity-framework/efcore-and-ef6/porting/index.md
+++ b/entity-framework/efcore-and-ef6/porting/index.md
@@ -26,7 +26,7 @@ All new Entity Framework development is happening in EF Core. There are no plans
 
 ## A note on migrations
 
-This documentation uses the terms _port_ and _upgrade_ to avoid confusion with the term [_migrations_](/ef/core/managing-schemas/migrations/) as a feature of EF Core. Migrations in EF Core are not compatible with [EF6 Code First migrations](/ef/ef6/modeling/code-first/migrations/) due to significant improvements to how migrations are handled. There is not a recommended approach to port your migrations history, so plan to start "fresh" in EF Core. You can maintain the codebase and data from your EF6 migrations. Apply your final migration in EF6, then create an initial migration in EF Core. You will be able to track history in EF Core moving forward.
+This documentation uses the terms _port_ and _upgrade_ to avoid confusion with the term [_migrations_](xref:core/managing-schemas/migrations/index) as a feature of EF Core. Migrations in EF Core are not compatible with [EF6 Code First migrations](xref:ef6/modeling/code-first/migrations/index) due to significant improvements to how migrations are handled. There is not a recommended approach to port your migrations history, so plan to start "fresh" in EF Core. You can maintain the codebase and data from your EF6 migrations. Apply your final migration in EF6, then create an initial migration in EF Core. You will be able to track history in EF Core moving forward.
 
 ## Upgrade steps
 
@@ -54,13 +54,13 @@ The hybrid approach is a more advanced approach with additional overhead compare
 
 ### Understand the impact of moving away from EDMX
 
-EF6 supported a special model definition format named *Entity Data Model XML (EDMX)*. EDMX files contain multiple definitions, including conceptual schema definitions (CSDL), mapping specifications (MSL), and store schema definitions (SSDL). EF Core tracks the domain, mapping, and database schemas through internal model graphs and does not support the EDMX format. Many blog posts and articles mistakenly state this means EF Core only supports "code first." EF Core supports all three application models described in the previous section. You can rebuild the model in EF Core by [reverse-engineering the database](/ef/core/managing-schemas/scaffolding). If you use EDMX for a visual representation of your entity model, consider using the open source [EF Core Power Tools](https://github.com/ErikEJ/EFCorePowerTools) that provide similar capabilities for EF Core.
+EF6 supported a special model definition format named *Entity Data Model XML (EDMX)*. EDMX files contain multiple definitions, including conceptual schema definitions (CSDL), mapping specifications (MSL), and store schema definitions (SSDL). EF Core tracks the domain, mapping, and database schemas through internal model graphs and does not support the EDMX format. Many blog posts and articles mistakenly state this means EF Core only supports "code first." EF Core supports all three application models described in the previous section. You can rebuild the model in EF Core by [reverse-engineering the database](xref:core/managing-schemas/scaffolding). If you use EDMX for a visual representation of your entity model, consider using the open source [EF Core Power Tools](https://github.com/ErikEJ/EFCorePowerTools) that provide similar capabilities for EF Core.
 
-For more information on the impact of lack of support for EDMX files, read the [porting EDMX](/ef/efcore-and-ef6/porting/port-edmx#other-considerations) guide.
+For more information on the impact of lack of support for EDMX files, read the [porting EDMX](xref:efcore-and-ef6/porting/port-edmx#other-considerations) guide.
 
 ### Perform the upgrade steps
 
-It is not a requirement to port the entire application. EF6 and EF Core can run in the same application (see: [using EF Core and EF6 in the same application](/ef/efcore-and-ef6/side-by-side?branch=pr-en-us-3509)). To minimize risk, you might consider:
+It is not a requirement to port the entire application. EF6 and EF Core can run in the same application (see: [using EF Core and EF6 in the same application](xref:efcore-and-ef6/side-by-side)). To minimize risk, you might consider:
 
 1. Move to EF6 on .NET Core if you haven't already.
 1. Migrate a small portion of your app to EF Core and run it side-by-side with EF6.
@@ -68,7 +68,7 @@ It is not a requirement to port the entire application. EF6 and EF Core can run 
 
 As for the port itself, at a high level, you will:
 
-1. [Review behavior changes between EF6 and EF Core](/ef/efcore-and-ef6/porting/port-behavior).
+1. [Review behavior changes between EF6 and EF Core](xref:efcore-and-ef6/porting/port-behavior).
 1. Perform your final migrations, if any, in EF6.
 1. Create your EF Core project.
 1. Either copy code to the new project, run reverse-engineering, or a combination of both.
@@ -78,12 +78,12 @@ As for the port itself, at a high level, you will:
     - `DbModelBuilder` to `ModelBuilder`
     - Rename `DbEntityEntry<T>` to `EntityEntry<T>`
     - Move from `Database.Log` to `Microsoft.Extensions.Logging` (advanced) or `DbContextOptionsBuilder.LogTo` (simple) APIs
-    - Apply changes for `WithRequired` and `WithOptional` (see [here](/ef/efcore-and-ef6/porting/port-detailed-cases#required-and-optional))
+    - Apply changes for `WithRequired` and `WithOptional` (see [here](xref:efcore-and-ef6/porting/port-detailed-cases#required-and-optional))
     - Update validation code. There is no data validation built into EF Core, but you can [do it yourself](/dotnet/architecture/microservices/microservice-ddd-cqrs-patterns/domain-model-layer-validations#use-validation-attributes-in-the-model-based-on-data-annotations).
-    - Follow any necessary steps to [port from EDMX](/ef/efcore-and-ef6/porting/port-edmx).
+    - Follow any necessary steps to [port from EDMX](xref:efcore-and-ef6/porting/port-edmx).
 1. Perform specific steps based on your EF Core approach:
-    - [Code as source of truth](/ef/efcore-and-ef6/porting/port-code.md)
-    - [Database as source of truth](/ef/efcore-and-ef6/porting/port-database.md)
-    - [Hybrid model](/ef/efcore-and-ef6/porting/port-hybrid.md)
+    - [Code as source of truth](xref:efcore-and-ef6/porting/port-code)
+    - [Database as source of truth](xref:efcore-and-ef6/porting/port-database)
+    - [Hybrid model](xref:efcore-and-ef6/porting/port-hybrid)
 
-There are many considerations that relate to all of the approaches, so you will also want to review ways to address and work around the [detailed differences between EF6 and EF Core](/ef/efcore-and-ef6/porting/port-detailed-cases.md).
+There are many considerations that relate to all of the approaches, so you will also want to review ways to address and work around the [detailed differences between EF6 and EF Core](xref:efcore-and-ef6/porting/port-detailed-cases).

--- a/entity-framework/efcore-and-ef6/porting/port-behavior.md
+++ b/entity-framework/efcore-and-ef6/porting/port-behavior.md
@@ -9,7 +9,7 @@ uid: efcore-and-ef6/porting/port-behavior
 
 This is a non-exhaustive list of changes in behavior between EF6 and EF Core. It is important to keep these in mind as your port your application as they may change the way your application behaves, but will not show up as compilation errors after swapping to EF Core.
 
-This is meant as a high level review to consider as part of the porting process. For more detailed, case-by-case instructions, read the [detailed cases](/efcore-and-ef6/porting/port-detailed-cases).
+This is meant as a high level review to consider as part of the porting process. For more detailed, case-by-case instructions, read the [detailed cases](xref:efcore-and-ef6/porting/port-detailed-cases).
 
 ## DbSet.Add/Attach and graph behavior
 
@@ -30,7 +30,7 @@ The general philosophy here is that `Update` is a very simple way to handle inse
 
 At the same time, `Add` still provides an easy way force entities to be inserted. Add is mostly useful only when not using store-generated keys, such that EF doesn't know if the entity is new or not.
 
-For more information on these behaviors in EF Core, read [Change Tracking in EF Core](/ef/core/change-tracking/).
+For more information on these behaviors in EF Core, read [Change Tracking in EF Core](xref:core/change-tracking/index).
 
 ## Code First database initialization
 
@@ -53,4 +53,4 @@ EF6 runs the entity class name through a pluralization service to calculate the 
 
 EF Core uses the name of the `DbSet` property that the entity is exposed in on the derived context. If the entity does not have a `DbSet` property, then the class name is used.
 
-For more information, read [Managing Database Schemas](/ef/core/managing-schemas/).
+For more information, read [Managing Database Schemas](xref:core/managing-schemas/index).

--- a/entity-framework/efcore-and-ef6/porting/port-code.md
+++ b/entity-framework/efcore-and-ef6/porting/port-code.md
@@ -23,7 +23,7 @@ Most APIs that you use in EF6 are in the `System.Data.Entity` namespace (and rel
 
 ## Context configuration (connection etc.)
 
-As described in [configuring the database  connection](/ef/efcore-and-ef6/porting/port-detailed-cases?#configuring-the-database-connection), EF Core has less magic around detecting the database to connect to. You will need to override the `OnConfiguring` method on your derived context, and use the database provider specific API to setup the connection to the database.
+As described in [configuring the database  connection](xref:efcore-and-ef6/porting/port-detailed-cases#configuring-the-database-connection), EF Core has less magic around detecting the database to connect to. You will need to override the `OnConfiguring` method on your derived context, and use the database provider specific API to setup the connection to the database.
 
 Most EF6 applications store the connection string in the applications `App/Web.config` file. In EF Core, you read this connection string using the `ConfigurationManager` API. You may need to add a reference to the `System.Configuration` framework assembly to be able to use this API.
 
@@ -54,4 +54,4 @@ If possible, it is best to assume that all previous migrations from EF6 have bee
 
 Just because your application compiles, does not mean it is successfully ported to EF Core. You will need to test all areas of your application to ensure that none of the behavior changes have adversely impacted your application.
 
-Finally, review the [detailed cases to consider when porting](/ef/efcore-and-ef6/porting/port-detailed-cases) for more advice on specific cases and scenarios in your code.
+Finally, review the [detailed cases to consider when porting](xref:efcore-and-ef6/porting/port-detailed-cases) for more advice on specific cases and scenarios in your code.

--- a/entity-framework/efcore-and-ef6/porting/port-database.md
+++ b/entity-framework/efcore-and-ef6/porting/port-database.md
@@ -14,11 +14,11 @@ If you're using the database as the source of truth, the upgrade will mostly inv
 1. Pick a point-in-time to model the database.
 1. Ensure your EF6 projects are up to date and in-sync with the database.
 1. Create the EF Core project.
-1. Use the [scaffolding tools](/ef/core/managing-schemas/scaffolding) to reverse-engineer your database to code.
+1. Use the [scaffolding tools](xref:core/managing-schemas/scaffolding) to reverse-engineer your database to code.
 1. Validate that the EF Core generated classes are compatible with your code.
-1. For exceptions, either modify the generated classes and update the [model configuration](/ef/core/modeling/) or adapt your code to the model.
+1. For exceptions, either modify the generated classes and update the [model configuration](xref:core/modeling/index) or adapt your code to the model.
 
-Note that although EF Core currently scaffolds everything needed to successfully generate a copy of the database, much of the code is not needed for the database-first approach. A fix for this is tracked in [Issue #10890](/dotnet/efcore/issues/10890). Things that you can safely ignore as not needed include: sequences, constraint names, non-unique indexes and index filters.
+Note that although EF Core currently scaffolds everything needed to successfully generate a copy of the database, much of the code is not needed for the database-first approach. A fix for this is tracked in [Issue #10890](https://github.com/dotnet/efcore/issues/10890). Things that you can safely ignore as not needed include: sequences, constraint names, non-unique indexes and index filters.
 
 ## Handling schema changes
 
@@ -30,10 +30,10 @@ For various reasons, you may want your C# domain model to be shaped differently 
 
  If your model is significantly different from the generated one, but doesn't change frequently, one option to consider is use of the [repository pattern](/dotnet/architecture/microservices/microservice-ddd-cqrs-patterns/infrastructure-persistence-layer-design) as an adapter. The repository can consume the EF Core generated classes and publish the custom classes you use. This may reduce the impact of changes by isolating them to the repository code, rather than having to perform an application-wide refactoring each time the schema changes.
 
-You may want to consider an alternate workflow and follow steps similar to the [hybrid approach](/ef/efcore-and-ef6/porting/port-hybrid). Instead of generating a new set of classes each time, you indicate specific tables to only generate new classes. You keep existing classes "as is" and directly add or remove properties that changed. You then update the model configuration to address any changes in how the database maps to your existing classes.
+You may want to consider an alternate workflow and follow steps similar to the [hybrid approach](xref:efcore-and-ef6/porting/port-hybrid). Instead of generating a new set of classes each time, you indicate specific tables to only generate new classes. You keep existing classes "as is" and directly add or remove properties that changed. You then update the model configuration to address any changes in how the database maps to your existing classes.
 
 ## Customize the code generation
 
-EF Core 6 currently does not support customization of the generated code. There are third party solutions like [EF Core Power Tools](https://github.com/ErikEJ/EFCorePowerTools/wiki) that are available. For a list of featured community tools and extensions, see: [EF Core Tools and Extensions](/ef/core/extensions/).
+EF Core 6 currently does not support customization of the generated code. There are third party solutions like [EF Core Power Tools](https://github.com/ErikEJ/EFCorePowerTools/wiki) that are available. For a list of featured community tools and extensions, see: [EF Core Tools and Extensions](xref:core/extensions/index).
 
-Finally, review the [detailed list of differences between EF6 and EF Core](/ef/efcore-and-ef6/porting/port-detailed-cases) to address any remaining issues with porting.
+Finally, review the [detailed list of differences between EF6 and EF Core](xref:efcore-and-ef6/porting/port-detailed-cases) to address any remaining issues with porting.

--- a/entity-framework/efcore-and-ef6/porting/port-detailed-cases.md
+++ b/entity-framework/efcore-and-ef6/porting/port-detailed-cases.md
@@ -14,15 +14,15 @@ This document details some specific differences between EF6 and EF Core. Consult
 
 There are several differences between how EF6 connects to various data sources compared to EF Core. They are important to understand when you port your code.
 
-- **Connection strings**: EF Core does not directly support multiple constructor overloads for different connection strings as EF6 does. Instead, it relies on [DbContextOptions](/ef/core/dbcontext-configuration/#dbcontextoptions). You can still provide multiple constructor overloads in derived types, but will need to map connections through the options.
+- **Connection strings**: EF Core does not directly support multiple constructor overloads for different connection strings as EF6 does. Instead, it relies on [DbContextOptions](xref:core/dbcontext-configuration/index#dbcontextoptions). You can still provide multiple constructor overloads in derived types, but will need to map connections through the options.
 - **Configuration and cache**: EF Core supports a more robust and flexible implementation of dependency injection with an internal infrastructure that can connect to external service providers. This can be managed by the application to handle situations when the caches must be flushed. The EF6 version was limited and could not be flushed.
 - **Configuration files**: EF6 supports configuration via config files that can include the provider. EF Core requires a direct reference to the provider assembly and explicit provider registration (i.e. `UseSqlServer`).
 - **Connection factories**: EF6 supported connection factories. EF Core does not support connection factories and always requires a connection string.
-- **Logging**: in general, [logging in EF Core](/ef/core/logging-events-diagnostics/) is far more robust and has multiple options for fine-tuned configuration.
+- **Logging**: in general, [logging in EF Core](xref:core/logging-events-diagnostics/index) is far more robust and has multiple options for fine-tuned configuration.
 
 ## Conventions
 
-EF6 supported custom ("lightweight") conventions and model conventions. The lightweight conventions are similar to EF Core's [pre-convention model configuration](/ef/core/what-is-new/ef-core-6.0/whatsnew#pre-convention-model-configuration). Other conventions are supported as part of model building.
+EF6 supported custom ("lightweight") conventions and model conventions. The lightweight conventions are similar to EF Core's [pre-convention model configuration](xref:core/what-is-new/ef-core-6.0/whatsnew#pre-convention-model-configuration). Other conventions are supported as part of model building.
 
 EF6 runs conventions after the model is built. EF Core applies them as the model is being built. In EF Core, you can decouple model building from active sessions with a DbContext. It is possible to create a model initialized with the conventions.
 
@@ -40,7 +40,7 @@ There are a few features in EF6 that don't exist yet in EF Core, but are on the 
 
 ## Leave ObjectContext behind
 
-EF Core uses a [DbContext](/ef/core/dbcontext-configuration) instead of an `ObjectContext`. You will have to update code that uses [IObjectContextAdapter](xref:System.Data.Entity.Infrastructure.IObjectContextAdapter). This was sometimes used for queries with `PreserveChanges` or `OverwriteChanges` merge option. For similar capabilities in EF Core, look into the [Reload](xref:Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry.Reload) method.
+EF Core uses a [DbContext](xref:core/dbcontext-configuration/index) instead of an `ObjectContext`. You will have to update code that uses [IObjectContextAdapter](xref:System.Data.Entity.Infrastructure.IObjectContextAdapter). This was sometimes used for queries with `PreserveChanges` or `OverwriteChanges` merge option. For similar capabilities in EF Core, look into the [Reload](xref:Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry.Reload) method.
 
 ## Model configuration
 
@@ -60,19 +60,19 @@ Assemblies are _not_ scanned for derived types.
 
 ### Mapping
 
-The `.Map()` extension in EF6 has been replaced with overloads and extension methods in EF Core. For example, you can use '.HasDiscriminator()` to configure table-per-hierarchy (TPH). See: [Modeling Inheritance](/ef/core/modeling/inheritance).
+The `.Map()` extension in EF6 has been replaced with overloads and extension methods in EF Core. For example, you can use '.HasDiscriminator()` to configure table-per-hierarchy (TPH). See: [Modeling Inheritance](xref:core/modeling/inheritance).
 
 ### Inheritance mapping
 
 EF6 supported table-per-hierarchy (TPH), table-per-type (TPT) and table-per-concrete-class (TPC) and enabled hybrid mapping of different flavors at different levels of the hierarchy. EF Core will continue to require an inheritance chain to modeled one way (TPT or TPH) and the plan is to add support for TPC in EF7.
 
-See: [Modeling Inheritance](/ef/core/modeling/inheritance).
+See: [Modeling Inheritance](xref:core/modeling/inheritance).
 
 ### Attributes
 
 EF6 supported index attributes on properties. In EF Core, they are applied at the type level which should make it easier for scenarios that require composite indexes. EF Core doesn't support composite keys with data annotations (i.e. using Order in `ColumnAttribute` together with `KeyAttribute`).
 
-For more information, see: [Indexes and constraints](/ef/core/modeling/indexes).
+For more information, see: [Indexes and constraints](xref:core/modeling/indexes).
 
 ### Required and optional
 
@@ -111,11 +111,11 @@ EF Core integrates with the third-party library community library [NetTopologySu
 
 ### Independent associations
 
-EF Core does not support independent associations (an EDM concept that allows the relationship between two entities to be defined independent from the entities themselves). A similar concept supported in EF Core is [shadow properties](/ef/core/modeling/shadow-properties).
+EF Core does not support independent associations (an EDM concept that allows the relationship between two entities to be defined independent from the entities themselves). A similar concept supported in EF Core is [shadow properties](xref:core/modeling/shadow-properties).
 
 ## Migrations
 
-EF Core does not support database initializers or automatic migrations. Although there is no `migrate.exe` in EF Core, you can produce [migration bundles](/ef/core/what-is-new/ef-core-6.0/whatsnew#migration-bundles).
+EF Core does not support database initializers or automatic migrations. Although there is no `migrate.exe` in EF Core, you can produce [migration bundles](xref:core/what-is-new/ef-core-6.0/whatsnew#migration-bundles).
 
 ## Visual Studio Tooling
 
@@ -127,7 +127,7 @@ Although these features do not ship with EF Core, there are OSS community projec
 - Visual inspection of DbContext with model graphing and scripting.
 - Management of migrations from within Visual Studio using a GUI.
 
-For a complete list of community tools and extensions, see: [EF Core Tools and Extensions](/ef/core/extensions/).
+For a complete list of community tools and extensions, see: [EF Core Tools and Extensions](xref:core/extensions/index).
 
 ## Change tracking
 
@@ -142,11 +142,11 @@ There are several differences between how EF6 and EF Core deal with change track
 |Data-binding|`.Local`|`.Local` plus `.ToObservableCollection` or `.ToBindingList`|
 |Change detection|Full graph|Per entity|
 
-\* By default, property notification will not be triggered in EF Core so it's important to [configure notification entities](/ef/core/change-tracking/change-detection#notification-entities).
+\* By default, property notification will not be triggered in EF Core so it's important to [configure notification entities](xref:core/change-tracking/change-detection#notification-entities).
 
 Note that EF Core does not call change detection automatically as often as EF6.
 
-EF Core introduces a detailed `DebugView` for the change tracker. To learn more, read [Change Tracker Debugging](/ef/core/change-tracking/debug-views).
+EF Core introduces a detailed `DebugView` for the change tracker. To learn more, read [Change Tracker Debugging](xref:core/change-tracking/debug-views).
 
 ## Queries
 
@@ -156,6 +156,6 @@ EF6 has some query capabilities that do not exist in EF Core. These include:
 - Interception of the command tree for queries and updates.
 - Support for table-valued parameters (TVPs).
 
-EF6 has built-in support for lazy-loading proxies. This is an opt-in package for EF Core (see [Lazy Loading of Related Data](/ef/core/querying/related-data/lazy)).
+EF6 has built-in support for lazy-loading proxies. This is an opt-in package for EF Core (see [Lazy Loading of Related Data]xref:core/querying/related-data/lazy)).
 
 EF Core allows you to compose over raw SQL using `FromSQL`.

--- a/entity-framework/efcore-and-ef6/porting/port-edmx.md
+++ b/entity-framework/efcore-and-ef6/porting/port-edmx.md
@@ -47,6 +47,6 @@ Just because your application compiles, does not mean it is successfully ported 
 
 EF Core does not support the `EntityClient` provider and therefore any [EntitySQL](/dotnet/framework/data/adonet/ef/language-reference/entity-sql-language) queries must be migrated to LINQ or `FromRawSql`.
 
-Furthermore, there is no support for [EntityClient connection strings](/ef/ef6/fundamentals/configuring/connection-strings#databasemodel-first-with-connection-string-in-appconfigwebconfig-file).
+Furthermore, there is no support for [EntityClient connection strings]xref:ef6/fundamentals/configuring/connection-strings#databasemodel-first-with-connection-string-in-appconfigwebconfig-file).
 
 For more considerations, read the complete guide to [differences between EF6 and EF Core](/efcore-and-ef6/porting/port-detailed-cases.md).

--- a/entity-framework/efcore-and-ef6/porting/port-hybrid.md
+++ b/entity-framework/efcore-and-ef6/porting/port-hybrid.md
@@ -11,7 +11,7 @@ uid: efcore-and-ef6/porting/port-hybrid
 
 Two common approaches are to generate your database from code and use migrations, or generate your entities from the database using reverse-engineering. In the hybrid approach, you don't generate anything. Instead, you let the database and codebase evolve and use model configuration to keep the two in sync. This page contains some tips for success using the hybrid approach:
 
-1. First, read the guides for [code as source of truth](/efcore-and-ef6/porting/port-code) and [database as source of truth](/efcore-and-ef6/porting/port-database) to familiarize yourself with some of the considerations to be aware of.
+1. First, read the guides for [code as source of truth](xref:efcore-and-ef6/porting/port-code) and [database as source of truth](xref:efcore-and-ef6/porting/port-database) to familiarize yourself with some of the considerations to be aware of.
 1. Because you won't be using migrations, there is no need to model sequences, non-primary indexes, constraints and index filters.
 1. An integration test suite is valuable in this approach for validating a proper handoff between code and the database as the code and database evolve.
 1. One approach to test that your mappings are correct is to generate a dummy database using a "throwaway" migration, then use a tool to compare the generated database to the actual database. You can quickly flag differences in schema and act on them.


### PR DESCRIPTION
Includes conversion from relative path to xref: for better validation.