### PR TITLE
Fix a few typos

### DIFF
--- a/entity-framework/core/testing/testing-with-the-database.md
+++ b/entity-framework/core/testing/testing-with-the-database.md
@@ -7,7 +7,7 @@ uid: core/testing/testing-with-the-database
 ---
 # Testing against your production database system
 
-In this page, we discuss techniques for writing automated tests which involve the database system against which the application runs in production. Alternate testing approaches exist, where the production database system is swapped out by test doubles; see the [testing overview page](xref:core/testing/index) for more information. Note that testing against an a different database than what is used in production (e.g. Sqlite) is not covered here, since the different database is used as a test double; this approach is covered in [Testing without your production database system](xref:core/testing/testing-without-the-database).
+In this page, we discuss techniques for writing automated tests which involve the database system against which the application runs in production. Alternate testing approaches exist, where the production database system is swapped out by test doubles; see the [testing overview page](xref:core/testing/index) for more information. Note that testing against a different database than what is used in production (e.g. Sqlite) is not covered here, since the different database is used as a test double; this approach is covered in [Testing without your production database system](xref:core/testing/testing-without-the-database).
 
 The main hurdle with testing which involves a real database is to ensure proper test isolation, so that tests running in parallel (or even in serial) don't interfere with each other. The full sample code for the below can be viewed [here](https://github.com/dotnet/EntityFramework.Docs/blob/main/samples/core/Testing/TestingWithTheDatabase).
 
@@ -16,7 +16,7 @@ The main hurdle with testing which involves a real database is to ensure proper 
 
 ## Setting up your database system
 
-Most database systems nowadays can be easily installed, both in CI environments and on developer machines. While it's frequently easy enough to install the database via the regular installation mechanism, ready-to-use Docker images are available for most major databases and can make installation particularly easy in CI. For the developer environment, [Github Workspaces](https://docs.github.com/en/codespaces/overview), [Dev Container](https://code.visualstudio.com/docs/remote/create-dev-container) can set up all needed services and dependencies - including the database. While this requires an initial investment in setup, once that's done you have a working testing environment and can concentrate on more important things.
+Most database systems nowadays can be easily installed, both in CI environments and on developer machines. While it's frequently easy enough to install the database via the regular installation mechanism, ready-to-use Docker images are available for most major databases and can make installation particularly easy in CI. For the developer environment, [GitHub Workspaces](https://docs.github.com/en/codespaces/overview), [Dev Container](https://code.visualstudio.com/docs/remote/create-dev-container) can set up all needed services and dependencies - including the database. While this requires an initial investment in setup, once that's done you have a working testing environment and can concentrate on more important things.
 
 In certain cases, databases have a special edition or version which can be helpful for testing. When using SQL Server, [LocalDB](/sql/database-engine/configure-windows/sql-server-express-localdb) can be used to run tests locally with virtually no setup at all, spinning up the database instance on demand and possibly saving resources on less powerful developer machines. However, LocalDB is not without its issues:
 
@@ -123,7 +123,7 @@ You may also want to consider using the [respawn](https://github.com/jbogard/res
 
 ## Summary
 
-* When test against a real database, it's worth distinguishing between the following test categories:
+* When testing against a real database, it's worth distinguishing between the following test categories:
   * Read-only tests are relatively simple, and can always execute in parallel against the same database without having to worry about isolation.
   * Write tests are more problematic, but transactions can be used to make sure they're properly isolated.
   * Transactional tests are the most problematic, requiring logic to reset the database back to its original state, as well as disabling parallelization.

--- a/entity-framework/core/testing/testing-with-the-database.md
+++ b/entity-framework/core/testing/testing-with-the-database.md
@@ -96,7 +96,7 @@ Finally, we make our test class disposable, arranging for the fixture's `Cleanup
 
 Note that since xUnit only ever instantiates the collection fixture once, there is no need for us to use locking around database creation and seeding as we did above.
 
-The full sample code for the above can be viewed [here](https://github.com/dotnet/EntityFramework.Docs/blob/main/samples/core/Testing/IntegrationTests/TransactionalBloggingControllerTest.cs).
+The full sample code for the above can be viewed [here](https://github.com/dotnet/EntityFramework.Docs/blob/main/samples/core/Testing/TestingWithTheDatabase/TransactionalBloggingControllerTest.cs).
 
 > [!TIP]
 > If you have multiple test classes with tests which modify the database, you can still run them in parallel by having different fixtures, each referencing its own database. Creating and using many test databases isn't problematic and should be done whenever it's helpful.

--- a/entity-framework/core/testing/testing-without-the-database.md
+++ b/entity-framework/core/testing/testing-without-the-database.md
@@ -28,7 +28,7 @@ For an ASP.NET Core application, we need to register the repository as a service
 
 [!code-csharp[Main](../../../samples/core/Testing/BloggingWebApi/Startup.cs?name=RegisterRepositoryInDI)]
 
-Finally, our ASP.NET Core controllers get injected with the repository service instead of the EF Core context, and execute methods on it:
+Finally, our controllers get injected with the repository service instead of the EF Core context, and execute methods on it:
 
 [!code-csharp[Main](../../../samples/core/Testing/BloggingWebApi/Controllers/BloggingControllerWithRepository.cs?name=BloggingControllerWithRepository&highlight=8)]
 

--- a/entity-framework/core/testing/testing-without-the-database.md
+++ b/entity-framework/core/testing/testing-without-the-database.md
@@ -24,11 +24,11 @@ If you've decided to write tests without involving your production database syst
 
 There's not much to it: the repository simply wraps an EF Core context, and exposes methods which execute the database queries and updates on it. A key point to note is that our `GetAllBlogs` method returns `IEnumerable<Blog>`, and not `IQueryable<Blog>`. Returning the latter would mean that query operators can still be composed over the result, requiring that EF Core still be involved in translating the query; this would defeat the purpose of having a repository in the first place. `IEnumerable<Blog>` allows us to easily stub or mock what the repository returns.
 
-For an ASP.NET application, we need to register the repository as a service in dependency injection by adding the following to the application's `ConfigureServices`:
+For an ASP.NET Core application, we need to register the repository as a service in dependency injection by adding the following to the application's `ConfigureServices`:
 
 [!code-csharp[Main](../../../samples/core/Testing/BloggingWebApi/Startup.cs?name=RegisterRepositoryInDI)]
 
-Finally, our ASP.NET controllers get injected with the repository service instead of the EF Core context, and execute methods on it:
+Finally, our ASP.NET Core controllers get injected with the repository service instead of the EF Core context, and execute methods on it:
 
 [!code-csharp[Main](../../../samples/core/Testing/BloggingWebApi/Controllers/BloggingControllerWithRepository.cs?name=BloggingControllerWithRepository&highlight=8)]
 


### PR DESCRIPTION
Fix a handful of minor typos in _Testing against your production database system_.

I also noticed while reading the document that the two blog controller code samples are empty, ~and the link to that code 404s~ (fixed in commit 2), but I don't know what they _should_ be to fix that.
