### PR TITLE
using System.ComponentModel.DataAnnotations.Schema

### DIFF
--- a/entity-framework/core/modeling/index.md
+++ b/entity-framework/core/modeling/index.md
@@ -41,4 +41,4 @@ It is possible to apply all configuration specified in types implementing `IEnti
 
 You can also apply attributes (known as Data Annotations) to your classes and properties. Data annotations will override conventions, but will be overridden by Fluent API configuration.
 
-[!code-csharp[Main](../../../samples/core/Modeling/EntityProperties/DataAnnotations/Required.cs?highlight=16)]
+[!code-csharp[Main](../../../samples/core/Modeling/EntityProperties/DataAnnotations/Annotations.cs)]

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/Annotations.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/Annotations.cs
@@ -1,10 +1,5 @@
-// RequiredAttribute
 using System.ComponentModel.DataAnnotations;
-
-// TableAttribute
 using System.ComponentModel.DataAnnotations.Schema;
-
-// DbContext
 using Microsoft.EntityFrameworkCore;
 
 namespace EFModeling.EntityProperties.DataAnnotations.Required
@@ -14,7 +9,6 @@ namespace EFModeling.EntityProperties.DataAnnotations.Required
         public DbSet<Blog> Blogs { get; set; }
     }
 
-    #region Required
     [Table("Blogs")]
     public class Blog
     {
@@ -23,5 +17,4 @@ namespace EFModeling.EntityProperties.DataAnnotations.Required
         [Required]
         public string Url { get; set; }
     }
-    #endregion
 }

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/Annotations.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/Annotations.cs
@@ -2,7 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.DataAnnotations.Required
+namespace EFModeling.EntityProperties.DataAnnotations.Annotations
 {
     internal class MyContext : DbContext
     {

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/Required.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/Required.cs
@@ -1,6 +1,3 @@
-using System.ComponentModel.DataAnnotations;
-using Microsoft.EntityFrameworkCore;
-
 namespace EFModeling.EntityProperties.DataAnnotations.Required
 {
     internal class MyContext : DbContext

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/Required.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/Required.cs
@@ -8,7 +8,7 @@ namespace EFModeling.EntityProperties.DataAnnotations.Required
         public DbSet<Blog> Blogs { get; set; }
     }
 
-#region Required
+    #region Required
     public class Blog
     {
         public int BlogId { get; set; }
@@ -16,5 +16,5 @@ namespace EFModeling.EntityProperties.DataAnnotations.Required
         [Required]
         public string Url { get; set; }
     }
-#endregion
+    #endregion
 }

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/Required.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/Required.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace EFModeling.EntityProperties.DataAnnotations.Required
+{
+    internal class MyContext : DbContext
+    {
+        public DbSet<Blog> Blogs { get; set; }
+    }
+
+    public class Blog
+    {
+        public int BlogId { get; set; }
+
+        [Required]
+        public string Url { get; set; }
+    }
+}

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/Required.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/Required.cs
@@ -1,4 +1,10 @@
-﻿using System.ComponentModel.DataAnnotations;
+// RequiredAttribute
+using System.ComponentModel.DataAnnotations;
+
+// TableAttribute
+using System.ComponentModel.DataAnnotations.Schema;
+
+// DbContext
 using Microsoft.EntityFrameworkCore;
 
 namespace EFModeling.EntityProperties.DataAnnotations.Required
@@ -9,6 +15,7 @@ namespace EFModeling.EntityProperties.DataAnnotations.Required
     }
 
     #region Required
+    [Table("Blogs")]
     public class Blog
     {
         public int BlogId { get; set; }

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/Required.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/Required.cs
@@ -1,3 +1,6 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
 namespace EFModeling.EntityProperties.DataAnnotations.Required
 {
     internal class MyContext : DbContext

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/Required.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/Required.cs
@@ -8,6 +8,7 @@ namespace EFModeling.EntityProperties.DataAnnotations.Required
         public DbSet<Blog> Blogs { get; set; }
     }
 
+#region Required
     public class Blog
     {
         public int BlogId { get; set; }
@@ -15,4 +16,5 @@ namespace EFModeling.EntityProperties.DataAnnotations.Required
         [Required]
         public string Url { get; set; }
     }
+#endregion
 }


### PR DESCRIPTION
This is the first and only place in the hand-out where `using` declarations are explicitly given.
`[Table]` attribute is used later on, so I added the namespace for it here.
I also added the `[Table]` attribute, otherwise the namespace would be unneeded for the given snippet.