### PR TITLE
Use file-scoped namespaces everywhere in samples

### DIFF
--- a/samples/core/CascadeDeletes/IntroOptionalSamples.cs
+++ b/samples/core/CascadeDeletes/IntroOptionalSamples.cs
@@ -4,168 +4,167 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace IntroOptional
+namespace IntroOptional;
+
+public static class IntroOptionalSamples
 {
-    public static class IntroOptionalSamples
+    public static void Deleting_principal_parent_1b()
     {
-        public static void Deleting_principal_parent_1b()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Deleting_principal_parent_1b)}");
-            Console.WriteLine();
+        Console.WriteLine($">>>> Sample: {nameof(Deleting_principal_parent_1b)}");
+        Console.WriteLine();
 
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-            #region Deleting_principal_parent_1b
-            using var context = new BlogsContext();
+        #region Deleting_principal_parent_1b
+        using var context = new BlogsContext();
 
-            var blog = context.Blogs.OrderBy(e => e.Name).Include(e => e.Posts).First();
+        var blog = context.Blogs.OrderBy(e => e.Name).Include(e => e.Posts).First();
 
-            context.Remove(blog);
+        context.Remove(blog);
 
-            context.SaveChanges();
-            #endregion
+        context.SaveChanges();
+        #endregion
 
-            Console.WriteLine();
-        }
-
-        public static void Severing_a_relationship_1b()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Severing_a_relationship_1b)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Severing_a_relationship_1b
-            using var context = new BlogsContext();
-
-            var blog = context.Blogs.OrderBy(e => e.Name).Include(e => e.Posts).First();
-
-            foreach (var post in blog.Posts)
-            {
-                post.Blog = null;
-            }
-
-            context.SaveChanges();
-            #endregion
-
-            Console.WriteLine();
-        }
-
-        public static void Severing_a_relationship_2b()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Severing_a_relationship_2b)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Severing_a_relationship_2b
-            using var context = new BlogsContext();
-
-            var blog = context.Blogs.OrderBy(e => e.Name).Include(e => e.Posts).First();
-
-            blog.Posts.Clear();
-
-            context.SaveChanges();
-            #endregion
-
-            Console.WriteLine();
-        }
+        Console.WriteLine();
     }
 
-    public static class Helpers
+    public static void Severing_a_relationship_1b()
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        Console.WriteLine($">>>> Sample: {nameof(Severing_a_relationship_1b)}");
+        Console.WriteLine();
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Severing_a_relationship_1b
+        using var context = new BlogsContext();
+
+        var blog = context.Blogs.OrderBy(e => e.Name).Include(e => e.Posts).First();
+
+        foreach (var post in blog.Posts)
+        {
+            post.Blog = null;
         }
 
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        context.SaveChanges();
+        #endregion
 
-            context.Add(
-                new Blog
+        Console.WriteLine();
+    }
+
+    public static void Severing_a_relationship_2b()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Severing_a_relationship_2b)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Severing_a_relationship_2b
+        using var context = new BlogsContext();
+
+        var blog = context.Blogs.OrderBy(e => e.Name).Include(e => e.Posts).First();
+
+        blog.Posts.Clear();
+
+        context.SaveChanges();
+        #endregion
+
+        Console.WriteLine();
+    }
+}
+
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+    }
+
+    public static void PopulateDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Add(
+            new Blog
+            {
+                Name = ".NET Blog",
+                Posts =
                 {
-                    Name = ".NET Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
-                    }
-                });
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
+                    },
+                }
+            });
 
-            context.SaveChanges();
-        }
+        context.SaveChanges();
+    }
+}
+
+#region Model
+public class Blog
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>();
+}
+
+public class Post
+{
+    public int Id { get; set; }
+
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int? BlogId { get; set; }
+    public Blog Blog { get; set; }
+}
+#endregion
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
     }
 
-    #region Model
-    public class Blog
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int Id { get; set; }
-
-        public string Name { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>();
+        modelBuilder
+            .Entity<Blog>()
+            .HasMany(e => e.Posts)
+            .WithOne(e => e.Blog)
+            .OnDelete(DeleteBehavior.ClientSetNull);
     }
 
-    public class Post
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        public int Id { get; set; }
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;Trusted_Connection=True");
+        //.UseSqlite("DataSource=test.db");
 
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int? BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
-    #endregion
-
-    public class BlogsContext : DbContext
-    {
-        private readonly bool _quiet;
-
-        public BlogsContext(bool quiet = false)
+        if (!_quiet)
         {
-            _quiet = quiet;
-        }
-
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder
-                .Entity<Blog>()
-                .HasMany(e => e.Posts)
-                .WithOne(e => e.Blog)
-                .OnDelete(DeleteBehavior.ClientSetNull);
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;Trusted_Connection=True");
-            //.UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
-            {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
     }
 }

--- a/samples/core/CascadeDeletes/IntroRequiredSamples.cs
+++ b/samples/core/CascadeDeletes/IntroRequiredSamples.cs
@@ -4,185 +4,184 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace IntroRequired
+namespace IntroRequired;
+
+public static class IntroRequiredSamples
 {
-    public static class IntroRequiredSamples
+    public static void Deleting_principal_parent_1()
     {
-        public static void Deleting_principal_parent_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Deleting_principal_parent_1)}");
-            Console.WriteLine();
+        Console.WriteLine($">>>> Sample: {nameof(Deleting_principal_parent_1)}");
+        Console.WriteLine();
 
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-            #region Deleting_principal_parent_1
-            using var context = new BlogsContext();
+        #region Deleting_principal_parent_1
+        using var context = new BlogsContext();
 
-            var blog = context.Blogs.OrderBy(e => e.Name).Include(e => e.Posts).First();
+        var blog = context.Blogs.OrderBy(e => e.Name).Include(e => e.Posts).First();
 
-            context.Remove(blog);
+        context.Remove(blog);
 
-            context.SaveChanges();
-            #endregion
+        context.SaveChanges();
+        #endregion
 
-            Console.WriteLine();
-        }
-
-        public static void Severing_a_relationship_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Severing_a_relationship_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Severing_a_relationship_1
-            using var context = new BlogsContext();
-
-            var blog = context.Blogs.OrderBy(e => e.Name).Include(e => e.Posts).First();
-
-            foreach (var post in blog.Posts)
-            {
-                post.Blog = null;
-            }
-
-            context.SaveChanges();
-            #endregion
-
-            Console.WriteLine();
-        }
-
-        public static void Severing_a_relationship_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Severing_a_relationship_2)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Severing_a_relationship_2
-            using var context = new BlogsContext();
-
-            var blog = context.Blogs.OrderBy(e => e.Name).Include(e => e.Posts).First();
-
-            blog.Posts.Clear();
-
-            context.SaveChanges();
-            #endregion
-
-            Console.WriteLine();
-        }
-
-        public static void Where_cascading_behaviors_happen_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Where_cascading_behaviors_happen_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Where_cascading_behaviors_happen_1
-            using var context = new BlogsContext();
-
-            var blog = context.Blogs.OrderBy(e => e.Name).First();
-
-            context.Remove(blog);
-
-            context.SaveChanges();
-            #endregion
-
-            Console.WriteLine();
-        }
+        Console.WriteLine();
     }
 
-    public static class Helpers
+    public static void Severing_a_relationship_1()
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        Console.WriteLine($">>>> Sample: {nameof(Severing_a_relationship_1)}");
+        Console.WriteLine();
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Severing_a_relationship_1
+        using var context = new BlogsContext();
+
+        var blog = context.Blogs.OrderBy(e => e.Name).Include(e => e.Posts).First();
+
+        foreach (var post in blog.Posts)
+        {
+            post.Blog = null;
         }
 
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        context.SaveChanges();
+        #endregion
 
-            context.Add(
-                new Blog
+        Console.WriteLine();
+    }
+
+    public static void Severing_a_relationship_2()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Severing_a_relationship_2)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Severing_a_relationship_2
+        using var context = new BlogsContext();
+
+        var blog = context.Blogs.OrderBy(e => e.Name).Include(e => e.Posts).First();
+
+        blog.Posts.Clear();
+
+        context.SaveChanges();
+        #endregion
+
+        Console.WriteLine();
+    }
+
+    public static void Where_cascading_behaviors_happen_1()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Where_cascading_behaviors_happen_1)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Where_cascading_behaviors_happen_1
+        using var context = new BlogsContext();
+
+        var blog = context.Blogs.OrderBy(e => e.Name).First();
+
+        context.Remove(blog);
+
+        context.SaveChanges();
+        #endregion
+
+        Console.WriteLine();
+    }
+}
+
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+    }
+
+    public static void PopulateDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Add(
+            new Blog
+            {
+                Name = ".NET Blog",
+                Posts =
                 {
-                    Name = ".NET Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
-                    }
-                });
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
+                    },
+                }
+            });
 
-            context.SaveChanges();
-        }
+        context.SaveChanges();
+    }
+}
+
+#region Model
+public class Blog
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>();
+}
+
+public class Post
+{
+    public int Id { get; set; }
+
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
+}
+#endregion
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
     }
 
-    #region Model
-    public class Blog
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int Id { get; set; }
-
-        public string Name { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>();
+        modelBuilder.Entity<Blog>().HasMany(e => e.Posts).WithOne(e => e.Blog); //.OnDelete(DeleteBehavior.ClientSetNull);
     }
 
-    public class Post
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        public int Id { get; set; }
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;Trusted_Connection=True");
+        //.UseSqlite("DataSource=test.db");
 
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
-    #endregion
-
-    public class BlogsContext : DbContext
-    {
-        private readonly bool _quiet;
-
-        public BlogsContext(bool quiet = false)
+        if (!_quiet)
         {
-            _quiet = quiet;
-        }
-
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>().HasMany(e => e.Posts).WithOne(e => e.Blog); //.OnDelete(DeleteBehavior.ClientSetNull);
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;Trusted_Connection=True");
-            //.UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
-            {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
     }
 }

--- a/samples/core/CascadeDeletes/OptionalDependentsSamples.cs
+++ b/samples/core/CascadeDeletes/OptionalDependentsSamples.cs
@@ -4,196 +4,195 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace Optional
+namespace Optional;
+
+public static class OptionalDependentsSamples
 {
-    public static class OptionalDependentsSamples
+    public static void Optional_relationship_with_dependents_children_loaded()
     {
-        public static void Optional_relationship_with_dependents_children_loaded()
+        Console.WriteLine("#### Optional relationship with dependents/children loaded");
+        Console.WriteLine();
+
+        var deleteResults = Helpers.GatherData(c => c.Remove(c.Blogs.Include(e => e.Posts).Single()));
+        var severResults = Helpers.GatherData(c => c.Blogs.Include(e => e.Posts).Single().Posts.Clear());
+
+        Console.WriteLine(
+            $"| `{"DeleteBehavior".PadRight(16)} | {"On deleting principal/parent".PadRight(40)} | On severing from principal/parent");
+        Console.WriteLine("|:------------------|------------------------------------------|----------------------------------------");
+        foreach (var deleteBehavior in DeleteBehaviors)
         {
-            Console.WriteLine("#### Optional relationship with dependents/children loaded");
-            Console.WriteLine();
-
-            var deleteResults = Helpers.GatherData(c => c.Remove(c.Blogs.Include(e => e.Posts).Single()));
-            var severResults = Helpers.GatherData(c => c.Blogs.Include(e => e.Posts).Single().Posts.Clear());
-
             Console.WriteLine(
-                $"| `{"DeleteBehavior".PadRight(16)} | {"On deleting principal/parent".PadRight(40)} | On severing from principal/parent");
-            Console.WriteLine("|:------------------|------------------------------------------|----------------------------------------");
-            foreach (var deleteBehavior in DeleteBehaviors)
-            {
-                Console.WriteLine(
-                    $"| `{(deleteBehavior + "`").PadRight(16)} | {deleteResults[deleteBehavior].PadRight(40)} | {severResults[deleteBehavior]}");
-            }
-
-            Console.WriteLine();
+                $"| `{(deleteBehavior + "`").PadRight(16)} | {deleteResults[deleteBehavior].PadRight(40)} | {severResults[deleteBehavior]}");
         }
 
-        public static void Optional_relationship_with_dependents_children_not_loaded()
+        Console.WriteLine();
+    }
+
+    public static void Optional_relationship_with_dependents_children_not_loaded()
+    {
+        Console.WriteLine("#### Optional relationship with dependents/children not loaded");
+        Console.WriteLine();
+
+        var deleteResults = Helpers.GatherData(c => c.Remove(c.Blogs.Single()));
+
+        Console.WriteLine(
+            $"| `{"DeleteBehavior".PadRight(16)} | {"On deleting principal/parent".PadRight(40)} | On severing from principal/parent");
+        Console.WriteLine("|:------------------|------------------------------------------|----------------------------------------");
+        foreach (var deleteBehavior in DeleteBehaviors)
         {
-            Console.WriteLine("#### Optional relationship with dependents/children not loaded");
-            Console.WriteLine();
-
-            var deleteResults = Helpers.GatherData(c => c.Remove(c.Blogs.Single()));
-
-            Console.WriteLine(
-                $"| `{"DeleteBehavior".PadRight(16)} | {"On deleting principal/parent".PadRight(40)} | On severing from principal/parent");
-            Console.WriteLine("|:------------------|------------------------------------------|----------------------------------------");
-            foreach (var deleteBehavior in DeleteBehaviors)
-            {
-                Console.WriteLine($"| `{(deleteBehavior + "`").PadRight(16)} | {deleteResults[deleteBehavior].PadRight(40)} | N/A");
-            }
-
-            Console.WriteLine();
+            Console.WriteLine($"| `{(deleteBehavior + "`").PadRight(16)} | {deleteResults[deleteBehavior].PadRight(40)} | N/A");
         }
 
-        public static DeleteBehavior[] DeleteBehaviors { get; }
-            =
-            {
-                DeleteBehavior.Cascade, DeleteBehavior.Restrict, DeleteBehavior.NoAction, DeleteBehavior.SetNull,
-                DeleteBehavior.ClientSetNull, DeleteBehavior.ClientCascade, DeleteBehavior.ClientNoAction
-            };
+        Console.WriteLine();
+    }
 
-        #region Model
-        public class Blog
+    public static DeleteBehavior[] DeleteBehaviors { get; }
+        =
         {
-            public int Id { get; set; }
+            DeleteBehavior.Cascade, DeleteBehavior.Restrict, DeleteBehavior.NoAction, DeleteBehavior.SetNull,
+            DeleteBehavior.ClientSetNull, DeleteBehavior.ClientCascade, DeleteBehavior.ClientNoAction
+        };
 
-            public string Name { get; set; }
+    #region Model
+    public class Blog
+    {
+        public int Id { get; set; }
 
-            public IList<Post> Posts { get; } = new List<Post>();
-        }
+        public string Name { get; set; }
 
-        public class Post
-        {
-            public int Id { get; set; }
+        public IList<Post> Posts { get; } = new List<Post>();
+    }
 
-            public string Title { get; set; }
-            public string Content { get; set; }
+    public class Post
+    {
+        public int Id { get; set; }
 
-            #region NullableBlogId
-            public int? BlogId { get; set; }
-            #endregion
+        public string Title { get; set; }
+        public string Content { get; set; }
 
-            public Blog Blog { get; set; }
-        }
+        #region NullableBlogId
+        public int? BlogId { get; set; }
         #endregion
 
-        public static class Helpers
+        public Blog Blog { get; set; }
+    }
+    #endregion
+
+    public static class Helpers
+    {
+        public static void RecreateCleanDatabase(OptionalBlogsContext context)
         {
-            public static void RecreateCleanDatabase(OptionalBlogsContext context)
+            using (context)
             {
-                using (context)
-                {
-                    context.Database.EnsureDeleted();
-                    context.Database.EnsureCreated();
-                }
-            }
-
-            public static void PopulateDatabase(OptionalBlogsContext context)
-            {
-                using (context)
-                {
-                    context.Add(
-                        new Blog
-                        {
-                            Name = ".NET Blog",
-                            Posts =
-                            {
-                                new Post
-                                {
-                                    Title = "Announcing the Release of EF Core 5.0",
-                                    Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                                },
-                                new Post
-                                {
-                                    Title = "Announcing F# 5",
-                                    Content = "F# 5 is the latest version of F#, the functional programming language..."
-                                },
-                            }
-                        });
-
-                    context.SaveChanges();
-                }
-            }
-
-            public static Dictionary<DeleteBehavior, string> GatherData(Action<OptionalBlogsContext> action)
-            {
-                var results = new Dictionary<DeleteBehavior, string>();
-
-                foreach (var deleteBehavior in DeleteBehaviors)
-                {
-                    RecreateCleanDatabase(new OptionalBlogsContext(deleteBehavior));
-                    PopulateDatabase(new OptionalBlogsContext(deleteBehavior));
-
-                    try
-                    {
-                        using var context = new OptionalBlogsContext(deleteBehavior);
-
-                        action(context);
-
-                        context.ChangeTracker.DetectChanges();
-
-                        var deletingPosts = context.ChangeTracker.Entries<Post>().Any(e => e.State == EntityState.Deleted);
-                        var settingFksToNull = context.ChangeTracker.Entries<Post>().Any(e => e.State == EntityState.Modified);
-
-                        context.SaveChanges();
-
-                        var deletedPosts = !context.Posts.AsNoTracking().Any();
-
-                        results[deleteBehavior] =
-                            deletingPosts
-                                ? "Dependents deleted by EF Core"
-                                : deletedPosts
-                                    ? "Dependents deleted by database"
-                                    : settingFksToNull
-                                        ? "Dependent FKs set to null by EF Core"
-                                        : "Dependent FKs set to null by database";
-                    }
-                    catch (Exception e)
-                    {
-                        results[deleteBehavior] = $"`{e.GetType().Name}`";
-                    }
-                }
-
-                return results;
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
             }
         }
 
-        public class OptionalBlogsContext : DbContext
+        public static void PopulateDatabase(OptionalBlogsContext context)
         {
-            private readonly DeleteBehavior _deleteBehavior;
-            private readonly bool _quiet;
-
-            public OptionalBlogsContext(DeleteBehavior deleteBehavior, bool quiet = true)
+            using (context)
             {
-                _deleteBehavior = deleteBehavior;
-                _quiet = quiet;
+                context.Add(
+                    new Blog
+                    {
+                        Name = ".NET Blog",
+                        Posts =
+                        {
+                            new Post
+                            {
+                                Title = "Announcing the Release of EF Core 5.0",
+                                Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                            },
+                            new Post
+                            {
+                                Title = "Announcing F# 5",
+                                Content = "F# 5 is the latest version of F#, the functional programming language..."
+                            },
+                        }
+                    });
+
+                context.SaveChanges();
             }
+        }
 
-            public DbSet<Blog> Blogs { get; set; }
-            public DbSet<Post> Posts { get; set; }
+        public static Dictionary<DeleteBehavior, string> GatherData(Action<OptionalBlogsContext> action)
+        {
+            var results = new Dictionary<DeleteBehavior, string>();
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            foreach (var deleteBehavior in DeleteBehaviors)
             {
-                modelBuilder
-                    .Entity<Blog>()
-                    .HasMany(e => e.Posts)
-                    .WithOne(e => e.Blog)
-                    .OnDelete(_deleteBehavior);
-            }
+                RecreateCleanDatabase(new OptionalBlogsContext(deleteBehavior));
+                PopulateDatabase(new OptionalBlogsContext(deleteBehavior));
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            {
-                optionsBuilder
-                    .EnableServiceProviderCaching(false)
-                    .EnableSensitiveDataLogging()
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;Trusted_Connection=True");
-                //.UseSqlite("DataSource=test.db");
-
-                if (!_quiet)
+                try
                 {
-                    optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
+                    using var context = new OptionalBlogsContext(deleteBehavior);
+
+                    action(context);
+
+                    context.ChangeTracker.DetectChanges();
+
+                    var deletingPosts = context.ChangeTracker.Entries<Post>().Any(e => e.State == EntityState.Deleted);
+                    var settingFksToNull = context.ChangeTracker.Entries<Post>().Any(e => e.State == EntityState.Modified);
+
+                    context.SaveChanges();
+
+                    var deletedPosts = !context.Posts.AsNoTracking().Any();
+
+                    results[deleteBehavior] =
+                        deletingPosts
+                            ? "Dependents deleted by EF Core"
+                            : deletedPosts
+                                ? "Dependents deleted by database"
+                                : settingFksToNull
+                                    ? "Dependent FKs set to null by EF Core"
+                                    : "Dependent FKs set to null by database";
                 }
+                catch (Exception e)
+                {
+                    results[deleteBehavior] = $"`{e.GetType().Name}`";
+                }
+            }
+
+            return results;
+        }
+    }
+
+    public class OptionalBlogsContext : DbContext
+    {
+        private readonly DeleteBehavior _deleteBehavior;
+        private readonly bool _quiet;
+
+        public OptionalBlogsContext(DeleteBehavior deleteBehavior, bool quiet = true)
+        {
+            _deleteBehavior = deleteBehavior;
+            _quiet = quiet;
+        }
+
+        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Post> Posts { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .Entity<Blog>()
+                .HasMany(e => e.Posts)
+                .WithOne(e => e.Blog)
+                .OnDelete(_deleteBehavior);
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder
+                .EnableServiceProviderCaching(false)
+                .EnableSensitiveDataLogging()
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;Trusted_Connection=True");
+            //.UseSqlite("DataSource=test.db");
+
+            if (!_quiet)
+            {
+                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
             }
         }
     }

--- a/samples/core/CascadeDeletes/RequiredDependentsSamples.cs
+++ b/samples/core/CascadeDeletes/RequiredDependentsSamples.cs
@@ -4,201 +4,200 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace Required
+namespace Required;
+
+public static class RequiredDependentsSamples
 {
-    public static class RequiredDependentsSamples
+    public static void Required_relationship_with_dependents_children_loaded()
     {
-        public static void Required_relationship_with_dependents_children_loaded()
+        Console.WriteLine("#### Required relationship with dependents/children loaded");
+        Console.WriteLine();
+
+        var deleteResults = Helpers.GatherData(c => c.Remove(c.Blogs.Include(e => e.Posts).Single()));
+        var severResults = Helpers.GatherData(c => c.Blogs.Include(e => e.Posts).Single().Posts.Clear());
+
+        Console.WriteLine(
+            $"| `{"DeleteBehavior".PadRight(16)} | {"On deleting principal/parent".PadRight(40)} | On severing from principal/parent");
+        Console.WriteLine("|:------------------|------------------------------------------|----------------------------------------");
+        foreach (var deleteBehavior in DeleteBehaviors)
         {
-            Console.WriteLine("#### Required relationship with dependents/children loaded");
-            Console.WriteLine();
-
-            var deleteResults = Helpers.GatherData(c => c.Remove(c.Blogs.Include(e => e.Posts).Single()));
-            var severResults = Helpers.GatherData(c => c.Blogs.Include(e => e.Posts).Single().Posts.Clear());
-
             Console.WriteLine(
-                $"| `{"DeleteBehavior".PadRight(16)} | {"On deleting principal/parent".PadRight(40)} | On severing from principal/parent");
-            Console.WriteLine("|:------------------|------------------------------------------|----------------------------------------");
-            foreach (var deleteBehavior in DeleteBehaviors)
+                $"| `{(deleteBehavior + "`").PadRight(16)} | {deleteResults[deleteBehavior].PadRight(40)} | {severResults[deleteBehavior]}");
+        }
+
+        Console.WriteLine();
+    }
+
+    public static void Required_relationship_with_dependents_children_not_loaded()
+    {
+        Console.WriteLine("#### Required relationship with dependents/children not loaded");
+        Console.WriteLine();
+
+        var deleteResults = Helpers.GatherData(c => c.Remove(c.Blogs.Single()));
+
+        Console.WriteLine(
+            $"| `{"DeleteBehavior".PadRight(16)} | {"On deleting principal/parent".PadRight(40)} | On severing from principal/parent");
+        Console.WriteLine("|:------------------|------------------------------------------|----------------------------------------");
+        foreach (var deleteBehavior in DeleteBehaviors)
+        {
+            Console.WriteLine($"| `{(deleteBehavior + "`").PadRight(16)} | {deleteResults[deleteBehavior].PadRight(40)} | N/A");
+        }
+
+        Console.WriteLine();
+    }
+
+    public static DeleteBehavior[] DeleteBehaviors { get; }
+        =
+        {
+            DeleteBehavior.Cascade, DeleteBehavior.Restrict, DeleteBehavior.NoAction, DeleteBehavior.SetNull,
+            DeleteBehavior.ClientSetNull, DeleteBehavior.ClientCascade, DeleteBehavior.ClientNoAction
+        };
+
+    #region Model
+    public class Blog
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public IList<Post> Posts { get; } = new List<Post>();
+    }
+
+    public class Post
+    {
+        public int Id { get; set; }
+
+        public string Title { get; set; }
+        public string Content { get; set; }
+
+        public int BlogId { get; set; }
+        public Blog Blog { get; set; }
+    }
+    #endregion
+
+    public static class Helpers
+    {
+        public static void RecreateCleanDatabase(RequiredBlogsContext context)
+        {
+            using (context)
             {
-                Console.WriteLine(
-                    $"| `{(deleteBehavior + "`").PadRight(16)} | {deleteResults[deleteBehavior].PadRight(40)} | {severResults[deleteBehavior]}");
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
             }
-
-            Console.WriteLine();
         }
 
-        public static void Required_relationship_with_dependents_children_not_loaded()
+        public static void PopulateDatabase(RequiredBlogsContext context)
         {
-            Console.WriteLine("#### Required relationship with dependents/children not loaded");
-            Console.WriteLine();
-
-            var deleteResults = Helpers.GatherData(c => c.Remove(c.Blogs.Single()));
-
-            Console.WriteLine(
-                $"| `{"DeleteBehavior".PadRight(16)} | {"On deleting principal/parent".PadRight(40)} | On severing from principal/parent");
-            Console.WriteLine("|:------------------|------------------------------------------|----------------------------------------");
-            foreach (var deleteBehavior in DeleteBehaviors)
+            using (context)
             {
-                Console.WriteLine($"| `{(deleteBehavior + "`").PadRight(16)} | {deleteResults[deleteBehavior].PadRight(40)} | N/A");
-            }
-
-            Console.WriteLine();
-        }
-
-        public static DeleteBehavior[] DeleteBehaviors { get; }
-            =
-            {
-                DeleteBehavior.Cascade, DeleteBehavior.Restrict, DeleteBehavior.NoAction, DeleteBehavior.SetNull,
-                DeleteBehavior.ClientSetNull, DeleteBehavior.ClientCascade, DeleteBehavior.ClientNoAction
-            };
-
-        #region Model
-        public class Blog
-        {
-            public int Id { get; set; }
-
-            public string Name { get; set; }
-
-            public IList<Post> Posts { get; } = new List<Post>();
-        }
-
-        public class Post
-        {
-            public int Id { get; set; }
-
-            public string Title { get; set; }
-            public string Content { get; set; }
-
-            public int BlogId { get; set; }
-            public Blog Blog { get; set; }
-        }
-        #endregion
-
-        public static class Helpers
-        {
-            public static void RecreateCleanDatabase(RequiredBlogsContext context)
-            {
-                using (context)
-                {
-                    context.Database.EnsureDeleted();
-                    context.Database.EnsureCreated();
-                }
-            }
-
-            public static void PopulateDatabase(RequiredBlogsContext context)
-            {
-                using (context)
-                {
-                    context.Add(
-                        new Blog
+                context.Add(
+                    new Blog
+                    {
+                        Name = ".NET Blog",
+                        Posts =
                         {
-                            Name = ".NET Blog",
-                            Posts =
+                            new Post
                             {
-                                new Post
-                                {
-                                    Title = "Announcing the Release of EF Core 5.0",
-                                    Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                                },
-                                new Post
-                                {
-                                    Title = "Announcing F# 5",
-                                    Content = "F# 5 is the latest version of F#, the functional programming language..."
-                                },
-                            }
-                        });
+                                Title = "Announcing the Release of EF Core 5.0",
+                                Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                            },
+                            new Post
+                            {
+                                Title = "Announcing F# 5",
+                                Content = "F# 5 is the latest version of F#, the functional programming language..."
+                            },
+                        }
+                    });
+
+                context.SaveChanges();
+            }
+        }
+
+        public static Dictionary<DeleteBehavior, string> GatherData(Action<RequiredBlogsContext> action)
+        {
+            var results = new Dictionary<DeleteBehavior, string>();
+
+            foreach (var deleteBehavior in DeleteBehaviors)
+            {
+                try
+                {
+                    RecreateCleanDatabase(new RequiredBlogsContext(deleteBehavior));
+                    PopulateDatabase(new RequiredBlogsContext(deleteBehavior));
+                }
+                catch (Exception e)
+                {
+                    results[deleteBehavior] = $"`{e.GetType().Name}`";
+                    continue;
+                }
+
+                try
+                {
+                    using var context = new RequiredBlogsContext(deleteBehavior);
+
+                    action(context);
+
+                    context.ChangeTracker.DetectChanges();
+
+                    var deletingPosts = context.ChangeTracker.Entries<Post>().Any(e => e.State == EntityState.Deleted);
+                    var settingFksToNull = context.ChangeTracker.Entries<Post>().Any(e => e.State == EntityState.Modified);
 
                     context.SaveChanges();
+
+                    var deletedPosts = !context.Posts.AsNoTracking().Any();
+
+                    results[deleteBehavior] =
+                        deletingPosts
+                            ? "Dependents deleted by EF Core"
+                            : deletedPosts
+                                ? "Dependents deleted by database"
+                                : settingFksToNull
+                                    ? "Dependent FKs set to null by EF Core"
+                                    : "Dependent FKs set to null by database";
                 }
-            }
-
-            public static Dictionary<DeleteBehavior, string> GatherData(Action<RequiredBlogsContext> action)
-            {
-                var results = new Dictionary<DeleteBehavior, string>();
-
-                foreach (var deleteBehavior in DeleteBehaviors)
+                catch (Exception e)
                 {
-                    try
-                    {
-                        RecreateCleanDatabase(new RequiredBlogsContext(deleteBehavior));
-                        PopulateDatabase(new RequiredBlogsContext(deleteBehavior));
-                    }
-                    catch (Exception e)
-                    {
-                        results[deleteBehavior] = $"`{e.GetType().Name}`";
-                        continue;
-                    }
-
-                    try
-                    {
-                        using var context = new RequiredBlogsContext(deleteBehavior);
-
-                        action(context);
-
-                        context.ChangeTracker.DetectChanges();
-
-                        var deletingPosts = context.ChangeTracker.Entries<Post>().Any(e => e.State == EntityState.Deleted);
-                        var settingFksToNull = context.ChangeTracker.Entries<Post>().Any(e => e.State == EntityState.Modified);
-
-                        context.SaveChanges();
-
-                        var deletedPosts = !context.Posts.AsNoTracking().Any();
-
-                        results[deleteBehavior] =
-                            deletingPosts
-                                ? "Dependents deleted by EF Core"
-                                : deletedPosts
-                                    ? "Dependents deleted by database"
-                                    : settingFksToNull
-                                        ? "Dependent FKs set to null by EF Core"
-                                        : "Dependent FKs set to null by database";
-                    }
-                    catch (Exception e)
-                    {
-                        results[deleteBehavior] = $"`{e.GetType().Name}`";
-                    }
+                    results[deleteBehavior] = $"`{e.GetType().Name}`";
                 }
-
-                return results;
             }
+
+            return results;
+        }
+    }
+
+    public class RequiredBlogsContext : DbContext
+    {
+        private readonly DeleteBehavior _deleteBehavior;
+        private readonly bool _quiet;
+
+        public RequiredBlogsContext(DeleteBehavior deleteBehavior, bool quiet = true)
+        {
+            _deleteBehavior = deleteBehavior;
+            _quiet = quiet;
         }
 
-        public class RequiredBlogsContext : DbContext
+        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Post> Posts { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            private readonly DeleteBehavior _deleteBehavior;
-            private readonly bool _quiet;
+            modelBuilder
+                .Entity<Blog>()
+                .HasMany(e => e.Posts)
+                .WithOne(e => e.Blog)
+                .OnDelete(_deleteBehavior);
+        }
 
-            public RequiredBlogsContext(DeleteBehavior deleteBehavior, bool quiet = true)
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder
+                .EnableServiceProviderCaching(false)
+                .EnableSensitiveDataLogging()
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;Trusted_Connection=True");
+            //.UseSqlite("DataSource=test.db");
+
+            if (!_quiet)
             {
-                _deleteBehavior = deleteBehavior;
-                _quiet = quiet;
-            }
-
-            public DbSet<Blog> Blogs { get; set; }
-            public DbSet<Post> Posts { get; set; }
-
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                modelBuilder
-                    .Entity<Blog>()
-                    .HasMany(e => e.Posts)
-                    .WithOne(e => e.Blog)
-                    .OnDelete(_deleteBehavior);
-            }
-
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            {
-                optionsBuilder
-                    .EnableServiceProviderCaching(false)
-                    .EnableSensitiveDataLogging()
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;Trusted_Connection=True");
-                //.UseSqlite("DataSource=test.db");
-
-                if (!_quiet)
-                {
-                    optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-                }
+                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
             }
         }
     }

--- a/samples/core/CascadeDeletes/WithDatabaseCycleSamples.cs
+++ b/samples/core/CascadeDeletes/WithDatabaseCycleSamples.cs
@@ -4,178 +4,177 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace DatabaseCycles
+namespace DatabaseCycles;
+
+public static class WithDatabaseCycleSamples
 {
-    public static class WithDatabaseCycleSamples
+    public static void Database_cascade_limitations_1()
     {
-        public static void Database_cascade_limitations_1()
+        Console.WriteLine($">>>> Sample: {nameof(Database_cascade_limitations_1)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Database_cascade_limitations_1
+        using var context = new BlogsContext();
+
+        var owner = context.People.Single(e => e.Name == "ajcvickers");
+        var blog = context.Blogs.Single(e => e.Owner == owner);
+
+        context.Remove(owner);
+
+        context.SaveChanges();
+        #endregion
+
+        Console.WriteLine();
+    }
+
+    public static void Database_cascade_limitations_2()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Database_cascade_limitations_2)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        try
         {
-            Console.WriteLine($">>>> Sample: {nameof(Database_cascade_limitations_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Database_cascade_limitations_1
+            #region Database_cascade_limitations_2
             using var context = new BlogsContext();
 
             var owner = context.People.Single(e => e.Name == "ajcvickers");
-            var blog = context.Blogs.Single(e => e.Owner == owner);
 
             context.Remove(owner);
 
             context.SaveChanges();
             #endregion
-
-            Console.WriteLine();
         }
-
-        public static void Database_cascade_limitations_2()
+        catch (Exception e)
         {
-            Console.WriteLine($">>>> Sample: {nameof(Database_cascade_limitations_2)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            try
+            Console.WriteLine($"{e.GetType().FullName}: {e.Message}");
+            if (e.InnerException != null)
             {
-                #region Database_cascade_limitations_2
-                using var context = new BlogsContext();
-
-                var owner = context.People.Single(e => e.Name == "ajcvickers");
-
-                context.Remove(owner);
-
-                context.SaveChanges();
-                #endregion
+                Console.WriteLine($"{e.InnerException.GetType().FullName}: {e.InnerException.Message}");
             }
-            catch (Exception e)
-            {
-                Console.WriteLine($"{e.GetType().FullName}: {e.Message}");
-                if (e.InnerException != null)
-                {
-                    Console.WriteLine($"{e.InnerException.GetType().FullName}: {e.InnerException.Message}");
-                }
-            }
-
-            Console.WriteLine();
         }
+
+        Console.WriteLine();
+    }
+}
+
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
     }
 
-    public static class Helpers
+    public static void PopulateDatabase()
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        using var context = new BlogsContext(quiet: true);
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-        }
+        var person = new Person { Name = "ajcvickers" };
 
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
-
-            var person = new Person { Name = "ajcvickers" };
-
-            context.Add(
-                new Blog
+        context.Add(
+            new Blog
+            {
+                Owner = person,
+                Name = ".NET Blog",
+                Posts =
                 {
-                    Owner = person,
-                    Name = ".NET Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform...",
-                            Author = person
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language...",
-                            Author = person
-                        },
-                    }
-                });
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform...",
+                        Author = person
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language...",
+                        Author = person
+                    },
+                }
+            });
 
-            context.SaveChanges();
-        }
+        context.SaveChanges();
+    }
+}
+
+#region Model
+public class Blog
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>();
+
+    public int OwnerId { get; set; }
+    public Person Owner { get; set; }
+}
+
+public class Post
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
+
+    public int AuthorId { get; set; }
+    public Person Author { get; set; }
+}
+
+public class Person
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>();
+
+    public Blog OwnedBlog { get; set; }
+}
+#endregion
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
     }
 
-    #region Model
-    public class Blog
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+    public DbSet<Person> People { get; set; }
+
+    #region OnModelCreating
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int Id { get; set; }
-        public string Name { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>();
-
-        public int OwnerId { get; set; }
-        public Person Owner { get; set; }
-    }
-
-    public class Post
-    {
-        public int Id { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-
-        public int AuthorId { get; set; }
-        public Person Author { get; set; }
-    }
-
-    public class Person
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>();
-
-        public Blog OwnedBlog { get; set; }
+        modelBuilder
+            .Entity<Blog>()
+            .HasOne(e => e.Owner)
+            .WithOne(e => e.OwnedBlog)
+            .OnDelete(DeleteBehavior.ClientCascade);
     }
     #endregion
 
-    public class BlogsContext : DbContext
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        private readonly bool _quiet;
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;Trusted_Connection=True");
+        //.UseSqlite("DataSource=test.db");
 
-        public BlogsContext(bool quiet = false)
+        if (!_quiet)
         {
-            _quiet = quiet;
-        }
-
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<Person> People { get; set; }
-
-        #region OnModelCreating
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder
-                .Entity<Blog>()
-                .HasOne(e => e.Owner)
-                .WithOne(e => e.OwnedBlog)
-                .OnDelete(DeleteBehavior.ClientCascade);
-        }
-        #endregion
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Scratch;Trusted_Connection=True");
-            //.UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
-            {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
     }
 }

--- a/samples/core/ChangeTracking/AdditionalChangeTrackingFeatures/DefaultValueSamples.cs
+++ b/samples/core/ChangeTracking/AdditionalChangeTrackingFeatures/DefaultValueSamples.cs
@@ -3,270 +3,269 @@ using System.Diagnostics;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace DefaultValues
+namespace DefaultValues;
+
+public class DefaultValueSamples
 {
-    public class DefaultValueSamples
+    public static void Working_with_default_values_1()
     {
-        public static void Working_with_default_values_1()
+        Console.WriteLine($">>>> Sample: {nameof(Working_with_default_values_1)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+
+        #region Working_with_default_values_1
+        using var context = new BlogsContext();
+
+        context.AddRange(
+            new Token { Name = "A" },
+            new Token { Name = "B", ValidFrom = new DateTime(1111, 11, 11, 11, 11, 11) });
+
+        context.SaveChanges();
+
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        #endregion
+
+        Console.WriteLine();
+    }
+
+    public static void Working_with_default_values_2()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Working_with_default_values_2)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+
+        #region Working_with_default_values_2
+        using var context = new BlogsContext();
+
+        var fooA = new Foo1 { Count = 10 };
+        var fooB = new Foo1 { Count = 0 };
+        var fooC = new Foo1();
+
+        context.AddRange(fooA, fooB, fooC);
+        context.SaveChanges();
+
+        Debug.Assert(fooA.Count == 10);
+        Debug.Assert(fooB.Count == -1); // Not what we want!
+        Debug.Assert(fooC.Count == -1);
+        #endregion
+
+        Console.WriteLine();
+    }
+
+    public static void Working_with_default_values_3()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Working_with_default_values_3)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+
+        #region Working_with_default_values_3
+        using var context = new BlogsContext();
+
+        var fooA = new Foo2 { Count = 10 };
+        var fooB = new Foo2 { Count = 0 };
+        var fooC = new Foo2();
+
+        context.AddRange(fooA, fooB, fooC);
+        context.SaveChanges();
+
+        Debug.Assert(fooA.Count == 10);
+        Debug.Assert(fooB.Count == 0);
+        Debug.Assert(fooC.Count == -1);
+        #endregion
+
+        Console.WriteLine();
+    }
+
+    public static void Working_with_default_values_4()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Working_with_default_values_4)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+
+        #region Working_with_default_values_4
+        using var context = new BlogsContext();
+
+        var fooA = new Foo3 { Count = 10 };
+        var fooB = new Foo3 { Count = 0 };
+        var fooC = new Foo3();
+
+        context.AddRange(fooA, fooB, fooC);
+        context.SaveChanges();
+
+        Debug.Assert(fooA.Count == 10);
+        Debug.Assert(fooB.Count == 0);
+        Debug.Assert(fooC.Count == -1);
+        #endregion
+
+        Console.WriteLine();
+    }
+
+    public static void Working_with_default_values_5()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Working_with_default_values_5)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+
+        #region Working_with_default_values_5
+        using var context = new BlogsContext();
+
+        var userA = new User { Name = "Mac" };
+        var userB = new User { Name = "Alice", IsAuthorized = true };
+        var userC = new User { Name = "Baxter", IsAuthorized = false }; // Always deny Baxter access!
+
+        context.AddRange(userA, userB, userC);
+
+        context.SaveChanges();
+        #endregion
+
+        Console.WriteLine();
+    }
+}
+
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+    }
+}
+
+#region Token
+public class Token
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public DateTime ValidFrom { get; set; }
+}
+#endregion
+
+#region Foo1
+public class Foo1
+{
+    public int Id { get; set; }
+    public int Count { get; set; }
+}
+#endregion
+
+#region Foo2
+public class Foo2
+{
+    public int Id { get; set; }
+    public int? Count { get; set; }
+}
+#endregion
+
+#region Foo3
+public class Foo3
+{
+    public int Id { get; set; }
+
+    private int? _count;
+
+    public int Count
+    {
+        get => _count ?? -1;
+        set => _count = value;
+    }
+}
+#endregion
+
+#region Bar
+public class Bar
+{
+    public int Id { get; set; }
+    public int Count { get; set; }
+}
+#endregion
+
+#region User
+public class User
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+
+    private bool? _isAuthorized;
+
+    public bool IsAuthorized
+    {
+        get => _isAuthorized ?? true;
+        set => _isAuthorized = value;
+    }
+}
+#endregion
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
+    }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
+
+        if (!_quiet)
         {
-            Console.WriteLine($">>>> Sample: {nameof(Working_with_default_values_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-
-            #region Working_with_default_values_1
-            using var context = new BlogsContext();
-
-            context.AddRange(
-                new Token { Name = "A" },
-                new Token { Name = "B", ValidFrom = new DateTime(1111, 11, 11, 11, 11, 11) });
-
-            context.SaveChanges();
-
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            #endregion
-
-            Console.WriteLine();
-        }
-
-        public static void Working_with_default_values_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Working_with_default_values_2)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-
-            #region Working_with_default_values_2
-            using var context = new BlogsContext();
-
-            var fooA = new Foo1 { Count = 10 };
-            var fooB = new Foo1 { Count = 0 };
-            var fooC = new Foo1();
-
-            context.AddRange(fooA, fooB, fooC);
-            context.SaveChanges();
-
-            Debug.Assert(fooA.Count == 10);
-            Debug.Assert(fooB.Count == -1); // Not what we want!
-            Debug.Assert(fooC.Count == -1);
-            #endregion
-
-            Console.WriteLine();
-        }
-
-        public static void Working_with_default_values_3()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Working_with_default_values_3)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-
-            #region Working_with_default_values_3
-            using var context = new BlogsContext();
-
-            var fooA = new Foo2 { Count = 10 };
-            var fooB = new Foo2 { Count = 0 };
-            var fooC = new Foo2();
-
-            context.AddRange(fooA, fooB, fooC);
-            context.SaveChanges();
-
-            Debug.Assert(fooA.Count == 10);
-            Debug.Assert(fooB.Count == 0);
-            Debug.Assert(fooC.Count == -1);
-            #endregion
-
-            Console.WriteLine();
-        }
-
-        public static void Working_with_default_values_4()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Working_with_default_values_4)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-
-            #region Working_with_default_values_4
-            using var context = new BlogsContext();
-
-            var fooA = new Foo3 { Count = 10 };
-            var fooB = new Foo3 { Count = 0 };
-            var fooC = new Foo3();
-
-            context.AddRange(fooA, fooB, fooC);
-            context.SaveChanges();
-
-            Debug.Assert(fooA.Count == 10);
-            Debug.Assert(fooB.Count == 0);
-            Debug.Assert(fooC.Count == -1);
-            #endregion
-
-            Console.WriteLine();
-        }
-
-        public static void Working_with_default_values_5()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Working_with_default_values_5)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-
-            #region Working_with_default_values_5
-            using var context = new BlogsContext();
-
-            var userA = new User { Name = "Mac" };
-            var userB = new User { Name = "Alice", IsAuthorized = true };
-            var userC = new User { Name = "Baxter", IsAuthorized = false }; // Always deny Baxter access!
-
-            context.AddRange(userA, userB, userC);
-
-            context.SaveChanges();
-            #endregion
-
-            Console.WriteLine();
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
     }
 
-    public static class Helpers
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        #region OnModelCreating_Token
+        modelBuilder
+            .Entity<Token>()
+            .Property(e => e.ValidFrom)
+            .HasDefaultValueSql("CURRENT_TIMESTAMP");
+        #endregion
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-        }
-    }
+        #region OnModelCreating_Foo1
+        modelBuilder
+            .Entity<Foo1>()
+            .Property(e => e.Count)
+            .HasDefaultValue(-1);
+        #endregion
 
-    #region Token
-    public class Token
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-        public DateTime ValidFrom { get; set; }
-    }
-    #endregion
+        #region OnModelCreating_Foo2
+        modelBuilder
+            .Entity<Foo2>()
+            .Property(e => e.Count)
+            .HasDefaultValue(-1);
+        #endregion
 
-    #region Foo1
-    public class Foo1
-    {
-        public int Id { get; set; }
-        public int Count { get; set; }
-    }
-    #endregion
+        #region OnModelCreating_Foo3
+        modelBuilder
+            .Entity<Foo3>()
+            .Property(e => e.Count)
+            .HasDefaultValue(-1);
+        #endregion
 
-    #region Foo2
-    public class Foo2
-    {
-        public int Id { get; set; }
-        public int? Count { get; set; }
-    }
-    #endregion
+        #region OnModelCreating_User
+        modelBuilder
+            .Entity<User>()
+            .Property(e => e.IsAuthorized)
+            .HasDefaultValue(true);
+        #endregion
 
-    #region Foo3
-    public class Foo3
-    {
-        public int Id { get; set; }
-
-        private int? _count;
-
-        public int Count
-        {
-            get => _count ?? -1;
-            set => _count = value;
-        }
-    }
-    #endregion
-
-    #region Bar
-    public class Bar
-    {
-        public int Id { get; set; }
-        public int Count { get; set; }
-    }
-    #endregion
-
-    #region User
-    public class User
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-
-        private bool? _isAuthorized;
-
-        public bool IsAuthorized
-        {
-            get => _isAuthorized ?? true;
-            set => _isAuthorized = value;
-        }
-    }
-    #endregion
-
-    public class BlogsContext : DbContext
-    {
-        private readonly bool _quiet;
-
-        public BlogsContext(bool quiet = false)
-        {
-            _quiet = quiet;
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
-            {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            #region OnModelCreating_Token
-            modelBuilder
-                .Entity<Token>()
-                .Property(e => e.ValidFrom)
-                .HasDefaultValueSql("CURRENT_TIMESTAMP");
-            #endregion
-
-            #region OnModelCreating_Foo1
-            modelBuilder
-                .Entity<Foo1>()
-                .Property(e => e.Count)
-                .HasDefaultValue(-1);
-            #endregion
-
-            #region OnModelCreating_Foo2
-            modelBuilder
-                .Entity<Foo2>()
-                .Property(e => e.Count)
-                .HasDefaultValue(-1);
-            #endregion
-
-            #region OnModelCreating_Foo3
-            modelBuilder
-                .Entity<Foo3>()
-                .Property(e => e.Count)
-                .HasDefaultValue(-1);
-            #endregion
-
-            #region OnModelCreating_User
-            modelBuilder
-                .Entity<User>()
-                .Property(e => e.IsAuthorized)
-                .HasDefaultValue(true);
-            #endregion
-
-            #region OnModelCreating_Bar
-            modelBuilder
-                .Entity<Bar>()
-                .Property(e => e.Count)
-                .HasDefaultValue(-1)
-                .ValueGeneratedNever();
-            #endregion
-        }
+        #region OnModelCreating_Bar
+        modelBuilder
+            .Entity<Bar>()
+            .Property(e => e.Count)
+            .HasDefaultValue(-1)
+            .ValueGeneratedNever();
+        #endregion
     }
 }

--- a/samples/core/ChangeTracking/AdditionalChangeTrackingFeatures/Samples.cs
+++ b/samples/core/ChangeTracking/AdditionalChangeTrackingFeatures/Samples.cs
@@ -4,242 +4,241 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace Optional
+namespace Optional;
+
+public class Samples
 {
-    public class Samples
+    public static void DbContext_versus_DbSet_methods_1()
     {
-        public static void DbContext_versus_DbSet_methods_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(DbContext_versus_DbSet_methods_1)}");
-            Console.WriteLine();
+        Console.WriteLine($">>>> Sample: {nameof(DbContext_versus_DbSet_methods_1)}");
+        Console.WriteLine();
 
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-            #region DbContext_versus_DbSet_methods_1
-            using var context = new BlogsContext();
+        #region DbContext_versus_DbSet_methods_1
+        using var context = new BlogsContext();
 
-            var post = context.Posts.Single(e => e.Id == 3);
-            var tag = context.Tags.Single(e => e.Id == 1);
+        var post = context.Posts.Single(e => e.Id == 3);
+        var tag = context.Tags.Single(e => e.Id == 1);
 
-            var joinEntitySet = context.Set<Dictionary<string, int>>("PostTag");
-            var joinEntity = new Dictionary<string, int> { ["PostId"] = post.Id, ["TagId"] = tag.Id };
-            joinEntitySet.Add(joinEntity);
+        var joinEntitySet = context.Set<Dictionary<string, int>>("PostTag");
+        var joinEntity = new Dictionary<string, int> { ["PostId"] = post.Id, ["TagId"] = tag.Id };
+        joinEntitySet.Add(joinEntity);
 
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
 
-            context.SaveChanges();
-            #endregion
+        context.SaveChanges();
+        #endregion
 
-            Console.WriteLine();
-        }
-
-        public static void Temporary_values_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Temporary_values_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Temporary_values_1
-            using var context = new BlogsContext();
-
-            var blog = new Blog { Name = ".NET Blog" };
-
-            context.Add(blog);
-
-            Console.WriteLine($"Blog.Id set on entity is {blog.Id}");
-            Console.WriteLine($"Blog.Id tracked by EF is {context.Entry(blog).Property(e => e.Id).CurrentValue}");
-            #endregion
-
-            Console.WriteLine();
-        }
-
-        public static void Temporary_values_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Temporary_values_2)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-
-            #region Temporary_values_2
-            var blogs = new List<Blog> { new Blog { Id = -1, Name = ".NET Blog" }, new Blog { Id = -2, Name = "Visual Studio Blog" } };
-
-            var posts = new List<Post>
-            {
-                new Post
-                {
-                    Id = -1,
-                    BlogId = -1,
-                    Title = "Announcing the Release of EF Core 5.0",
-                    Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                },
-                new Post
-                {
-                    Id = -2,
-                    BlogId = -2,
-                    Title = "Disassembly improvements for optimized managed debugging",
-                    Content = "If you are focused on squeezing out the last bits of performance for your .NET service or..."
-                }
-            };
-
-            using var context = new BlogsContext();
-
-            foreach (var blog in blogs)
-            {
-                context.Add(blog).Property(e => e.Id).IsTemporary = true;
-            }
-
-            foreach (var post in posts)
-            {
-                context.Add(post).Property(e => e.Id).IsTemporary = true;
-            }
-
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            #endregion
-
-            Console.WriteLine();
-        }
+        Console.WriteLine();
     }
 
-    public static class Helpers
+    public static void Temporary_values_1()
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        Console.WriteLine($">>>> Sample: {nameof(Temporary_values_1)}");
+        Console.WriteLine();
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Temporary_values_1
+        using var context = new BlogsContext();
+
+        var blog = new Blog { Name = ".NET Blog" };
+
+        context.Add(blog);
+
+        Console.WriteLine($"Blog.Id set on entity is {blog.Id}");
+        Console.WriteLine($"Blog.Id tracked by EF is {context.Entry(blog).Property(e => e.Id).CurrentValue}");
+        #endregion
+
+        Console.WriteLine();
+    }
+
+    public static void Temporary_values_2()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Temporary_values_2)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+
+        #region Temporary_values_2
+        var blogs = new List<Blog> { new Blog { Id = -1, Name = ".NET Blog" }, new Blog { Id = -2, Name = "Visual Studio Blog" } };
+
+        var posts = new List<Post>
+        {
+            new Post
+            {
+                Id = -1,
+                BlogId = -1,
+                Title = "Announcing the Release of EF Core 5.0",
+                Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+            },
+            new Post
+            {
+                Id = -2,
+                BlogId = -2,
+                Title = "Disassembly improvements for optimized managed debugging",
+                Content = "If you are focused on squeezing out the last bits of performance for your .NET service or..."
+            }
+        };
+
+        using var context = new BlogsContext();
+
+        foreach (var blog in blogs)
+        {
+            context.Add(blog).Property(e => e.Id).IsTemporary = true;
         }
 
-        public static void PopulateDatabase()
+        foreach (var post in posts)
         {
-            using var context = new BlogsContext(quiet: true);
+            context.Add(post).Property(e => e.Id).IsTemporary = true;
+        }
 
-            context.AddRange(
-                new Blog
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        #endregion
+
+        Console.WriteLine();
+    }
+}
+
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+    }
+
+    public static void PopulateDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.AddRange(
+            new Blog
+            {
+                Name = ".NET Blog",
+                Posts =
                 {
-                    Name = ".NET Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
                     },
                 },
-                new Blog
+            },
+            new Blog
+            {
+                Name = "Visual Studio Blog",
+                Posts =
                 {
-                    Name = "Visual Studio Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Disassembly improvements for optimized managed debugging",
-                            Content =
-                                "If you are focused on squeezing out the last bits of performance for your .NET service or..."
-                        },
-                        new Post
-                        {
-                            Title = "Database Profiling with Visual Studio",
-                            Content = "Examine when database queries were executed and measure how long the take using..."
-                        },
-                    }
-                },
-                new Tag { Text = ".NET" },
-                new Tag { Text = "Visual Studio" },
-                new Tag { Text = "EF Core" });
+                        Title = "Disassembly improvements for optimized managed debugging",
+                        Content =
+                            "If you are focused on squeezing out the last bits of performance for your .NET service or..."
+                    },
+                    new Post
+                    {
+                        Title = "Database Profiling with Visual Studio",
+                        Content = "Examine when database queries were executed and measure how long the take using..."
+                    },
+                }
+            },
+            new Tag { Text = ".NET" },
+            new Tag { Text = "Visual Studio" },
+            new Tag { Text = "EF Core" });
 
-            context.SaveChanges();
+        context.SaveChanges();
+    }
+}
+
+#region Model
+public class Blog
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>();
+}
+
+public class Post
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int? BlogId { get; set; }
+    public Blog Blog { get; set; }
+
+    public IList<Tag> Tags { get; } = new List<Tag>();
+}
+
+public class Tag
+{
+    public int Id { get; set; } // Primary key
+    public string Text { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>(); // Collection navigation
+}
+#endregion
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
+    }
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+    public DbSet<Tag> Tags { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
+
+        if (!_quiet)
+        {
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
     }
 
-    #region Model
-    public class Blog
+    #region OnModelCreating
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int Id { get; set; }
-        public string Name { get; set; }
+        modelBuilder
+            .SharedTypeEntity<Dictionary<string, int>>(
+                "PostTag",
+                b =>
+                {
+                    b.IndexerProperty<int>("TagId");
+                    b.IndexerProperty<int>("PostId");
+                });
 
-        public IList<Post> Posts { get; } = new List<Post>();
-    }
-
-    public class Post
-    {
-        public int Id { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int? BlogId { get; set; }
-        public Blog Blog { get; set; }
-
-        public IList<Tag> Tags { get; } = new List<Tag>();
-    }
-
-    public class Tag
-    {
-        public int Id { get; set; } // Primary key
-        public string Text { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>(); // Collection navigation
+        modelBuilder.Entity<Post>()
+            .HasMany(p => p.Tags)
+            .WithMany(p => p.Posts)
+            .UsingEntity<Dictionary<string, int>>(
+                "PostTag",
+                j => j.HasOne<Tag>().WithMany(),
+                j => j.HasOne<Post>().WithMany());
     }
     #endregion
-
-    public class BlogsContext : DbContext
-    {
-        private readonly bool _quiet;
-
-        public BlogsContext(bool quiet = false)
-        {
-            _quiet = quiet;
-        }
-
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<Tag> Tags { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
-            {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
-        }
-
-        #region OnModelCreating
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder
-                .SharedTypeEntity<Dictionary<string, int>>(
-                    "PostTag",
-                    b =>
-                    {
-                        b.IndexerProperty<int>("TagId");
-                        b.IndexerProperty<int>("PostId");
-                    });
-
-            modelBuilder.Entity<Post>()
-                .HasMany(p => p.Tags)
-                .WithMany(p => p.Posts)
-                .UsingEntity<Dictionary<string, int>>(
-                    "PostTag",
-                    j => j.HasOne<Tag>().WithMany(),
-                    j => j.HasOne<Post>().WithMany());
-        }
-        #endregion
-    }
 }

--- a/samples/core/ChangeTracking/ChangeDetectionAndNotifications/ChangeTrackingProxiesSamples.cs
+++ b/samples/core/ChangeTracking/ChangeDetectionAndNotifications/ChangeTrackingProxiesSamples.cs
@@ -5,152 +5,151 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace Proxies
+namespace Proxies;
+
+public class ChangeTrackingProxiesSamples
 {
-    public class ChangeTrackingProxiesSamples
+    public static void Change_tracking_proxies_1()
     {
-        public static void Change_tracking_proxies_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Change_tracking_proxies_1)}");
-            Console.WriteLine();
+        Console.WriteLine($">>>> Sample: {nameof(Change_tracking_proxies_1)}");
+        Console.WriteLine();
 
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-            #region Change_tracking_proxies_1
-            using var context = new BlogsContext();
-            var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
+        #region Change_tracking_proxies_1
+        using var context = new BlogsContext();
+        var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
 
-            // Change a property value
-            blog.Name = ".NET Blog (Updated!)";
+        // Change a property value
+        blog.Name = ".NET Blog (Updated!)";
 
-            // Add a new entity to a navigation
-            blog.Posts.Add(
-                context.CreateProxy<Post>(
-                    p =>
-                    {
-                        p.Title = "What’s next for System.Text.Json?";
-                        p.Content = ".NET 5.0 was released recently and has come with many...";
-                    }));
+        // Add a new entity to a navigation
+        blog.Posts.Add(
+            context.CreateProxy<Post>(
+                p =>
+                {
+                    p.Title = "What’s next for System.Text.Json?";
+                    p.Content = ".NET 5.0 was released recently and has come with many...";
+                }));
 
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            #endregion
-
-            Console.WriteLine();
-        }
-    }
-
-    public static class Helpers
-    {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
-
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-        }
-
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
-
-            context.AddRange(
-                context.CreateProxy<Blog>(
-                    b =>
-                    {
-                        b.Name = ".NET Blog";
-                        b.Posts.Add(
-                            context.CreateProxy<Post>(
-                                p =>
-                                {
-                                    p.Title = "Announcing the Release of EF Core 5.0";
-                                    p.Content = "Announcing the release of EF Core 5.0, a full featured cross-platform...";
-                                }));
-                        b.Posts.Add(
-                            context.CreateProxy<Post>(
-                                p =>
-                                {
-                                    p.Title = "Announcing F# 5";
-                                    p.Content = "F# 5 is the latest version of F#, the functional programming language...";
-                                }));
-                    }),
-                context.CreateProxy<Blog>(
-                    b =>
-                    {
-                        b.Name = "Visual Studio Blog";
-                        b.Posts.Add(
-                            context.CreateProxy<Post>(
-                                p =>
-                                {
-                                    p.Title = "Disassembly improvements for optimized managed debugging";
-                                    p.Content =
-                                        "If you are focused on squeezing out the last bits of performance for your .NET service or...";
-                                }));
-                        b.Posts.Add(
-                            context.CreateProxy<Post>(
-                                p =>
-                                {
-                                    p.Title = "Database Profiling with Visual Studio";
-                                    p.Content = "Examine when database queries were executed and measure how long the take using...";
-                                }));
-                    }));
-
-            context.SaveChanges();
-        }
-    }
-
-    #region Model
-    public class Blog
-    {
-        public virtual int Id { get; set; }
-        public virtual string Name { get; set; }
-
-        public virtual IList<Post> Posts { get; } = new ObservableCollection<Post>();
-    }
-
-    public class Post
-    {
-        public virtual int Id { get; set; }
-        public virtual string Title { get; set; }
-        public virtual string Content { get; set; }
-
-        public virtual int BlogId { get; set; }
-        public virtual Blog Blog { get; set; }
-    }
-    #endregion
-
-    public class BlogsContextBase : DbContext
-    {
-        #region OnConfiguring
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.UseChangeTrackingProxies();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
         #endregion
+
+        Console.WriteLine();
+    }
+}
+
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
     }
 
-    public class BlogsContext : BlogsContextBase
+    public static void PopulateDatabase()
     {
-        private readonly bool _quiet;
+        using var context = new BlogsContext(quiet: true);
 
-        public BlogsContext(bool quiet = false)
+        context.AddRange(
+            context.CreateProxy<Blog>(
+                b =>
+                {
+                    b.Name = ".NET Blog";
+                    b.Posts.Add(
+                        context.CreateProxy<Post>(
+                            p =>
+                            {
+                                p.Title = "Announcing the Release of EF Core 5.0";
+                                p.Content = "Announcing the release of EF Core 5.0, a full featured cross-platform...";
+                            }));
+                    b.Posts.Add(
+                        context.CreateProxy<Post>(
+                            p =>
+                            {
+                                p.Title = "Announcing F# 5";
+                                p.Content = "F# 5 is the latest version of F#, the functional programming language...";
+                            }));
+                }),
+            context.CreateProxy<Blog>(
+                b =>
+                {
+                    b.Name = "Visual Studio Blog";
+                    b.Posts.Add(
+                        context.CreateProxy<Post>(
+                            p =>
+                            {
+                                p.Title = "Disassembly improvements for optimized managed debugging";
+                                p.Content =
+                                    "If you are focused on squeezing out the last bits of performance for your .NET service or...";
+                            }));
+                    b.Posts.Add(
+                        context.CreateProxy<Post>(
+                            p =>
+                            {
+                                p.Title = "Database Profiling with Visual Studio";
+                                p.Content = "Examine when database queries were executed and measure how long the take using...";
+                            }));
+                }));
+
+        context.SaveChanges();
+    }
+}
+
+#region Model
+public class Blog
+{
+    public virtual int Id { get; set; }
+    public virtual string Name { get; set; }
+
+    public virtual IList<Post> Posts { get; } = new ObservableCollection<Post>();
+}
+
+public class Post
+{
+    public virtual int Id { get; set; }
+    public virtual string Title { get; set; }
+    public virtual string Content { get; set; }
+
+    public virtual int BlogId { get; set; }
+    public virtual Blog Blog { get; set; }
+}
+#endregion
+
+public class BlogsContextBase : DbContext
+{
+    #region OnConfiguring
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseChangeTrackingProxies();
+    #endregion
+}
+
+public class BlogsContext : BlogsContextBase
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
+    }
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
+
+        if (!_quiet)
         {
-            _quiet = quiet;
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
 
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
-            {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
-
-            base.OnConfiguring(optionsBuilder);
-        }
+        base.OnConfiguring(optionsBuilder);
     }
 }

--- a/samples/core/ChangeTracking/ChangeDetectionAndNotifications/NotificationEntitiesSamples.cs
+++ b/samples/core/ChangeTracking/ChangeDetectionAndNotifications/NotificationEntitiesSamples.cs
@@ -6,228 +6,227 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace Notification
+namespace Notification;
+
+public class NotificationEntitiesSamples
 {
-    public class NotificationEntitiesSamples
+    public static void Notification_entities_1()
     {
-        public static void Notification_entities_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Notification_entities_1)}");
-            Console.WriteLine();
+        Console.WriteLine($">>>> Sample: {nameof(Notification_entities_1)}");
+        Console.WriteLine();
 
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-            #region Notification_entities_1
-            using var context = new BlogsContext();
-            var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
+        #region Notification_entities_1
+        using var context = new BlogsContext();
+        var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
 
-            // Change a property value
-            blog.Name = ".NET Blog (Updated!)";
+        // Change a property value
+        blog.Name = ".NET Blog (Updated!)";
 
-            // Add a new entity to a navigation
-            blog.Posts.Add(
-                new Post
-                {
-                    Title = "What’s next for System.Text.Json?", Content = ".NET 5.0 was released recently and has come with many..."
-                });
+        // Add a new entity to a navigation
+        blog.Posts.Add(
+            new Post
+            {
+                Title = "What’s next for System.Text.Json?", Content = ".NET 5.0 was released recently and has come with many..."
+            });
 
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            #endregion
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        #endregion
 
-            Console.WriteLine();
-        }
+        Console.WriteLine();
+    }
+}
+
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
     }
 
-    public static class Helpers
+    public static void PopulateDatabase()
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        using var context = new BlogsContext(quiet: true);
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-        }
-
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
-
-            context.AddRange(
-                new Blog
+        context.AddRange(
+            new Blog
+            {
+                Name = ".NET Blog",
+                Posts =
                 {
-                    Name = ".NET Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
                     },
                 },
-                new Blog
+            },
+            new Blog
+            {
+                Name = "Visual Studio Blog",
+                Posts =
                 {
-                    Name = "Visual Studio Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Disassembly improvements for optimized managed debugging",
-                            Content =
-                                "If you are focused on squeezing out the last bits of performance for your .NET service or..."
-                        },
-                        new Post
-                        {
-                            Title = "Database Profiling with Visual Studio",
-                            Content = "Examine when database queries were executed and measure how long the take using..."
-                        },
-                    }
-                });
+                        Title = "Disassembly improvements for optimized managed debugging",
+                        Content =
+                            "If you are focused on squeezing out the last bits of performance for your .NET service or..."
+                    },
+                    new Post
+                    {
+                        Title = "Database Profiling with Visual Studio",
+                        Content = "Examine when database queries were executed and measure how long the take using..."
+                    },
+                }
+            });
 
-            context.SaveChanges();
+        context.SaveChanges();
+    }
+}
+
+#region Model
+public class Blog : INotifyPropertyChanging, INotifyPropertyChanged
+{
+    public event PropertyChangingEventHandler PropertyChanging;
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    private int _id;
+
+    public int Id
+    {
+        get => _id;
+        set
+        {
+            PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(nameof(Id)));
+            _id = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Id)));
         }
     }
 
-    #region Model
-    public class Blog : INotifyPropertyChanging, INotifyPropertyChanged
+    private string _name;
+
+    public string Name
     {
-        public event PropertyChangingEventHandler PropertyChanging;
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        private int _id;
-
-        public int Id
+        get => _name;
+        set
         {
-            get => _id;
-            set
-            {
-                PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(nameof(Id)));
-                _id = value;
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Id)));
-            }
-        }
-
-        private string _name;
-
-        public string Name
-        {
-            get => _name;
-            set
-            {
-                PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(nameof(Name)));
-                _name = value;
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Name)));
-            }
-        }
-
-        public IList<Post> Posts { get; } = new ObservableCollection<Post>();
-    }
-    #endregion
-
-    public class Post : INotifyPropertyChanging, INotifyPropertyChanged
-    {
-        public event PropertyChangingEventHandler PropertyChanging;
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        private int _id;
-
-        public int Id
-        {
-            get => _id;
-            set
-            {
-                PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(nameof(Id)));
-                _id = value;
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Id)));
-            }
-        }
-
-        private string _title;
-
-        public string Title
-        {
-            get => _title;
-            set
-            {
-                PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(nameof(Title)));
-                _title = value;
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Title)));
-            }
-        }
-
-        private string _content;
-
-        public string Content
-        {
-            get => _content;
-            set
-            {
-                PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(nameof(Content)));
-                _content = value;
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Content)));
-            }
-        }
-
-        private int? _blogId;
-
-        public int? BlogId
-        {
-            get => _blogId;
-            set
-            {
-                PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(nameof(BlogId)));
-                _blogId = value;
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(BlogId)));
-            }
-        }
-
-        private Blog _blog;
-
-        public Blog Blog
-        {
-            get => _blog;
-            set
-            {
-                PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(nameof(Blog)));
-                _blog = value;
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Blog)));
-            }
+            PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(nameof(Name)));
+            _name = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Name)));
         }
     }
 
-    public class BlogsContext : DbContext
+    public IList<Post> Posts { get; } = new ObservableCollection<Post>();
+}
+#endregion
+
+public class Post : INotifyPropertyChanging, INotifyPropertyChanged
+{
+    public event PropertyChangingEventHandler PropertyChanging;
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    private int _id;
+
+    public int Id
     {
-        private readonly bool _quiet;
-
-        public BlogsContext(bool quiet = false)
+        get => _id;
+        set
         {
-            _quiet = quiet;
+            PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(nameof(Id)));
+            _id = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Id)));
         }
+    }
 
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+    private string _title;
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    public string Title
+    {
+        get => _title;
+        set
         {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
-            {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
+            PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(nameof(Title)));
+            _title = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Title)));
         }
+    }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+    private string _content;
+
+    public string Content
+    {
+        get => _content;
+        set
         {
-            modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
+            PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(nameof(Content)));
+            _content = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Content)));
         }
+    }
+
+    private int? _blogId;
+
+    public int? BlogId
+    {
+        get => _blogId;
+        set
+        {
+            PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(nameof(BlogId)));
+            _blogId = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(BlogId)));
+        }
+    }
+
+    private Blog _blog;
+
+    public Blog Blog
+    {
+        get => _blog;
+        set
+        {
+            PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(nameof(Blog)));
+            _blog = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Blog)));
+        }
+    }
+}
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
+    }
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
+
+        if (!_quiet)
+        {
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
+        }
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
     }
 }

--- a/samples/core/ChangeTracking/ChangeDetectionAndNotifications/NotificationWithBaseSamples.cs
+++ b/samples/core/ChangeTracking/ChangeDetectionAndNotifications/NotificationWithBaseSamples.cs
@@ -7,204 +7,203 @@ using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace NotificationWithBase
+namespace NotificationWithBase;
+
+public class NotificationWithBaseSamples
 {
-    public class NotificationWithBaseSamples
+    public static void Notification_entities_2()
     {
-        public static void Notification_entities_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Notification_entities_2)}");
-            Console.WriteLine();
+        Console.WriteLine($">>>> Sample: {nameof(Notification_entities_2)}");
+        Console.WriteLine();
 
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-            #region Notification_entities_2
-            using var context = new BlogsContext();
-            var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
+        #region Notification_entities_2
+        using var context = new BlogsContext();
+        var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
 
-            // Change a property value
-            blog.Name = ".NET Blog (Updated!)";
+        // Change a property value
+        blog.Name = ".NET Blog (Updated!)";
 
-            // Add a new entity to a navigation
-            blog.Posts.Add(
-                new Post
-                {
-                    Title = "What’s next for System.Text.Json?", Content = ".NET 5.0 was released recently and has come with many..."
-                });
+        // Add a new entity to a navigation
+        blog.Posts.Add(
+            new Post
+            {
+                Title = "What’s next for System.Text.Json?", Content = ".NET 5.0 was released recently and has come with many..."
+            });
 
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            #endregion
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        #endregion
 
-            Console.WriteLine();
-        }
+        Console.WriteLine();
+    }
+}
+
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
     }
 
-    public static class Helpers
+    public static void PopulateDatabase()
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        using var context = new BlogsContext(quiet: true);
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-        }
-
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
-
-            context.AddRange(
-                new Blog
+        context.AddRange(
+            new Blog
+            {
+                Name = ".NET Blog",
+                Posts =
                 {
-                    Name = ".NET Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
                     },
                 },
-                new Blog
+            },
+            new Blog
+            {
+                Name = "Visual Studio Blog",
+                Posts =
                 {
-                    Name = "Visual Studio Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Disassembly improvements for optimized managed debugging",
-                            Content =
-                                "If you are focused on squeezing out the last bits of performance for your .NET service or..."
-                        },
-                        new Post
-                        {
-                            Title = "Database Profiling with Visual Studio",
-                            Content = "Examine when database queries were executed and measure how long the take using..."
-                        },
-                    }
-                });
+                        Title = "Disassembly improvements for optimized managed debugging",
+                        Content =
+                            "If you are focused on squeezing out the last bits of performance for your .NET service or..."
+                    },
+                    new Post
+                    {
+                        Title = "Database Profiling with Visual Studio",
+                        Content = "Examine when database queries were executed and measure how long the take using..."
+                    },
+                }
+            });
 
-            context.SaveChanges();
+        context.SaveChanges();
+    }
+}
+
+public class Post : NotifyingEntity
+{
+    private int _id;
+    private string _title;
+    private string _content;
+    private int? _blogId;
+    private Blog _blog;
+
+    public int Id
+    {
+        get => _id;
+        set => SetWithNotify(value, out _id);
+    }
+
+    public string Title
+    {
+        get => _title;
+        set => SetWithNotify(value, out _title);
+    }
+
+    public string Content
+    {
+        get => _content;
+        set => SetWithNotify(value, out _content);
+    }
+
+    public int? BlogId
+    {
+        get => _blogId;
+        set => SetWithNotify(value, out _blogId);
+    }
+
+    public Blog Blog
+    {
+        get => _blog;
+        set => SetWithNotify(value, out _blog);
+    }
+}
+
+#region Model
+public class Blog : NotifyingEntity
+{
+    private int _id;
+
+    public int Id
+    {
+        get => _id;
+        set => SetWithNotify(value, out _id);
+    }
+
+    private string _name;
+
+    public string Name
+    {
+        get => _name;
+        set => SetWithNotify(value, out _name);
+    }
+
+    public IList<Post> Posts { get; } = new ObservableCollection<Post>();
+}
+
+public abstract class NotifyingEntity : INotifyPropertyChanging, INotifyPropertyChanged
+{
+    protected void SetWithNotify<T>(T value, out T field, [CallerMemberName] string propertyName = "")
+    {
+        NotifyChanging(propertyName);
+        field = value;
+        NotifyChanged(propertyName);
+    }
+
+    public event PropertyChangingEventHandler PropertyChanging;
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    private void NotifyChanged(string propertyName)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+    private void NotifyChanging(string propertyName)
+        => PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
+}
+#endregion
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
+    }
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
+
+        if (!_quiet)
+        {
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
     }
 
-    public class Post : NotifyingEntity
+    #region OnModelCreating
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        private int _id;
-        private string _title;
-        private string _content;
-        private int? _blogId;
-        private Blog _blog;
-
-        public int Id
-        {
-            get => _id;
-            set => SetWithNotify(value, out _id);
-        }
-
-        public string Title
-        {
-            get => _title;
-            set => SetWithNotify(value, out _title);
-        }
-
-        public string Content
-        {
-            get => _content;
-            set => SetWithNotify(value, out _content);
-        }
-
-        public int? BlogId
-        {
-            get => _blogId;
-            set => SetWithNotify(value, out _blogId);
-        }
-
-        public Blog Blog
-        {
-            get => _blog;
-            set => SetWithNotify(value, out _blog);
-        }
-    }
-
-    #region Model
-    public class Blog : NotifyingEntity
-    {
-        private int _id;
-
-        public int Id
-        {
-            get => _id;
-            set => SetWithNotify(value, out _id);
-        }
-
-        private string _name;
-
-        public string Name
-        {
-            get => _name;
-            set => SetWithNotify(value, out _name);
-        }
-
-        public IList<Post> Posts { get; } = new ObservableCollection<Post>();
-    }
-
-    public abstract class NotifyingEntity : INotifyPropertyChanging, INotifyPropertyChanged
-    {
-        protected void SetWithNotify<T>(T value, out T field, [CallerMemberName] string propertyName = "")
-        {
-            NotifyChanging(propertyName);
-            field = value;
-            NotifyChanged(propertyName);
-        }
-
-        public event PropertyChangingEventHandler PropertyChanging;
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        private void NotifyChanged(string propertyName)
-            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-
-        private void NotifyChanging(string propertyName)
-            => PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
+        modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
     }
     #endregion
-
-    public class BlogsContext : DbContext
-    {
-        private readonly bool _quiet;
-
-        public BlogsContext(bool quiet = false)
-        {
-            _quiet = quiet;
-        }
-
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
-            {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
-        }
-
-        #region OnModelCreating
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
-        }
-        #endregion
-    }
 }

--- a/samples/core/ChangeTracking/ChangeDetectionAndNotifications/SnapshotSamples.cs
+++ b/samples/core/ChangeTracking/ChangeDetectionAndNotifications/SnapshotSamples.cs
@@ -4,204 +4,203 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace Snapshot
+namespace Snapshot;
+
+public class SnapshotSamples
 {
-    public class SnapshotSamples
+    public static void Snapshot_change_tracking_1()
     {
-        public static void Snapshot_change_tracking_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Snapshot_change_tracking_1)}");
-            Console.WriteLine();
+        Console.WriteLine($">>>> Sample: {nameof(Snapshot_change_tracking_1)}");
+        Console.WriteLine();
 
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-            #region Snapshot_change_tracking_1
-            using var context = new BlogsContext();
-            var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
+        #region Snapshot_change_tracking_1
+        using var context = new BlogsContext();
+        var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
 
-            // Change a property value
-            blog.Name = ".NET Blog (Updated!)";
+        // Change a property value
+        blog.Name = ".NET Blog (Updated!)";
 
-            // Add a new entity to a navigation
-            blog.Posts.Add(
-                new Post
-                {
-                    Title = "What’s next for System.Text.Json?", Content = ".NET 5.0 was released recently and has come with many..."
-                });
+        // Add a new entity to a navigation
+        blog.Posts.Add(
+            new Post
+            {
+                Title = "What’s next for System.Text.Json?", Content = ".NET 5.0 was released recently and has come with many..."
+            });
 
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            #endregion
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        #endregion
 
-            Console.WriteLine();
-        }
-
-        public static void Snapshot_change_tracking_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Snapshot_change_tracking_2)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Snapshot_change_tracking_2
-            using var context = new BlogsContext();
-            var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
-
-            // Change a property value
-            context.Entry(blog).Property(e => e.Name).CurrentValue = ".NET Blog (Updated!)";
-
-            // Add a new entity to the DbContext
-            context.Add(
-                new Post
-                {
-                    Blog = blog,
-                    Title = "What’s next for System.Text.Json?",
-                    Content = ".NET 5.0 was released recently and has come with many..."
-                });
-
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            #endregion
-
-            Console.WriteLine();
-        }
+        Console.WriteLine();
     }
 
-    public static class Helpers
+    public static void Snapshot_change_tracking_2()
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        Console.WriteLine($">>>> Sample: {nameof(Snapshot_change_tracking_2)}");
+        Console.WriteLine();
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-        }
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        #region Snapshot_change_tracking_2
+        using var context = new BlogsContext();
+        var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
 
-            context.AddRange(
-                new Blog
+        // Change a property value
+        context.Entry(blog).Property(e => e.Name).CurrentValue = ".NET Blog (Updated!)";
+
+        // Add a new entity to the DbContext
+        context.Add(
+            new Post
+            {
+                Blog = blog,
+                Title = "What’s next for System.Text.Json?",
+                Content = ".NET 5.0 was released recently and has come with many..."
+            });
+
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        #endregion
+
+        Console.WriteLine();
+    }
+}
+
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+    }
+
+    public static void PopulateDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.AddRange(
+            new Blog
+            {
+                Name = ".NET Blog",
+                Posts =
                 {
-                    Name = ".NET Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
                     },
                 },
-                new Blog
+            },
+            new Blog
+            {
+                Name = "Visual Studio Blog",
+                Posts =
                 {
-                    Name = "Visual Studio Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Disassembly improvements for optimized managed debugging",
-                            Content =
-                                "If you are focused on squeezing out the last bits of performance for your .NET service or..."
-                        },
-                        new Post
-                        {
-                            Title = "Database Profiling with Visual Studio",
-                            Content = "Examine when database queries were executed and measure how long the take using..."
-                        },
-                    }
-                });
-
-            context.SaveChanges();
-        }
-    }
-
-    public class Blog
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>();
-    }
-
-    public class Post
-    {
-        public int Id { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int? BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
-
-    public class PostTag
-    {
-        public int PostId { get; set; }
-        public int TagId { get; set; }
-
-        public DateTime TaggedOn { get; set; }
-        public string TaggedBy { get; set; }
-    }
-
-    public class BlogsContext : DbContext
-    {
-        private readonly bool _quiet;
-
-        public BlogsContext(bool quiet = false)
-        {
-            _quiet = quiet;
-        }
-
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
-            {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<PostTag>().HasKey(e => new { e.PostId, e.TagId });
-        }
-
-        #region SaveChanges
-        public override int SaveChanges()
-        {
-            foreach (var entityEntry in ChangeTracker.Entries<PostTag>()) // Detects changes automatically
-            {
-                if (entityEntry.State == EntityState.Added)
-                {
-                    entityEntry.Entity.TaggedBy = "ajcvickers";
-                    entityEntry.Entity.TaggedOn = DateTime.Now;
+                        Title = "Disassembly improvements for optimized managed debugging",
+                        Content =
+                            "If you are focused on squeezing out the last bits of performance for your .NET service or..."
+                    },
+                    new Post
+                    {
+                        Title = "Database Profiling with Visual Studio",
+                        Content = "Examine when database queries were executed and measure how long the take using..."
+                    },
                 }
-            }
+            });
 
-            try
+        context.SaveChanges();
+    }
+}
+
+public class Blog
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>();
+}
+
+public class Post
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int? BlogId { get; set; }
+    public Blog Blog { get; set; }
+}
+
+public class PostTag
+{
+    public int PostId { get; set; }
+    public int TagId { get; set; }
+
+    public DateTime TaggedOn { get; set; }
+    public string TaggedBy { get; set; }
+}
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
+    }
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
+
+        if (!_quiet)
+        {
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
+        }
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<PostTag>().HasKey(e => new { e.PostId, e.TagId });
+    }
+
+    #region SaveChanges
+    public override int SaveChanges()
+    {
+        foreach (var entityEntry in ChangeTracker.Entries<PostTag>()) // Detects changes automatically
+        {
+            if (entityEntry.State == EntityState.Added)
             {
-                ChangeTracker.AutoDetectChangesEnabled = false;
-                return base.SaveChanges(); // Avoid automatically detecting changes again here
-            }
-            finally
-            {
-                ChangeTracker.AutoDetectChangesEnabled = true;
+                entityEntry.Entity.TaggedBy = "ajcvickers";
+                entityEntry.Entity.TaggedOn = DateTime.Now;
             }
         }
-        #endregion
+
+        try
+        {
+            ChangeTracker.AutoDetectChangesEnabled = false;
+            return base.SaveChanges(); // Avoid automatically detecting changes again here
+        }
+        finally
+        {
+            ChangeTracker.AutoDetectChangesEnabled = true;
+        }
     }
+    #endregion
 }

--- a/samples/core/ChangeTracking/ChangeTrackingInEFCore/ExplicitKeysRequiredSamples.cs
+++ b/samples/core/ChangeTracking/ChangeTrackingInEFCore/ExplicitKeysRequiredSamples.cs
@@ -5,134 +5,133 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace ExplicitKeysRequired
+namespace ExplicitKeysRequired;
+
+public static class ExplicitKeysRequiredSamples
 {
-    public static class ExplicitKeysRequiredSamples
+    public static void Deleting_principal_parent_entities_1()
     {
-        public static void Deleting_principal_parent_entities_1()
+        Console.WriteLine($">>>> Sample: {nameof(Deleting_principal_parent_entities_1)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        var blog = GetDisconnectedBlogAndPosts();
+
+        #region Deleting_principal_parent_entities_1
+        // Attach a blog and associated posts
+        context.Attach(blog);
+
+        // Mark the blog as deleted
+        context.Remove(blog);
+        #endregion
+
+        Console.WriteLine("Before SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine("After SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        Console.WriteLine();
+
+        Blog GetDisconnectedBlogAndPosts()
         {
-            Console.WriteLine($">>>> Sample: {nameof(Deleting_principal_parent_entities_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var blog = GetDisconnectedBlogAndPosts();
-
-            #region Deleting_principal_parent_entities_1
-            // Attach a blog and associated posts
-            context.Attach(blog);
-
-            // Mark the blog as deleted
-            context.Remove(blog);
-            #endregion
-
-            Console.WriteLine("Before SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine("After SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            Console.WriteLine();
-
-            Blog GetDisconnectedBlogAndPosts()
-            {
-                using var tempContext = new BlogsContext();
-                return tempContext.Blogs.Include(e => e.Posts).Single();
-            }
+            using var tempContext = new BlogsContext();
+            return tempContext.Blogs.Include(e => e.Posts).Single();
         }
     }
+}
 
-    public static class Helpers
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        using var context = new BlogsContext(quiet: true);
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-        }
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+    }
 
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+    public static void PopulateDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
 
-            context.Add(
-                new Blog
+        context.Add(
+            new Blog
+            {
+                Id = 1,
+                Name = ".NET Blog",
+                Posts =
                 {
-                    Id = 1,
-                    Name = ".NET Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Id = 1,
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Id = 2,
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
-                    }
-                });
+                        Id = 1,
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Id = 2,
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
+                    },
+                }
+            });
 
-            context.SaveChanges();
-        }
+        context.SaveChanges();
+    }
+}
+
+#region Model
+public class Blog
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public int Id { get; set; }
+
+    public string Name { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>();
+}
+
+public class Post
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public int Id { get; set; }
+
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
+}
+#endregion
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
     }
 
-    #region Model
-    public class Blog
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public int Id { get; set; }
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
 
-        public string Name { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>();
-    }
-
-    public class Post
-    {
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public int Id { get; set; }
-
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
-    #endregion
-
-    public class BlogsContext : DbContext
-    {
-        private readonly bool _quiet;
-
-        public BlogsContext(bool quiet = false)
+        if (!_quiet)
         {
-            _quiet = quiet;
-        }
-
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
-            {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
     }
 }

--- a/samples/core/ChangeTracking/ChangeTrackingInEFCore/ExplicitKeysSamples.cs
+++ b/samples/core/ChangeTracking/ChangeTrackingInEFCore/ExplicitKeysSamples.cs
@@ -5,442 +5,441 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace ExplicitKeys
+namespace ExplicitKeys;
+
+public static class ExplicitKeysSamples
 {
-    public static class ExplicitKeysSamples
+    public static void Inserting_new_entities_1()
     {
-        public static void Inserting_new_entities_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Inserting_new_entities_1)}");
-            Console.WriteLine();
+        Console.WriteLine($">>>> Sample: {nameof(Inserting_new_entities_1)}");
+        Console.WriteLine();
 
-            Helpers.RecreateCleanDatabase();
+        Helpers.RecreateCleanDatabase();
 
-            using var context = new BlogsContext();
+        using var context = new BlogsContext();
 
-            #region Inserting_new_entities_1
-            context.Add(
-                new Blog { Id = 1, Name = ".NET Blog", });
-            #endregion
+        #region Inserting_new_entities_1
+        context.Add(
+            new Blog { Id = 1, Name = ".NET Blog", });
+        #endregion
 
-            Console.WriteLine("Before SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        Console.WriteLine("Before SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
 
-            context.SaveChanges();
+        context.SaveChanges();
 
-            Console.WriteLine("After SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        Console.WriteLine("After SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
 
-            Console.WriteLine();
-        }
+        Console.WriteLine();
+    }
 
-        public static void Inserting_new_entities_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Inserting_new_entities_2)}");
-            Console.WriteLine();
+    public static void Inserting_new_entities_2()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Inserting_new_entities_2)}");
+        Console.WriteLine();
 
-            Helpers.RecreateCleanDatabase();
+        Helpers.RecreateCleanDatabase();
 
-            using var context = new BlogsContext();
+        using var context = new BlogsContext();
 
-            #region Inserting_new_entities_2
-            context.Add(
-                new Blog
-                {
-                    Id = 1,
-                    Name = ".NET Blog",
-                    Posts =
-                    {
-                        new Post
-                        {
-                            Id = 1,
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Id = 2,
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        }
-                    }
-                });
-            #endregion
-
-            Console.WriteLine("Before SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine("After SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            Console.WriteLine();
-        }
-
-        public static void Attaching_existing_entities_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Attaching_existing_entities_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            #region Attaching_existing_entities_1
-            context.Attach(
-                new Blog { Id = 1, Name = ".NET Blog", });
-            #endregion
-
-            Console.WriteLine("Before SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine("After SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            Console.WriteLine();
-        }
-
-        public static void Attaching_existing_entities_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Attaching_existing_entities_2)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            #region Attaching_existing_entities_2
-            context.Attach(
-                new Blog
-                {
-                    Id = 1,
-                    Name = ".NET Blog",
-                    Posts =
-                    {
-                        new Post
-                        {
-                            Id = 1,
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Id = 2,
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        }
-                    }
-                });
-            #endregion
-
-            Console.WriteLine("Before SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine("After SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            Console.WriteLine();
-        }
-
-        public static void Updating_existing_entities_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Updating_existing_entities_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            #region Updating_existing_entities_1
-            context.Update(
-                new Blog { Id = 1, Name = ".NET Blog", });
-            #endregion
-
-            Console.WriteLine("Before SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine("After SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            Console.WriteLine();
-        }
-
-        public static void Updating_existing_entities_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Updating_existing_entities_2)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            #region Updating_existing_entities_2
-            context.Update(
-                new Blog
-                {
-                    Id = 1,
-                    Name = ".NET Blog",
-                    Posts =
-                    {
-                        new Post
-                        {
-                            Id = 1,
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Id = 2,
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        }
-                    }
-                });
-            #endregion
-
-            Console.WriteLine("Before SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine("After SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            Console.WriteLine();
-        }
-
-        public static void Deleting_existing_entities_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Deleting_existing_entities_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            #region Deleting_existing_entities_1
-            context.Remove(
-                new Post { Id = 2 });
-            #endregion
-
-            Console.WriteLine("Before SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine("After SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            Console.WriteLine();
-        }
-
-        public static void Deleting_dependent_child_entities_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Deleting_dependent_child_entities_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var post = GetDisconnectedPost();
-
-            #region Deleting_dependent_child_entities_1
-            context.Attach(post);
-            context.Remove(post);
-            #endregion
-
-            Console.WriteLine("Before SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine("After SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            Console.WriteLine();
-
-            Post GetDisconnectedPost()
+        #region Inserting_new_entities_2
+        context.Add(
+            new Blog
             {
-                using var tempContext = new BlogsContext();
-                return tempContext.Posts.Find(2);
-            }
-        }
+                Id = 1,
+                Name = ".NET Blog",
+                Posts =
+                {
+                    new Post
+                    {
+                        Id = 1,
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Id = 2,
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
+                    }
+                }
+            });
+        #endregion
 
-        public static void Deleting_dependent_child_entities_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Deleting_dependent_child_entities_2)}");
-            Console.WriteLine();
+        Console.WriteLine("Before SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
 
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
+        context.SaveChanges();
 
-            using var context = new BlogsContext();
+        Console.WriteLine("After SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
 
-            var blog = GetDisconnectedBlogAndPosts();
+        Console.WriteLine();
+    }
 
-            #region Deleting_dependent_child_entities_2
-            // Attach a blog and associated posts
-            context.Attach(blog);
+    public static void Attaching_existing_entities_1()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Attaching_existing_entities_1)}");
+        Console.WriteLine();
 
-            // Mark one post as Deleted
-            context.Remove(blog.Posts[1]);
-            #endregion
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-            Console.WriteLine("Before SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        using var context = new BlogsContext();
 
-            context.SaveChanges();
+        #region Attaching_existing_entities_1
+        context.Attach(
+            new Blog { Id = 1, Name = ".NET Blog", });
+        #endregion
 
-            Console.WriteLine("After SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        Console.WriteLine("Before SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
 
-            Console.WriteLine();
+        context.SaveChanges();
 
-            Blog GetDisconnectedBlogAndPosts()
+        Console.WriteLine("After SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        Console.WriteLine();
+    }
+
+    public static void Attaching_existing_entities_2()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Attaching_existing_entities_2)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        #region Attaching_existing_entities_2
+        context.Attach(
+            new Blog
             {
-                using var tempContext = new BlogsContext();
-                return tempContext.Blogs.Include(e => e.Posts).Single();
-            }
-        }
+                Id = 1,
+                Name = ".NET Blog",
+                Posts =
+                {
+                    new Post
+                    {
+                        Id = 1,
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Id = 2,
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
+                    }
+                }
+            });
+        #endregion
 
-        public static void Deleting_principal_parent_entities_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Deleting_principal_parent_entities_1)}");
-            Console.WriteLine();
+        Console.WriteLine("Before SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
 
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
+        context.SaveChanges();
 
-            using var context = new BlogsContext();
+        Console.WriteLine("After SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
 
-            var blog = GetDisconnectedBlogAndPosts();
+        Console.WriteLine();
+    }
 
-            #region Deleting_principal_parent_entities_1
-            // Attach a blog and associated posts
-            context.Attach(blog);
+    public static void Updating_existing_entities_1()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Updating_existing_entities_1)}");
+        Console.WriteLine();
 
-            // Mark the blog as deleted
-            context.Remove(blog);
-            #endregion
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-            Console.WriteLine("Before SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        using var context = new BlogsContext();
 
-            context.SaveChanges();
+        #region Updating_existing_entities_1
+        context.Update(
+            new Blog { Id = 1, Name = ".NET Blog", });
+        #endregion
 
-            Console.WriteLine("After SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        Console.WriteLine("Before SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
 
-            Console.WriteLine();
+        context.SaveChanges();
 
-            Blog GetDisconnectedBlogAndPosts()
+        Console.WriteLine("After SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        Console.WriteLine();
+    }
+
+    public static void Updating_existing_entities_2()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Updating_existing_entities_2)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        #region Updating_existing_entities_2
+        context.Update(
+            new Blog
             {
-                using var tempContext = new BlogsContext();
-                return tempContext.Blogs.Include(e => e.Posts).Single();
-            }
+                Id = 1,
+                Name = ".NET Blog",
+                Posts =
+                {
+                    new Post
+                    {
+                        Id = 1,
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Id = 2,
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
+                    }
+                }
+            });
+        #endregion
+
+        Console.WriteLine("Before SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine("After SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        Console.WriteLine();
+    }
+
+    public static void Deleting_existing_entities_1()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Deleting_existing_entities_1)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        #region Deleting_existing_entities_1
+        context.Remove(
+            new Post { Id = 2 });
+        #endregion
+
+        Console.WriteLine("Before SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine("After SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        Console.WriteLine();
+    }
+
+    public static void Deleting_dependent_child_entities_1()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Deleting_dependent_child_entities_1)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        var post = GetDisconnectedPost();
+
+        #region Deleting_dependent_child_entities_1
+        context.Attach(post);
+        context.Remove(post);
+        #endregion
+
+        Console.WriteLine("Before SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine("After SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        Console.WriteLine();
+
+        Post GetDisconnectedPost()
+        {
+            using var tempContext = new BlogsContext();
+            return tempContext.Posts.Find(2);
         }
     }
 
-    public static class Helpers
+    public static void Deleting_dependent_child_entities_2()
     {
-        public static void RecreateCleanDatabase()
+        Console.WriteLine($">>>> Sample: {nameof(Deleting_dependent_child_entities_2)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        var blog = GetDisconnectedBlogAndPosts();
+
+        #region Deleting_dependent_child_entities_2
+        // Attach a blog and associated posts
+        context.Attach(blog);
+
+        // Mark one post as Deleted
+        context.Remove(blog.Posts[1]);
+        #endregion
+
+        Console.WriteLine("Before SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine("After SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        Console.WriteLine();
+
+        Blog GetDisconnectedBlogAndPosts()
         {
-            using var context = new BlogsContext(quiet: true);
-
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-        }
-
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
-
-            context.Add(
-                new Blog
-                {
-                    Id = 1,
-                    Name = ".NET Blog",
-                    Posts =
-                    {
-                        new Post
-                        {
-                            Id = 1,
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Id = 2,
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
-                    }
-                });
-
-            context.SaveChanges();
+            using var tempContext = new BlogsContext();
+            return tempContext.Blogs.Include(e => e.Posts).Single();
         }
     }
 
-    #region Model
-    public class Blog
+    public static void Deleting_principal_parent_entities_1()
     {
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public int Id { get; set; }
+        Console.WriteLine($">>>> Sample: {nameof(Deleting_principal_parent_entities_1)}");
+        Console.WriteLine();
 
-        public string Name { get; set; }
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-        public IList<Post> Posts { get; } = new List<Post>();
-    }
+        using var context = new BlogsContext();
 
-    public class Post
-    {
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public int Id { get; set; }
+        var blog = GetDisconnectedBlogAndPosts();
 
-        public string Title { get; set; }
-        public string Content { get; set; }
+        #region Deleting_principal_parent_entities_1
+        // Attach a blog and associated posts
+        context.Attach(blog);
 
-        public int? BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
-    #endregion
+        // Mark the blog as deleted
+        context.Remove(blog);
+        #endregion
 
-    public class BlogsContext : DbContext
-    {
-        private readonly bool _quiet;
+        Console.WriteLine("Before SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
 
-        public BlogsContext(bool quiet = false)
+        context.SaveChanges();
+
+        Console.WriteLine("After SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        Console.WriteLine();
+
+        Blog GetDisconnectedBlogAndPosts()
         {
-            _quiet = quiet;
+            using var tempContext = new BlogsContext();
+            return tempContext.Blogs.Include(e => e.Posts).Single();
         }
+    }
+}
 
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+    }
 
-            if (!_quiet)
+    public static void PopulateDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Add(
+            new Blog
             {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
+                Id = 1,
+                Name = ".NET Blog",
+                Posts =
+                {
+                    new Post
+                    {
+                        Id = 1,
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Id = 2,
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
+                    },
+                }
+            });
+
+        context.SaveChanges();
+    }
+}
+
+#region Model
+public class Blog
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public int Id { get; set; }
+
+    public string Name { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>();
+}
+
+public class Post
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public int Id { get; set; }
+
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int? BlogId { get; set; }
+    public Blog Blog { get; set; }
+}
+#endregion
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
+    }
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
+
+        if (!_quiet)
+        {
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
     }
 }

--- a/samples/core/ChangeTracking/ChangeTrackingInEFCore/GeneratedKeysSamples.cs
+++ b/samples/core/ChangeTracking/ChangeTrackingInEFCore/GeneratedKeysSamples.cs
@@ -4,382 +4,381 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace GeneratedKeys
+namespace GeneratedKeys;
+
+public static class GeneratedKeysSamples
 {
-    public static class GeneratedKeysSamples
+    public static void Simple_query_and_update_1()
     {
-        public static void Simple_query_and_update_1()
+        Console.WriteLine($">>>> Sample: {nameof(Simple_query_and_update_1)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Simple_query_and_update_1
+        using var context = new BlogsContext();
+
+        var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
+
+        blog.Name = ".NET Blog (Updated!)";
+
+        foreach (var post in blog.Posts.Where(e => !e.Title.Contains("5.0")))
         {
-            Console.WriteLine($">>>> Sample: {nameof(Simple_query_and_update_1)}");
-            Console.WriteLine();
+            post.Title = post.Title.Replace("5", "5.0");
+        }
 
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
+        context.SaveChanges();
+        #endregion
 
-            #region Simple_query_and_update_1
-            using var context = new BlogsContext();
+        Console.WriteLine();
+    }
 
-            var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
+    public static void Simple_query_and_update_2()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Simple_query_and_update_2)}");
+        Console.WriteLine();
 
-            blog.Name = ".NET Blog (Updated!)";
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-            foreach (var post in blog.Posts.Where(e => !e.Title.Contains("5.0")))
+        using var context = new BlogsContext();
+
+        var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
+
+        blog.Name = ".NET Blog (Updated!)";
+
+        foreach (var post in blog.Posts.Where(e => !e.Title.Contains("5.0")))
+        {
+            post.Title = post.Title.Replace("5", "5.0");
+        }
+
+        #region Simple_query_and_update_2
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        #endregion
+
+        context.SaveChanges();
+
+        Console.WriteLine();
+    }
+
+    public static void Query_then_insert_update_and_delete_1()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Query_then_insert_update_and_delete_1)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Query_then_insert_update_and_delete_1
+        using var context = new BlogsContext();
+
+        var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
+
+        // Modify property values
+        blog.Name = ".NET Blog (Updated!)";
+
+        // Insert a new Post
+        blog.Posts.Add(
+            new Post
             {
-                post.Title = post.Title.Replace("5", "5.0");
-            }
+                Title = "What’s next for System.Text.Json?", Content = ".NET 5.0 was released recently and has come with many..."
+            });
 
-            context.SaveChanges();
-            #endregion
+        // Mark an existing Post as Deleted
+        var postToDelete = blog.Posts.Single(e => e.Title == "Announcing F# 5");
+        context.Remove(postToDelete);
 
-            Console.WriteLine();
-        }
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
 
-        public static void Simple_query_and_update_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Simple_query_and_update_2)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
-
-            blog.Name = ".NET Blog (Updated!)";
-
-            foreach (var post in blog.Posts.Where(e => !e.Title.Contains("5.0")))
-            {
-                post.Title = post.Title.Replace("5", "5.0");
-            }
-
-            #region Simple_query_and_update_2
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            #endregion
-
-            context.SaveChanges();
-
-            Console.WriteLine();
-        }
-
-        public static void Query_then_insert_update_and_delete_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Query_then_insert_update_and_delete_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Query_then_insert_update_and_delete_1
-            using var context = new BlogsContext();
-
-            var blog = context.Blogs.Include(e => e.Posts).First(e => e.Name == ".NET Blog");
-
-            // Modify property values
-            blog.Name = ".NET Blog (Updated!)";
-
-            // Insert a new Post
-            blog.Posts.Add(
-                new Post
-                {
-                    Title = "What’s next for System.Text.Json?", Content = ".NET 5.0 was released recently and has come with many..."
-                });
-
-            // Mark an existing Post as Deleted
-            var postToDelete = blog.Posts.Single(e => e.Title == "Announcing F# 5");
-            context.Remove(postToDelete);
-
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-            #endregion
-        }
-
-        public static void Inserting_new_entities_3()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Inserting_new_entities_3)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-
-            using var context = new BlogsContext();
-
-            #region Inserting_new_entities_3
-            context.Add(
-                new Blog
-                {
-                    Name = ".NET Blog",
-                    Posts =
-                    {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        }
-                    }
-                });
-            #endregion
-
-            Console.WriteLine("Before SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine("After SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            Console.WriteLine();
-        }
-
-        public static void Attaching_existing_entities_3()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Attaching_existing_entities_3)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            #region Attaching_existing_entities_3
-            context.Attach(
-                new Blog
-                {
-                    Id = 1,
-                    Name = ".NET Blog",
-                    Posts =
-                    {
-                        new Post
-                        {
-                            Id = 1,
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Id = 2,
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing .NET 5.0",
-                            Content = ".NET 5.0 includes many enhancements, including single file applications, more..."
-                        },
-                    }
-                });
-            #endregion
-
-            Console.WriteLine("Before SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine("After SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            Console.WriteLine();
-        }
-
-        public static void Updating_existing_entities_3()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Updating_existing_entities_3)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            #region Updating_existing_entities_3
-            context.Update(
-                new Blog
-                {
-                    Id = 1,
-                    Name = ".NET Blog",
-                    Posts =
-                    {
-                        new Post
-                        {
-                            Id = 1,
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Id = 2,
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing .NET 5.0",
-                            Content = ".NET 5.0 includes many enhancements, including single file applications, more..."
-                        },
-                    }
-                });
-            #endregion
-
-            Console.WriteLine("Before SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine("After SaveChanges:");
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            Console.WriteLine();
-        }
-
-        public static void Custom_tracking_with_TrackGraph_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Custom_tracking_with_TrackGraph_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var blog = context.Blogs.AsNoTracking().Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
-
-            #region Custom_tracking_with_TrackGraph_1a
-            blog.Posts.Add(
-                new Post
-                {
-                    Title = "Announcing .NET 5.0",
-                    Content = ".NET 5.0 includes many enhancements, including single file applications, more..."
-                }
-            );
-
-            var toDelete = blog.Posts.Single(e => e.Title == "Announcing F# 5");
-            toDelete.Id = -toDelete.Id;
-            #endregion
-
-            UpdateBlog(blog);
-
-            Console.WriteLine();
-        }
-
-        #region Custom_tracking_with_TrackGraph_1b
-        public static void UpdateBlog(Blog blog)
-        {
-            using var context = new BlogsContext();
-
-            context.ChangeTracker.TrackGraph(
-                blog, node =>
-                {
-                    var propertyEntry = node.Entry.Property("Id");
-                    var keyValue = (int)propertyEntry.CurrentValue;
-
-                    if (keyValue == 0)
-                    {
-                        node.Entry.State = EntityState.Added;
-                    }
-                    else if (keyValue < 0)
-                    {
-                        propertyEntry.CurrentValue = -keyValue;
-                        node.Entry.State = EntityState.Deleted;
-                    }
-                    else
-                    {
-                        node.Entry.State = EntityState.Modified;
-                    }
-
-                    Console.WriteLine($"Tracking {node.Entry.Metadata.DisplayName()} with key value {keyValue} as {node.Entry.State}");
-                });
-
-            context.SaveChanges();
-        }
+        context.SaveChanges();
         #endregion
     }
 
-    public static class Helpers
+    public static void Inserting_new_entities_3()
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        Console.WriteLine($">>>> Sample: {nameof(Inserting_new_entities_3)}");
+        Console.WriteLine();
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-        }
+        Helpers.RecreateCleanDatabase();
 
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        using var context = new BlogsContext();
 
-            context.Add(
-                new Blog
+        #region Inserting_new_entities_3
+        context.Add(
+            new Blog
+            {
+                Name = ".NET Blog",
+                Posts =
                 {
-                    Name = ".NET Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
                     }
-                });
+                }
+            });
+        #endregion
 
-            context.SaveChanges();
-        }
+        Console.WriteLine("Before SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine("After SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        Console.WriteLine();
     }
 
-    #region Model
-    public class Blog
+    public static void Attaching_existing_entities_3()
     {
-        public int Id { get; set; }
-        public string Name { get; set; }
+        Console.WriteLine($">>>> Sample: {nameof(Attaching_existing_entities_3)}");
+        Console.WriteLine();
 
-        public IList<Post> Posts { get; } = new List<Post>();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        #region Attaching_existing_entities_3
+        context.Attach(
+            new Blog
+            {
+                Id = 1,
+                Name = ".NET Blog",
+                Posts =
+                {
+                    new Post
+                    {
+                        Id = 1,
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Id = 2,
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing .NET 5.0",
+                        Content = ".NET 5.0 includes many enhancements, including single file applications, more..."
+                    },
+                }
+            });
+        #endregion
+
+        Console.WriteLine("Before SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine("After SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        Console.WriteLine();
     }
 
-    public class Post
+    public static void Updating_existing_entities_3()
     {
-        public int Id { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+        Console.WriteLine($">>>> Sample: {nameof(Updating_existing_entities_3)}");
+        Console.WriteLine();
 
-        public int? BlogId { get; set; }
-        public Blog Blog { get; set; }
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        #region Updating_existing_entities_3
+        context.Update(
+            new Blog
+            {
+                Id = 1,
+                Name = ".NET Blog",
+                Posts =
+                {
+                    new Post
+                    {
+                        Id = 1,
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Id = 2,
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing .NET 5.0",
+                        Content = ".NET 5.0 includes many enhancements, including single file applications, more..."
+                    },
+                }
+            });
+        #endregion
+
+        Console.WriteLine("Before SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine("After SaveChanges:");
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        Console.WriteLine();
+    }
+
+    public static void Custom_tracking_with_TrackGraph_1()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Custom_tracking_with_TrackGraph_1)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        var blog = context.Blogs.AsNoTracking().Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
+
+        #region Custom_tracking_with_TrackGraph_1a
+        blog.Posts.Add(
+            new Post
+            {
+                Title = "Announcing .NET 5.0",
+                Content = ".NET 5.0 includes many enhancements, including single file applications, more..."
+            }
+        );
+
+        var toDelete = blog.Posts.Single(e => e.Title == "Announcing F# 5");
+        toDelete.Id = -toDelete.Id;
+        #endregion
+
+        UpdateBlog(blog);
+
+        Console.WriteLine();
+    }
+
+    #region Custom_tracking_with_TrackGraph_1b
+    public static void UpdateBlog(Blog blog)
+    {
+        using var context = new BlogsContext();
+
+        context.ChangeTracker.TrackGraph(
+            blog, node =>
+            {
+                var propertyEntry = node.Entry.Property("Id");
+                var keyValue = (int)propertyEntry.CurrentValue;
+
+                if (keyValue == 0)
+                {
+                    node.Entry.State = EntityState.Added;
+                }
+                else if (keyValue < 0)
+                {
+                    propertyEntry.CurrentValue = -keyValue;
+                    node.Entry.State = EntityState.Deleted;
+                }
+                else
+                {
+                    node.Entry.State = EntityState.Modified;
+                }
+
+                Console.WriteLine($"Tracking {node.Entry.Metadata.DisplayName()} with key value {keyValue} as {node.Entry.State}");
+            });
+
+        context.SaveChanges();
     }
     #endregion
+}
 
-    public class BlogsContext : DbContext
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
     {
-        private readonly bool _quiet;
+        using var context = new BlogsContext(quiet: true);
 
-        public BlogsContext(bool quiet = false)
-        {
-            _quiet = quiet;
-        }
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+    }
 
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+    public static void PopulateDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
+        context.Add(
+            new Blog
             {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
+                Name = ".NET Blog",
+                Posts =
+                {
+                    new Post
+                    {
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
+                    },
+                }
+            });
+
+        context.SaveChanges();
+    }
+}
+
+#region Model
+public class Blog
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>();
+}
+
+public class Post
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int? BlogId { get; set; }
+    public Blog Blog { get; set; }
+}
+#endregion
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
+    }
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
+
+        if (!_quiet)
+        {
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
     }
 }

--- a/samples/core/ChangeTracking/ChangingFKsAndNavigations/ExplicitJoinEntityAndSkipsSamples.cs
+++ b/samples/core/ChangeTracking/ChangingFKsAndNavigations/ExplicitJoinEntityAndSkipsSamples.cs
@@ -4,214 +4,213 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace JoinEntityWithSkips
+namespace JoinEntityWithSkips;
+
+public class ExplicitJoinEntityWithSkipsSamples
 {
-    public class ExplicitJoinEntityWithSkipsSamples
+    public static void Many_to_many_relationships_3()
     {
-        public static void Many_to_many_relationships_3()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_3)}");
-            Console.WriteLine();
+        Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_3)}");
+        Console.WriteLine();
 
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-            #region Many_to_many_relationships_3
-            using var context = new BlogsContext();
+        #region Many_to_many_relationships_3
+        using var context = new BlogsContext();
 
-            var post = context.Posts.Single(e => e.Id == 3);
-            var tag = context.Tags.Single(e => e.Id == 1);
+        var post = context.Posts.Single(e => e.Id == 3);
+        var tag = context.Tags.Single(e => e.Id == 1);
 
-            post.Tags.Add(tag);
+        post.Tags.Add(tag);
 
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            #endregion
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        #endregion
 
-            Console.WriteLine();
-        }
-
-        public static void Many_to_many_relationships_4()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_4)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var post = context.Posts.Single(e => e.Id == 3);
-            var tag = context.Tags.Single(e => e.Id == 1);
-
-            #region Many_to_many_relationships_4
-            context.Add(new PostTag { Post = post, Tag = tag });
-            #endregion
-
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            Console.WriteLine();
-        }
-
-        public static void Many_to_many_relationships_5()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_5)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var post = context.Posts.Single(e => e.Id == 3);
-            var tag = context.Tags.Single(e => e.Id == 1);
-
-            #region Many_to_many_relationships_5
-            context.Add(new PostTag { PostId = post.Id, TagId = tag.Id });
-            #endregion
-
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            Console.WriteLine();
-        }
+        Console.WriteLine();
     }
 
-    public static class Helpers
+    public static void Many_to_many_relationships_4()
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_4)}");
+        Console.WriteLine();
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-        }
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        using var context = new BlogsContext();
 
-            context.AddRange(
-                new Blog
+        var post = context.Posts.Single(e => e.Id == 3);
+        var tag = context.Tags.Single(e => e.Id == 1);
+
+        #region Many_to_many_relationships_4
+        context.Add(new PostTag { Post = post, Tag = tag });
+        #endregion
+
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        Console.WriteLine();
+    }
+
+    public static void Many_to_many_relationships_5()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_5)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        var post = context.Posts.Single(e => e.Id == 3);
+        var tag = context.Tags.Single(e => e.Id == 1);
+
+        #region Many_to_many_relationships_5
+        context.Add(new PostTag { PostId = post.Id, TagId = tag.Id });
+        #endregion
+
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        Console.WriteLine();
+    }
+}
+
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+    }
+
+    public static void PopulateDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.AddRange(
+            new Blog
+            {
+                Name = ".NET Blog",
+                Posts =
                 {
-                    Name = ".NET Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
                     },
                 },
-                new Blog
+            },
+            new Blog
+            {
+                Name = "Visual Studio Blog",
+                Posts =
                 {
-                    Name = "Visual Studio Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Disassembly improvements for optimized managed debugging",
-                            Content =
-                                "If you are focused on squeezing out the last bits of performance for your .NET service or..."
-                        },
-                        new Post
-                        {
-                            Title = "Database Profiling with Visual Studio",
-                            Content = "Examine when database queries were executed and measure how long the take using..."
-                        },
-                    }
-                },
-                new Tag { Text = ".NET" },
-                new Tag { Text = "Visual Studio" },
-                new Tag { Text = "EF Core" });
+                        Title = "Disassembly improvements for optimized managed debugging",
+                        Content =
+                            "If you are focused on squeezing out the last bits of performance for your .NET service or..."
+                    },
+                    new Post
+                    {
+                        Title = "Database Profiling with Visual Studio",
+                        Content = "Examine when database queries were executed and measure how long the take using..."
+                    },
+                }
+            },
+            new Tag { Text = ".NET" },
+            new Tag { Text = "Visual Studio" },
+            new Tag { Text = "EF Core" });
 
-            context.SaveChanges();
+        context.SaveChanges();
+    }
+}
+
+public class Blog
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>();
+}
+
+#region Model
+public class Post
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int? BlogId { get; set; }
+    public Blog Blog { get; set; }
+
+    public IList<Tag> Tags { get; } = new List<Tag>(); // Skip collection navigation
+    public IList<PostTag> PostTags { get; } = new List<PostTag>(); // Collection navigation
+}
+
+public class Tag
+{
+    public int Id { get; set; }
+    public string Text { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>(); // Skip collection navigation
+    public IList<PostTag> PostTags { get; } = new List<PostTag>(); // Collection navigation
+}
+
+public class PostTag
+{
+    public int PostId { get; set; } // First part of composite PK; FK to Post
+    public int TagId { get; set; } // Second part of composite PK; FK to Tag
+
+    public Post Post { get; set; } // Reference navigation
+    public Tag Tag { get; set; } // Reference navigation
+}
+#endregion
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
+    }
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+    public DbSet<Tag> Tags { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
+
+        if (!_quiet)
+        {
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
     }
 
-    public class Blog
+    #region OnModelCreating
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int Id { get; set; }
-        public string Name { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>();
-    }
-
-    #region Model
-    public class Post
-    {
-        public int Id { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int? BlogId { get; set; }
-        public Blog Blog { get; set; }
-
-        public IList<Tag> Tags { get; } = new List<Tag>(); // Skip collection navigation
-        public IList<PostTag> PostTags { get; } = new List<PostTag>(); // Collection navigation
-    }
-
-    public class Tag
-    {
-        public int Id { get; set; }
-        public string Text { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>(); // Skip collection navigation
-        public IList<PostTag> PostTags { get; } = new List<PostTag>(); // Collection navigation
-    }
-
-    public class PostTag
-    {
-        public int PostId { get; set; } // First part of composite PK; FK to Post
-        public int TagId { get; set; } // Second part of composite PK; FK to Tag
-
-        public Post Post { get; set; } // Reference navigation
-        public Tag Tag { get; set; } // Reference navigation
+        modelBuilder.Entity<Post>()
+            .HasMany(p => p.Tags)
+            .WithMany(p => p.Posts)
+            .UsingEntity<PostTag>(
+                j => j.HasOne(t => t.Tag).WithMany(p => p.PostTags),
+                j => j.HasOne(t => t.Post).WithMany(p => p.PostTags));
     }
     #endregion
-
-    public class BlogsContext : DbContext
-    {
-        private readonly bool _quiet;
-
-        public BlogsContext(bool quiet = false)
-        {
-            _quiet = quiet;
-        }
-
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<Tag> Tags { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
-            {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
-        }
-
-        #region OnModelCreating
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Post>()
-                .HasMany(p => p.Tags)
-                .WithMany(p => p.Posts)
-                .UsingEntity<PostTag>(
-                    j => j.HasOne(t => t.Tag).WithMany(p => p.PostTags),
-                    j => j.HasOne(t => t.Post).WithMany(p => p.PostTags));
-        }
-        #endregion
-    }
 }

--- a/samples/core/ChangeTracking/ChangingFKsAndNavigations/ExplicitJoinEntitySamples.cs
+++ b/samples/core/ChangeTracking/ChangingFKsAndNavigations/ExplicitJoinEntitySamples.cs
@@ -4,184 +4,183 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace JoinEntity
+namespace JoinEntity;
+
+public class ExplicitJoinEntitySamples
 {
-    public class ExplicitJoinEntitySamples
+    public static void Many_to_many_relationships_1()
     {
-        public static void Many_to_many_relationships_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_1)}");
-            Console.WriteLine();
+        Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_1)}");
+        Console.WriteLine();
 
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-            #region Many_to_many_relationships_1
-            using var context = new BlogsContext();
+        #region Many_to_many_relationships_1
+        using var context = new BlogsContext();
 
-            var post = context.Posts.Single(e => e.Id == 3);
-            var tag = context.Tags.Single(e => e.Id == 1);
+        var post = context.Posts.Single(e => e.Id == 3);
+        var tag = context.Tags.Single(e => e.Id == 1);
 
-            context.Add(new PostTag { PostId = post.Id, TagId = tag.Id });
+        context.Add(new PostTag { PostId = post.Id, TagId = tag.Id });
 
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            #endregion
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        #endregion
 
-            context.SaveChanges();
+        context.SaveChanges();
 
-            Console.WriteLine();
-        }
-
-        public static void Many_to_many_relationships_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_2)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var post = context.Posts.Single(e => e.Id == 3);
-            var tag = context.Tags.Single(e => e.Id == 1);
-
-            #region Many_to_many_relationships_2
-            context.Add(new PostTag { Post = post, Tag = tag });
-            #endregion
-
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine();
-        }
+        Console.WriteLine();
     }
 
-    public static class Helpers
+    public static void Many_to_many_relationships_2()
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_2)}");
+        Console.WriteLine();
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-        }
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        using var context = new BlogsContext();
 
-            context.AddRange(
-                new Blog
+        var post = context.Posts.Single(e => e.Id == 3);
+        var tag = context.Tags.Single(e => e.Id == 1);
+
+        #region Many_to_many_relationships_2
+        context.Add(new PostTag { Post = post, Tag = tag });
+        #endregion
+
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine();
+    }
+}
+
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+    }
+
+    public static void PopulateDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.AddRange(
+            new Blog
+            {
+                Name = ".NET Blog",
+                Posts =
                 {
-                    Name = ".NET Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
                     },
                 },
-                new Blog
-                {
-                    Name = "Visual Studio Blog",
-                    Posts =
-                    {
-                        new Post
-                        {
-                            Title = "Disassembly improvements for optimized managed debugging",
-                            Content =
-                                "If you are focused on squeezing out the last bits of performance for your .NET service or..."
-                        },
-                        new Post
-                        {
-                            Title = "Database Profiling with Visual Studio",
-                            Content = "Examine when database queries were executed and measure how long the take using..."
-                        },
-                    }
-                },
-                new Tag { Text = ".NET" },
-                new Tag { Text = "Visual Studio" },
-                new Tag { Text = "EF Core" });
-
-            context.SaveChanges();
-        }
-    }
-
-    public class Blog
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>();
-    }
-
-    #region Model
-    public class Post
-    {
-        public int Id { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int? BlogId { get; set; }
-        public Blog Blog { get; set; }
-
-        public IList<PostTag> PostTags { get; } = new List<PostTag>(); // Collection navigation
-    }
-
-    public class Tag
-    {
-        public int Id { get; set; }
-        public string Text { get; set; }
-
-        public IList<PostTag> PostTags { get; } = new List<PostTag>(); // Collection navigation
-    }
-
-    public class PostTag
-    {
-        public int PostId { get; set; } // First part of composite PK; FK to Post
-        public int TagId { get; set; } // Second part of composite PK; FK to Tag
-
-        public Post Post { get; set; } // Reference navigation
-        public Tag Tag { get; set; } // Reference navigation
-    }
-    #endregion
-
-    public class BlogsContext : DbContext
-    {
-        private readonly bool _quiet;
-
-        public BlogsContext(bool quiet = false)
-        {
-            _quiet = quiet;
-        }
-
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<Tag> Tags { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
+            },
+            new Blog
             {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
-        }
+                Name = "Visual Studio Blog",
+                Posts =
+                {
+                    new Post
+                    {
+                        Title = "Disassembly improvements for optimized managed debugging",
+                        Content =
+                            "If you are focused on squeezing out the last bits of performance for your .NET service or..."
+                    },
+                    new Post
+                    {
+                        Title = "Database Profiling with Visual Studio",
+                        Content = "Examine when database queries were executed and measure how long the take using..."
+                    },
+                }
+            },
+            new Tag { Text = ".NET" },
+            new Tag { Text = "Visual Studio" },
+            new Tag { Text = "EF Core" });
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        context.SaveChanges();
+    }
+}
+
+public class Blog
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>();
+}
+
+#region Model
+public class Post
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int? BlogId { get; set; }
+    public Blog Blog { get; set; }
+
+    public IList<PostTag> PostTags { get; } = new List<PostTag>(); // Collection navigation
+}
+
+public class Tag
+{
+    public int Id { get; set; }
+    public string Text { get; set; }
+
+    public IList<PostTag> PostTags { get; } = new List<PostTag>(); // Collection navigation
+}
+
+public class PostTag
+{
+    public int PostId { get; set; } // First part of composite PK; FK to Post
+    public int TagId { get; set; } // Second part of composite PK; FK to Tag
+
+    public Post Post { get; set; } // Reference navigation
+    public Tag Tag { get; set; } // Reference navigation
+}
+#endregion
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
+    }
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+    public DbSet<Tag> Tags { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
+
+        if (!_quiet)
         {
-            modelBuilder.Entity<PostTag>().HasKey(e => new { e.PostId, e.TagId });
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<PostTag>().HasKey(e => new { e.PostId, e.TagId });
     }
 }

--- a/samples/core/ChangeTracking/ChangingFKsAndNavigations/ExplicitJoinEntityWithStringPayloadSamples.cs
+++ b/samples/core/ChangeTracking/ChangingFKsAndNavigations/ExplicitJoinEntityWithStringPayloadSamples.cs
@@ -4,214 +4,213 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace JoinEntityWithStringPayload
+namespace JoinEntityWithStringPayload;
+
+public class ExplicitJoinEntityWithStringPayloadSamples
 {
-    public class ExplicitJoinEntityWithStringPayloadSamples
+    public static void Many_to_many_relationships_8()
     {
-        public static void Many_to_many_relationships_8()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_8)}");
-            Console.WriteLine();
+        Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_8)}");
+        Console.WriteLine();
 
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-            #region Many_to_many_relationships_8
-            using var context = new BlogsContext();
+        #region Many_to_many_relationships_8
+        using var context = new BlogsContext();
 
-            var post = context.Posts.Single(e => e.Id == 3);
-            var tag = context.Tags.Single(e => e.Id == 1);
+        var post = context.Posts.Single(e => e.Id == 3);
+        var tag = context.Tags.Single(e => e.Id == 1);
 
-            post.Tags.Add(tag);
+        post.Tags.Add(tag);
 
-            context.ChangeTracker.DetectChanges();
+        context.ChangeTracker.DetectChanges();
 
-            var joinEntity = context.Set<PostTag>().Find(post.Id, tag.Id);
+        var joinEntity = context.Set<PostTag>().Find(post.Id, tag.Id);
 
-            joinEntity.TaggedBy = "ajcvickers";
+        joinEntity.TaggedBy = "ajcvickers";
 
-            context.SaveChanges();
+        context.SaveChanges();
 
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            #endregion
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        #endregion
 
-            Console.WriteLine();
-        }
-
-        public static void Many_to_many_relationships_9()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_9)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Many_to_many_relationships_9
-            using var context = new BlogsContext();
-
-            var post = context.Posts.Single(e => e.Id == 3);
-            var tag = context.Tags.Single(e => e.Id == 1);
-
-            context.Add(
-                new PostTag { PostId = post.Id, TagId = tag.Id, TaggedBy = "ajcvickers" });
-
-            context.SaveChanges();
-
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            #endregion
-
-            Console.WriteLine();
-        }
+        Console.WriteLine();
     }
 
-    public static class Helpers
+    public static void Many_to_many_relationships_9()
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_9)}");
+        Console.WriteLine();
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-        }
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        #region Many_to_many_relationships_9
+        using var context = new BlogsContext();
 
-            context.AddRange(
-                new Blog
+        var post = context.Posts.Single(e => e.Id == 3);
+        var tag = context.Tags.Single(e => e.Id == 1);
+
+        context.Add(
+            new PostTag { PostId = post.Id, TagId = tag.Id, TaggedBy = "ajcvickers" });
+
+        context.SaveChanges();
+
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        #endregion
+
+        Console.WriteLine();
+    }
+}
+
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+    }
+
+    public static void PopulateDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.AddRange(
+            new Blog
+            {
+                Name = ".NET Blog",
+                Posts =
                 {
-                    Name = ".NET Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
                     },
                 },
-                new Blog
+            },
+            new Blog
+            {
+                Name = "Visual Studio Blog",
+                Posts =
                 {
-                    Name = "Visual Studio Blog",
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Disassembly improvements for optimized managed debugging",
-                            Content =
-                                "If you are focused on squeezing out the last bits of performance for your .NET service or..."
-                        },
-                        new Post
-                        {
-                            Title = "Database Profiling with Visual Studio",
-                            Content = "Examine when database queries were executed and measure how long the take using..."
-                        },
-                    }
-                },
-                new Tag { Text = ".NET" },
-                new Tag { Text = "Visual Studio" },
-                new Tag { Text = "EF Core" });
+                        Title = "Disassembly improvements for optimized managed debugging",
+                        Content =
+                            "If you are focused on squeezing out the last bits of performance for your .NET service or..."
+                    },
+                    new Post
+                    {
+                        Title = "Database Profiling with Visual Studio",
+                        Content = "Examine when database queries were executed and measure how long the take using..."
+                    },
+                }
+            },
+            new Tag { Text = ".NET" },
+            new Tag { Text = "Visual Studio" },
+            new Tag { Text = "EF Core" });
 
-            context.SaveChanges();
+        context.SaveChanges();
+    }
+}
+
+public class Blog
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>();
+}
+
+public class Post
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int? BlogId { get; set; }
+    public Blog Blog { get; set; }
+
+    public IList<Tag> Tags { get; } = new List<Tag>(); // Skip collection navigation
+}
+
+public class Tag
+{
+    public int Id { get; set; }
+    public string Text { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>(); // Skip collection navigation
+}
+
+#region Model
+public class PostTag
+{
+    public int PostId { get; set; } // First part of composite PK; FK to Post
+    public int TagId { get; set; } // Second part of composite PK; FK to Tag
+
+    public DateTime TaggedOn { get; set; } // Auto-generated payload property
+    public string TaggedBy { get; set; } // Not-generated payload property
+}
+#endregion
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
+    }
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+    public DbSet<Tag> Tags { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
+
+        if (!_quiet)
+        {
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
     }
 
-    public class Blog
+    #region OnModelCreating
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int Id { get; set; }
-        public string Name { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>();
-    }
-
-    public class Post
-    {
-        public int Id { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int? BlogId { get; set; }
-        public Blog Blog { get; set; }
-
-        public IList<Tag> Tags { get; } = new List<Tag>(); // Skip collection navigation
-    }
-
-    public class Tag
-    {
-        public int Id { get; set; }
-        public string Text { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>(); // Skip collection navigation
-    }
-
-    #region Model
-    public class PostTag
-    {
-        public int PostId { get; set; } // First part of composite PK; FK to Post
-        public int TagId { get; set; } // Second part of composite PK; FK to Tag
-
-        public DateTime TaggedOn { get; set; } // Auto-generated payload property
-        public string TaggedBy { get; set; } // Not-generated payload property
+        modelBuilder.Entity<Post>()
+            .HasMany(p => p.Tags)
+            .WithMany(p => p.Posts)
+            .UsingEntity<PostTag>(
+                j => j.HasOne<Tag>().WithMany(),
+                j => j.HasOne<Post>().WithMany(),
+                j => j.Property(e => e.TaggedOn).HasDefaultValueSql("CURRENT_TIMESTAMP"));
     }
     #endregion
 
-    public class BlogsContext : DbContext
+    #region SaveChanges
+    public override int SaveChanges()
     {
-        private readonly bool _quiet;
-
-        public BlogsContext(bool quiet = false)
+        foreach (var entityEntry in ChangeTracker.Entries<PostTag>())
         {
-            _quiet = quiet;
-        }
-
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<Tag> Tags { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
+            if (entityEntry.State == EntityState.Added)
             {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
+                entityEntry.Entity.TaggedBy = "ajcvickers";
             }
         }
 
-        #region OnModelCreating
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Post>()
-                .HasMany(p => p.Tags)
-                .WithMany(p => p.Posts)
-                .UsingEntity<PostTag>(
-                    j => j.HasOne<Tag>().WithMany(),
-                    j => j.HasOne<Post>().WithMany(),
-                    j => j.Property(e => e.TaggedOn).HasDefaultValueSql("CURRENT_TIMESTAMP"));
-        }
-        #endregion
-
-        #region SaveChanges
-        public override int SaveChanges()
-        {
-            foreach (var entityEntry in ChangeTracker.Entries<PostTag>())
-            {
-                if (entityEntry.State == EntityState.Added)
-                {
-                    entityEntry.Entity.TaggedBy = "ajcvickers";
-                }
-            }
-
-            return base.SaveChanges();
-        }
-        #endregion
+        return base.SaveChanges();
     }
+    #endregion
 }

--- a/samples/core/ChangeTracking/ChangingFKsAndNavigations/OptionalRelationshipsSamples.cs
+++ b/samples/core/ChangeTracking/ChangingFKsAndNavigations/OptionalRelationshipsSamples.cs
@@ -4,426 +4,425 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace Optional
+namespace Optional;
+
+public class OptionalRelationshipsSamples
 {
-    public class OptionalRelationshipsSamples
+    public static void Relationship_fixup_1()
     {
-        public static void Relationship_fixup_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Relationship_fixup_1)}");
-            Console.WriteLine();
+        Console.WriteLine($">>>> Sample: {nameof(Relationship_fixup_1)}");
+        Console.WriteLine();
 
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-            #region Relationship_fixup_1
-            using var context = new BlogsContext();
+        #region Relationship_fixup_1
+        using var context = new BlogsContext();
 
-            var blogs = context.Blogs
-                .Include(e => e.Posts)
-                .Include(e => e.Assets)
-                .ToList();
+        var blogs = context.Blogs
+            .Include(e => e.Posts)
+            .Include(e => e.Assets)
+            .ToList();
 
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            #endregion
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        #endregion
 
-            Console.WriteLine();
-        }
-
-        public static void Relationship_fixup_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Relationship_fixup_2)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Relationship_fixup_2
-            using var context = new BlogsContext();
-
-            var blogs = context.Blogs.ToList();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            var assets = context.Assets.ToList();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            var posts = context.Posts.ToList();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            #endregion
-
-            Console.WriteLine();
-        }
-
-        public static void Changing_relationships_using_navigations_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Changing_relationships_using_navigations_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Changing_relationships_using_navigations_1
-            using var context = new BlogsContext();
-
-            var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
-            var vsBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == "Visual Studio Blog");
-
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            var post = vsBlog.Posts.Single(e => e.Title.StartsWith("Disassembly improvements"));
-            vsBlog.Posts.Remove(post);
-            dotNetBlog.Posts.Add(post);
-
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-            #endregion
-
-            Console.WriteLine();
-        }
-
-        public static void Changing_relationships_using_navigations_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Changing_relationships_using_navigations_2)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
-            var vsBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == "Visual Studio Blog");
-
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            #region Changing_relationships_using_navigations_2
-            var post = vsBlog.Posts.Single(e => e.Title.StartsWith("Disassembly improvements"));
-            post.Blog = dotNetBlog;
-            #endregion
-
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine();
-        }
-
-        public static void Changing_relationships_using_foreign_key_values_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Changing_relationships_using_foreign_key_values_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
-            var vsBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == "Visual Studio Blog");
-
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            #region Changing_relationships_using_foreign_key_values_1
-            var post = vsBlog.Posts.Single(e => e.Title.StartsWith("Disassembly improvements"));
-            post.BlogId = dotNetBlog.Id;
-            #endregion
-
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine();
-        }
-
-        public static void Fixup_for_added_or_deleted_entities_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
-            var vsBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == "Visual Studio Blog");
-
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            #region Fixup_for_added_or_deleted_entities_1
-            var post = vsBlog.Posts.Single(e => e.Title.StartsWith("Disassembly improvements"));
-            vsBlog.Posts.Remove(post);
-            dotNetBlog.Posts.Add(post);
-            #endregion
-
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine();
-        }
-
-        public static void Fixup_for_added_or_deleted_entities_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_2)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
-            var vsBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == "Visual Studio Blog");
-
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            #region Fixup_for_added_or_deleted_entities_2
-            var post = vsBlog.Posts.Single(e => e.Title.StartsWith("Disassembly improvements"));
-            dotNetBlog.Posts.Add(post);
-            #endregion
-
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine();
-        }
-
-        public static void Fixup_for_added_or_deleted_entities_3()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_3)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
-
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            #region Fixup_for_added_or_deleted_entities_3
-            var post = dotNetBlog.Posts.Single(e => e.Title == "Announcing F# 5");
-            dotNetBlog.Posts.Remove(post);
-            #endregion
-
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine();
-        }
-
-        public static void Fixup_for_added_or_deleted_entities_7()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_7)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Fixup_for_added_or_deleted_entities_7
-            using var context = new BlogsContext();
-
-            var dotNetBlog = context.Blogs.Include(e => e.Assets).Single(e => e.Name == ".NET Blog");
-            dotNetBlog.Assets = new BlogAssets();
-
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-            #endregion
-
-            Console.WriteLine();
-        }
-
-        public static void Deleting_an_entity_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Deleting_an_entity_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Deleting_an_entity_1
-            using var context = new BlogsContext();
-
-            var vsBlog = context.Blogs
-                .Include(e => e.Posts)
-                .Include(e => e.Assets)
-                .Single(e => e.Name == "Visual Studio Blog");
-
-            context.Remove(vsBlog);
-
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-            #endregion
-
-            Console.WriteLine();
-        }
-
-        public static void Many_to_many_relationships_6()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_6)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Many_to_many_relationships_6
-            using var context = new BlogsContext();
-
-            var post = context.Posts.Single(e => e.Id == 3);
-            var tag = context.Tags.Single(e => e.Id == 1);
-
-            post.Tags.Add(tag);
-
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-            #endregion
-
-            Console.WriteLine();
-        }
+        Console.WriteLine();
     }
 
-    public static class Helpers
+    public static void Relationship_fixup_2()
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        Console.WriteLine($">>>> Sample: {nameof(Relationship_fixup_2)}");
+        Console.WriteLine();
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-        }
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        #region Relationship_fixup_2
+        using var context = new BlogsContext();
 
-            context.AddRange(
-                new Blog
+        var blogs = context.Blogs.ToList();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        var assets = context.Assets.ToList();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        var posts = context.Posts.ToList();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        #endregion
+
+        Console.WriteLine();
+    }
+
+    public static void Changing_relationships_using_navigations_1()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Changing_relationships_using_navigations_1)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Changing_relationships_using_navigations_1
+        using var context = new BlogsContext();
+
+        var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
+        var vsBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == "Visual Studio Blog");
+
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        var post = vsBlog.Posts.Single(e => e.Title.StartsWith("Disassembly improvements"));
+        vsBlog.Posts.Remove(post);
+        dotNetBlog.Posts.Add(post);
+
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+        #endregion
+
+        Console.WriteLine();
+    }
+
+    public static void Changing_relationships_using_navigations_2()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Changing_relationships_using_navigations_2)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
+        var vsBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == "Visual Studio Blog");
+
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        #region Changing_relationships_using_navigations_2
+        var post = vsBlog.Posts.Single(e => e.Title.StartsWith("Disassembly improvements"));
+        post.Blog = dotNetBlog;
+        #endregion
+
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine();
+    }
+
+    public static void Changing_relationships_using_foreign_key_values_1()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Changing_relationships_using_foreign_key_values_1)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
+        var vsBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == "Visual Studio Blog");
+
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        #region Changing_relationships_using_foreign_key_values_1
+        var post = vsBlog.Posts.Single(e => e.Title.StartsWith("Disassembly improvements"));
+        post.BlogId = dotNetBlog.Id;
+        #endregion
+
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine();
+    }
+
+    public static void Fixup_for_added_or_deleted_entities_1()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_1)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
+        var vsBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == "Visual Studio Blog");
+
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        #region Fixup_for_added_or_deleted_entities_1
+        var post = vsBlog.Posts.Single(e => e.Title.StartsWith("Disassembly improvements"));
+        vsBlog.Posts.Remove(post);
+        dotNetBlog.Posts.Add(post);
+        #endregion
+
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine();
+    }
+
+    public static void Fixup_for_added_or_deleted_entities_2()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_2)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
+        var vsBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == "Visual Studio Blog");
+
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        #region Fixup_for_added_or_deleted_entities_2
+        var post = vsBlog.Posts.Single(e => e.Title.StartsWith("Disassembly improvements"));
+        dotNetBlog.Posts.Add(post);
+        #endregion
+
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine();
+    }
+
+    public static void Fixup_for_added_or_deleted_entities_3()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_3)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
+
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        #region Fixup_for_added_or_deleted_entities_3
+        var post = dotNetBlog.Posts.Single(e => e.Title == "Announcing F# 5");
+        dotNetBlog.Posts.Remove(post);
+        #endregion
+
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine();
+    }
+
+    public static void Fixup_for_added_or_deleted_entities_7()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_7)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Fixup_for_added_or_deleted_entities_7
+        using var context = new BlogsContext();
+
+        var dotNetBlog = context.Blogs.Include(e => e.Assets).Single(e => e.Name == ".NET Blog");
+        dotNetBlog.Assets = new BlogAssets();
+
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+        #endregion
+
+        Console.WriteLine();
+    }
+
+    public static void Deleting_an_entity_1()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Deleting_an_entity_1)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Deleting_an_entity_1
+        using var context = new BlogsContext();
+
+        var vsBlog = context.Blogs
+            .Include(e => e.Posts)
+            .Include(e => e.Assets)
+            .Single(e => e.Name == "Visual Studio Blog");
+
+        context.Remove(vsBlog);
+
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+        #endregion
+
+        Console.WriteLine();
+    }
+
+    public static void Many_to_many_relationships_6()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Many_to_many_relationships_6)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Many_to_many_relationships_6
+        using var context = new BlogsContext();
+
+        var post = context.Posts.Single(e => e.Id == 3);
+        var tag = context.Tags.Single(e => e.Id == 1);
+
+        post.Tags.Add(tag);
+
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+        #endregion
+
+        Console.WriteLine();
+    }
+}
+
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+    }
+
+    public static void PopulateDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.AddRange(
+            new Blog
+            {
+                Name = ".NET Blog",
+                Assets = new BlogAssets(),
+                Posts =
                 {
-                    Name = ".NET Blog",
-                    Assets = new BlogAssets(),
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
                     },
                 },
-                new Blog
-                {
-                    Name = "Visual Studio Blog",
-                    Assets = new BlogAssets(),
-                    Posts =
-                    {
-                        new Post
-                        {
-                            Title = "Disassembly improvements for optimized managed debugging",
-                            Content =
-                                "If you are focused on squeezing out the last bits of performance for your .NET service or..."
-                        },
-                        new Post
-                        {
-                            Title = "Database Profiling with Visual Studio",
-                            Content = "Examine when database queries were executed and measure how long the take using..."
-                        },
-                    }
-                },
-                new Tag { Text = ".NET" },
-                new Tag { Text = "Visual Studio" },
-                new Tag { Text = "EF Core" });
-
-            context.SaveChanges();
-        }
-    }
-
-    #region Model
-    public class Blog
-    {
-        public int Id { get; set; } // Primary key
-        public string Name { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>(); // Collection navigation
-        public BlogAssets Assets { get; set; } // Reference navigation
-    }
-
-    public class BlogAssets
-    {
-        public int Id { get; set; } // Primary key
-        public byte[] Banner { get; set; }
-
-        public int? BlogId { get; set; } // Foreign key
-        public Blog Blog { get; set; } // Reference navigation
-    }
-
-    public class Post
-    {
-        public int Id { get; set; } // Primary key
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int? BlogId { get; set; } // Foreign key
-        public Blog Blog { get; set; } // Reference navigation
-
-        public IList<Tag> Tags { get; } = new List<Tag>(); // Skip collection navigation
-    }
-
-    public class Tag
-    {
-        public int Id { get; set; } // Primary key
-        public string Text { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>(); // Skip collection navigation
-    }
-    #endregion
-
-    public class BlogsContext : DbContext
-    {
-        private readonly bool _quiet;
-
-        public BlogsContext(bool quiet = false)
-        {
-            _quiet = quiet;
-        }
-
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<BlogAssets> Assets { get; set; }
-        public DbSet<Tag> Tags { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
+            },
+            new Blog
             {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
-        }
+                Name = "Visual Studio Blog",
+                Assets = new BlogAssets(),
+                Posts =
+                {
+                    new Post
+                    {
+                        Title = "Disassembly improvements for optimized managed debugging",
+                        Content =
+                            "If you are focused on squeezing out the last bits of performance for your .NET service or..."
+                    },
+                    new Post
+                    {
+                        Title = "Database Profiling with Visual Studio",
+                        Content = "Examine when database queries were executed and measure how long the take using..."
+                    },
+                }
+            },
+            new Tag { Text = ".NET" },
+            new Tag { Text = "Visual Studio" },
+            new Tag { Text = "EF Core" });
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        context.SaveChanges();
+    }
+}
+
+#region Model
+public class Blog
+{
+    public int Id { get; set; } // Primary key
+    public string Name { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>(); // Collection navigation
+    public BlogAssets Assets { get; set; } // Reference navigation
+}
+
+public class BlogAssets
+{
+    public int Id { get; set; } // Primary key
+    public byte[] Banner { get; set; }
+
+    public int? BlogId { get; set; } // Foreign key
+    public Blog Blog { get; set; } // Reference navigation
+}
+
+public class Post
+{
+    public int Id { get; set; } // Primary key
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int? BlogId { get; set; } // Foreign key
+    public Blog Blog { get; set; } // Reference navigation
+
+    public IList<Tag> Tags { get; } = new List<Tag>(); // Skip collection navigation
+}
+
+public class Tag
+{
+    public int Id { get; set; } // Primary key
+    public string Text { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>(); // Skip collection navigation
+}
+#endregion
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
+    }
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+    public DbSet<BlogAssets> Assets { get; set; }
+    public DbSet<Tag> Tags { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
+
+        if (!_quiet)
         {
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
     }
 }

--- a/samples/core/ChangeTracking/ChangingFKsAndNavigations/RequiredRelationshipsSamples.cs
+++ b/samples/core/ChangeTracking/ChangingFKsAndNavigations/RequiredRelationshipsSamples.cs
@@ -5,279 +5,278 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace Required
+namespace Required;
+
+public class RequiredRelationshipsSamples
 {
-    public class RequiredRelationshipsSamples
+    public static void Fixup_for_added_or_deleted_entities_4()
     {
-        public static void Fixup_for_added_or_deleted_entities_4()
+        Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_4)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
+
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        #region Fixup_for_added_or_deleted_entities_4
+        var post = dotNetBlog.Posts.Single(e => e.Title == "Announcing F# 5");
+        dotNetBlog.Posts.Remove(post);
+        #endregion
+
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+
+        Console.WriteLine();
+    }
+
+    public static void Fixup_for_added_or_deleted_entities_5()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_5)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
+        var vsBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == "Visual Studio Blog");
+
+        #region Fixup_for_added_or_deleted_entities_5
+        context.ChangeTracker.DeleteOrphansTiming = CascadeTiming.OnSaveChanges;
+
+        var post = vsBlog.Posts.Single(e => e.Title.StartsWith("Disassembly improvements"));
+        vsBlog.Posts.Remove(post);
+
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        dotNetBlog.Posts.Add(post);
+
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+        #endregion
+
+        Console.WriteLine();
+    }
+
+    public static void Fixup_for_added_or_deleted_entities_6()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_6)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        try
         {
-            Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_4)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
+            #region Fixup_for_added_or_deleted_entities_6
             var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
 
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+            context.ChangeTracker.DeleteOrphansTiming = CascadeTiming.Never;
 
-            #region Fixup_for_added_or_deleted_entities_4
             var post = dotNetBlog.Posts.Single(e => e.Title == "Announcing F# 5");
             dotNetBlog.Posts.Remove(post);
+
+            context.SaveChanges(); // Throws
             #endregion
-
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-
-            Console.WriteLine();
         }
-
-        public static void Fixup_for_added_or_deleted_entities_5()
+        catch (Exception e)
         {
-            Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_5)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
-            var vsBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == "Visual Studio Blog");
-
-            #region Fixup_for_added_or_deleted_entities_5
-            context.ChangeTracker.DeleteOrphansTiming = CascadeTiming.OnSaveChanges;
-
-            var post = vsBlog.Posts.Single(e => e.Title.StartsWith("Disassembly improvements"));
-            vsBlog.Posts.Remove(post);
-
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            dotNetBlog.Posts.Add(post);
-
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-            #endregion
-
-            Console.WriteLine();
+            Console.WriteLine($"{e.GetType().FullName}: {e.Message}");
         }
 
-        public static void Fixup_for_added_or_deleted_entities_6()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_6)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            try
-            {
-                #region Fixup_for_added_or_deleted_entities_6
-                var dotNetBlog = context.Blogs.Include(e => e.Posts).Single(e => e.Name == ".NET Blog");
-
-                context.ChangeTracker.DeleteOrphansTiming = CascadeTiming.Never;
-
-                var post = dotNetBlog.Posts.Single(e => e.Title == "Announcing F# 5");
-                dotNetBlog.Posts.Remove(post);
-
-                context.SaveChanges(); // Throws
-                #endregion
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"{e.GetType().FullName}: {e.Message}");
-            }
-
-            Console.WriteLine();
-        }
-
-        public static void Fixup_for_added_or_deleted_entities_8()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_8)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Fixup_for_added_or_deleted_entities_8
-            using var context = new BlogsContext();
-
-            var dotNetBlog = context.Blogs.Include(e => e.Assets).Single(e => e.Name == ".NET Blog");
-            dotNetBlog.Assets = new BlogAssets();
-
-            context.ChangeTracker.DetectChanges();
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-            #endregion
-
-            Console.WriteLine();
-        }
-
-        public static void Deleting_an_entity_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Deleting_an_entity_2)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Deleting_an_entity_2
-            using var context = new BlogsContext();
-
-            var vsBlog = context.Blogs
-                .Include(e => e.Posts)
-                .Include(e => e.Assets)
-                .Single(e => e.Name == "Visual Studio Blog");
-
-            context.Remove(vsBlog);
-
-            Console.WriteLine(context.ChangeTracker.DebugView.LongView);
-
-            context.SaveChanges();
-            #endregion
-
-            Console.WriteLine();
-        }
+        Console.WriteLine();
     }
 
-    public static class Helpers
+    public static void Fixup_for_added_or_deleted_entities_8()
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        Console.WriteLine($">>>> Sample: {nameof(Fixup_for_added_or_deleted_entities_8)}");
+        Console.WriteLine();
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-        }
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        #region Fixup_for_added_or_deleted_entities_8
+        using var context = new BlogsContext();
 
-            context.AddRange(
-                new Blog
+        var dotNetBlog = context.Blogs.Include(e => e.Assets).Single(e => e.Name == ".NET Blog");
+        dotNetBlog.Assets = new BlogAssets();
+
+        context.ChangeTracker.DetectChanges();
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+        #endregion
+
+        Console.WriteLine();
+    }
+
+    public static void Deleting_an_entity_2()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Deleting_an_entity_2)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Deleting_an_entity_2
+        using var context = new BlogsContext();
+
+        var vsBlog = context.Blogs
+            .Include(e => e.Posts)
+            .Include(e => e.Assets)
+            .Single(e => e.Name == "Visual Studio Blog");
+
+        context.Remove(vsBlog);
+
+        Console.WriteLine(context.ChangeTracker.DebugView.LongView);
+
+        context.SaveChanges();
+        #endregion
+
+        Console.WriteLine();
+    }
+}
+
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+    }
+
+    public static void PopulateDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.AddRange(
+            new Blog
+            {
+                Name = ".NET Blog",
+                Assets = new BlogAssets(),
+                Posts =
                 {
-                    Name = ".NET Blog",
-                    Assets = new BlogAssets(),
-                    Posts =
+                    new Post
                     {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
                     },
                 },
-                new Blog
-                {
-                    Name = "Visual Studio Blog",
-                    Assets = new BlogAssets(),
-                    Posts =
-                    {
-                        new Post
-                        {
-                            Title = "Disassembly improvements for optimized managed debugging",
-                            Content =
-                                "If you are focused on squeezing out the last bits of performance for your .NET service or..."
-                        },
-                        new Post
-                        {
-                            Title = "Database Profiling with Visual Studio",
-                            Content = "Examine when database queries were executed and measure how long the take using..."
-                        },
-                    }
-                },
-                new Tag { Text = ".NET" },
-                new Tag { Text = "Visual Studio" },
-                new Tag { Text = "EF Core" });
-
-            context.SaveChanges();
-        }
-    }
-
-    #region Model
-    public class Blog
-    {
-        public int Id { get; set; } // Primary key
-        public string Name { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>(); // Collection navigation
-        public BlogAssets Assets { get; set; } // Reference navigation
-    }
-
-    public class BlogAssets
-    {
-        public int Id { get; set; } // Primary key
-        public byte[] Banner { get; set; }
-
-        public int BlogId { get; set; } // Foreign key
-        public Blog Blog { get; set; } // Reference navigation
-    }
-
-    public class Post
-    {
-        public int Id { get; set; } // Primary key
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int BlogId { get; set; } // Foreign key
-        public Blog Blog { get; set; } // Reference navigation
-
-        public IList<Tag> Tags { get; } = new List<Tag>(); // Collection navigation
-    }
-
-    public class Tag
-    {
-        public int Id { get; set; } // Primary key
-        public string Text { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>(); // Collection navigation
-    }
-    #endregion
-
-    public class BlogsContext : DbContext
-    {
-        private readonly bool _quiet;
-
-        public BlogsContext(bool quiet = false)
-        {
-            _quiet = quiet;
-        }
-
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<BlogAssets> Assets { get; set; }
-        public DbSet<Tag> Tags { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
+            },
+            new Blog
             {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
-        }
+                Name = "Visual Studio Blog",
+                Assets = new BlogAssets(),
+                Posts =
+                {
+                    new Post
+                    {
+                        Title = "Disassembly improvements for optimized managed debugging",
+                        Content =
+                            "If you are focused on squeezing out the last bits of performance for your .NET service or..."
+                    },
+                    new Post
+                    {
+                        Title = "Database Profiling with Visual Studio",
+                        Content = "Examine when database queries were executed and measure how long the take using..."
+                    },
+                }
+            },
+            new Tag { Text = ".NET" },
+            new Tag { Text = "Visual Studio" },
+            new Tag { Text = "EF Core" });
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        context.SaveChanges();
+    }
+}
+
+#region Model
+public class Blog
+{
+    public int Id { get; set; } // Primary key
+    public string Name { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>(); // Collection navigation
+    public BlogAssets Assets { get; set; } // Reference navigation
+}
+
+public class BlogAssets
+{
+    public int Id { get; set; } // Primary key
+    public byte[] Banner { get; set; }
+
+    public int BlogId { get; set; } // Foreign key
+    public Blog Blog { get; set; } // Reference navigation
+}
+
+public class Post
+{
+    public int Id { get; set; } // Primary key
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int BlogId { get; set; } // Foreign key
+    public Blog Blog { get; set; } // Reference navigation
+
+    public IList<Tag> Tags { get; } = new List<Tag>(); // Collection navigation
+}
+
+public class Tag
+{
+    public int Id { get; set; } // Primary key
+    public string Text { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>(); // Collection navigation
+}
+#endregion
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
+    }
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+    public DbSet<BlogAssets> Assets { get; set; }
+    public DbSet<Tag> Tags { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
+
+        if (!_quiet)
         {
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
     }
 }

--- a/samples/core/ChangeTracking/IdentityResolutionInEFCore/IdentityResolutionSamples.cs
+++ b/samples/core/ChangeTracking/IdentityResolutionInEFCore/IdentityResolutionSamples.cs
@@ -5,328 +5,327 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace Updates
+namespace Updates;
+
+public static class IdentityResolutionSamples
 {
-    public static class IdentityResolutionSamples
+    public static void Identity_Resolution_in_EF_Core_1()
     {
-        public static void Identity_Resolution_in_EF_Core_1()
+        Console.WriteLine($">>>> Sample: {nameof(Identity_Resolution_in_EF_Core_1)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Identity_Resolution_in_EF_Core_1
+        using var context = new BlogsContext();
+
+        var blogA = context.Blogs.Single(e => e.Id == 1);
+        var blogB = new Blog { Id = 1, Name = ".NET Blog (All new!)" };
+
+        try
         {
-            Console.WriteLine($">>>> Sample: {nameof(Identity_Resolution_in_EF_Core_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Identity_Resolution_in_EF_Core_1
-            using var context = new BlogsContext();
-
-            var blogA = context.Blogs.Single(e => e.Id == 1);
-            var blogB = new Blog { Id = 1, Name = ".NET Blog (All new!)" };
-
-            try
-            {
-                context.Update(blogB); // This will throw
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"{e.GetType().FullName}: {e.Message}");
-            }
-            #endregion
-
-            Console.WriteLine();
+            context.Update(blogB); // This will throw
         }
-
-        public static void Updating_an_entity_1()
+        catch (Exception e)
         {
-            Console.WriteLine($">>>> Sample: {nameof(Updating_an_entity_1)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            UpdateFromHttpPost1(
-                new Blog { Id = 1, Name = ".NET Blog (All new!)", Summary = "Posts about .NET" });
-
-            Console.WriteLine();
-        }
-
-        #region Updating_an_entity_1
-        public static void UpdateFromHttpPost1(Blog blog)
-        {
-            using var context = new BlogsContext();
-
-            context.Update(blog);
-
-            context.SaveChanges();
+            Console.WriteLine($"{e.GetType().FullName}: {e.Message}");
         }
         #endregion
 
-        public static void Updating_an_entity_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Updating_an_entity_2)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            UpdateFromHttpPost2(
-                new Blog { Id = 1, Name = ".NET Blog (All new!)", Summary = "Posts about .NET" });
-
-            Console.WriteLine();
-        }
-
-        #region Updating_an_entity_2
-        public static void UpdateFromHttpPost2(Blog blog)
-        {
-            using var context = new BlogsContext();
-
-            var trackedBlog = context.Blogs.Find(blog.Id);
-
-            trackedBlog.Name = blog.Name;
-            trackedBlog.Summary = blog.Summary;
-
-            context.SaveChanges();
-        }
-        #endregion
-
-        public static void Updating_an_entity_3()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Updating_an_entity_3)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            UpdateFromHttpPost3(
-                new Blog { Id = 1, Name = ".NET Blog (All new!)", Summary = "Posts about .NET" });
-
-            Console.WriteLine();
-        }
-
-        #region Updating_an_entity_3
-        public static void UpdateFromHttpPost3(Blog blog)
-        {
-            using var context = new BlogsContext();
-
-            var trackedBlog = context.Blogs.Find(blog.Id);
-
-            context.Entry(trackedBlog).CurrentValues.SetValues(blog);
-
-            context.SaveChanges();
-        }
-        #endregion
-
-        public static void Updating_an_entity_4()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Updating_an_entity_4)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            UpdateFromHttpPost4(
-                new BlogDto { Id = 1, Name = ".NET Blog (All new!)", Summary = "Posts about .NET" });
-
-            Console.WriteLine();
-        }
-
-        #region Updating_an_entity_4
-        public static void UpdateFromHttpPost4(BlogDto dto)
-        {
-            using var context = new BlogsContext();
-
-            var trackedBlog = context.Blogs.Find(dto.Id);
-
-            context.Entry(trackedBlog).CurrentValues.SetValues(dto);
-
-            context.SaveChanges();
-        }
-        #endregion
-
-        public static void Updating_an_entity_5()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Updating_an_entity_5)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            UpdateFromHttpPost5(
-                new Dictionary<string, object> { ["Id"] = 1, ["Name"] = ".NET Blog (All new!)", ["Summary"] = "Posts about .NET" });
-
-            Console.WriteLine();
-        }
-
-        #region Updating_an_entity_5
-        public static void UpdateFromHttpPost5(Dictionary<string, object> propertyValues)
-        {
-            using var context = new BlogsContext();
-
-            var trackedBlog = context.Blogs.Find(propertyValues["Id"]);
-
-            context.Entry(trackedBlog).CurrentValues.SetValues(propertyValues);
-
-            context.SaveChanges();
-        }
-        #endregion
-
-        public static void Updating_an_entity_6()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Updating_an_entity_6)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            UpdateFromHttpPost6(
-                new Blog { Id = 1, Name = ".NET Blog (All new!)", Summary = "Posts about .NET" },
-                new Dictionary<string, object> { ["Id"] = 1, ["Name"] = ".NET Blog", ["Summary"] = "Posts about .NET" });
-
-            Console.WriteLine();
-        }
-
-        #region Updating_an_entity_6
-        public static void UpdateFromHttpPost6(Blog blog, Dictionary<string, object> originalValues)
-        {
-            using var context = new BlogsContext();
-
-            context.Attach(blog);
-            context.Entry(blog).OriginalValues.SetValues(originalValues);
-
-            context.SaveChanges();
-        }
-        #endregion
-
-        public static void Failing_to_set_key_values_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Failing_to_set_key_values_1)}");
-            Console.WriteLine();
-
-            #region Failing_to_set_key_values_1
-            using var context = new BlogsContext();
-
-            context.Add(new Pet { Name = "Smokey" });
-
-            try
-            {
-                context.Add(new Pet { Name = "Clippy" }); // This will throw
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"{e.GetType().FullName}: {e.Message}");
-            }
-            #endregion
-        }
+        Console.WriteLine();
     }
 
-    public static class Helpers
+    public static void Updating_an_entity_1()
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        Console.WriteLine($">>>> Sample: {nameof(Updating_an_entity_1)}");
+        Console.WriteLine();
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-        }
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        UpdateFromHttpPost1(
+            new Blog { Id = 1, Name = ".NET Blog (All new!)", Summary = "Posts about .NET" });
 
-            context.Add(
-                new Blog
-                {
-                    Name = ".NET Blog",
-                    Posts =
-                    {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
-                    }
-                });
-
-            context.SaveChanges();
-        }
+        Console.WriteLine();
     }
 
-    #region Pet
-    public class Pet
+    #region Updating_an_entity_1
+    public static void UpdateFromHttpPost1(Blog blog)
     {
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public int Id { get; set; }
+        using var context = new BlogsContext();
 
-        public string Name { get; set; }
+        context.Update(blog);
+
+        context.SaveChanges();
     }
     #endregion
 
-    public class Customer
+    public static void Updating_an_entity_2()
     {
-        #region OrdersCollection
-        public ICollection<Order> Orders { get; set; }
-            = new HashSet<Order>(ReferenceEqualityComparer.Instance);
+        Console.WriteLine($">>>> Sample: {nameof(Updating_an_entity_2)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        UpdateFromHttpPost2(
+            new Blog { Id = 1, Name = ".NET Blog (All new!)", Summary = "Posts about .NET" });
+
+        Console.WriteLine();
+    }
+
+    #region Updating_an_entity_2
+    public static void UpdateFromHttpPost2(Blog blog)
+    {
+        using var context = new BlogsContext();
+
+        var trackedBlog = context.Blogs.Find(blog.Id);
+
+        trackedBlog.Name = blog.Name;
+        trackedBlog.Summary = blog.Summary;
+
+        context.SaveChanges();
+    }
+    #endregion
+
+    public static void Updating_an_entity_3()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Updating_an_entity_3)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        UpdateFromHttpPost3(
+            new Blog { Id = 1, Name = ".NET Blog (All new!)", Summary = "Posts about .NET" });
+
+        Console.WriteLine();
+    }
+
+    #region Updating_an_entity_3
+    public static void UpdateFromHttpPost3(Blog blog)
+    {
+        using var context = new BlogsContext();
+
+        var trackedBlog = context.Blogs.Find(blog.Id);
+
+        context.Entry(trackedBlog).CurrentValues.SetValues(blog);
+
+        context.SaveChanges();
+    }
+    #endregion
+
+    public static void Updating_an_entity_4()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Updating_an_entity_4)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        UpdateFromHttpPost4(
+            new BlogDto { Id = 1, Name = ".NET Blog (All new!)", Summary = "Posts about .NET" });
+
+        Console.WriteLine();
+    }
+
+    #region Updating_an_entity_4
+    public static void UpdateFromHttpPost4(BlogDto dto)
+    {
+        using var context = new BlogsContext();
+
+        var trackedBlog = context.Blogs.Find(dto.Id);
+
+        context.Entry(trackedBlog).CurrentValues.SetValues(dto);
+
+        context.SaveChanges();
+    }
+    #endregion
+
+    public static void Updating_an_entity_5()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Updating_an_entity_5)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        UpdateFromHttpPost5(
+            new Dictionary<string, object> { ["Id"] = 1, ["Name"] = ".NET Blog (All new!)", ["Summary"] = "Posts about .NET" });
+
+        Console.WriteLine();
+    }
+
+    #region Updating_an_entity_5
+    public static void UpdateFromHttpPost5(Dictionary<string, object> propertyValues)
+    {
+        using var context = new BlogsContext();
+
+        var trackedBlog = context.Blogs.Find(propertyValues["Id"]);
+
+        context.Entry(trackedBlog).CurrentValues.SetValues(propertyValues);
+
+        context.SaveChanges();
+    }
+    #endregion
+
+    public static void Updating_an_entity_6()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Updating_an_entity_6)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        UpdateFromHttpPost6(
+            new Blog { Id = 1, Name = ".NET Blog (All new!)", Summary = "Posts about .NET" },
+            new Dictionary<string, object> { ["Id"] = 1, ["Name"] = ".NET Blog", ["Summary"] = "Posts about .NET" });
+
+        Console.WriteLine();
+    }
+
+    #region Updating_an_entity_6
+    public static void UpdateFromHttpPost6(Blog blog, Dictionary<string, object> originalValues)
+    {
+        using var context = new BlogsContext();
+
+        context.Attach(blog);
+        context.Entry(blog).OriginalValues.SetValues(originalValues);
+
+        context.SaveChanges();
+    }
+    #endregion
+
+    public static void Failing_to_set_key_values_1()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Failing_to_set_key_values_1)}");
+        Console.WriteLine();
+
+        #region Failing_to_set_key_values_1
+        using var context = new BlogsContext();
+
+        context.Add(new Pet { Name = "Smokey" });
+
+        try
+        {
+            context.Add(new Pet { Name = "Clippy" }); // This will throw
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"{e.GetType().FullName}: {e.Message}");
+        }
         #endregion
     }
+}
 
-    public class Order
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
     {
+        using var context = new BlogsContext(quiet: true);
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
     }
 
-    public class BlogDto
+    public static void PopulateDatabase()
     {
-        public int Id { get; set; }
-        public string Name { get; set; }
-        public string Summary { get; set; }
-    }
+        using var context = new BlogsContext(quiet: true);
 
-    public class Blog
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-        public string Summary { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>();
-    }
-
-    public class Post
-    {
-        public int Id { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int? BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
-
-    public class BlogsContext : DbContext
-    {
-        private readonly bool _quiet;
-
-        public BlogsContext(bool quiet = false)
-        {
-            _quiet = quiet;
-        }
-
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<Pet> Pets { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
-
-            if (!_quiet)
+        context.Add(
+            new Blog
             {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
+                Name = ".NET Blog",
+                Posts =
+                {
+                    new Post
+                    {
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
+                    },
+                }
+            });
+
+        context.SaveChanges();
+    }
+}
+
+#region Pet
+public class Pet
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public int Id { get; set; }
+
+    public string Name { get; set; }
+}
+#endregion
+
+public class Customer
+{
+    #region OrdersCollection
+    public ICollection<Order> Orders { get; set; }
+        = new HashSet<Order>(ReferenceEqualityComparer.Instance);
+    #endregion
+}
+
+public class Order
+{
+}
+
+public class BlogDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Summary { get; set; }
+}
+
+public class Blog
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Summary { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>();
+}
+
+public class Post
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int? BlogId { get; set; }
+    public Blog Blog { get; set; }
+}
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
+    }
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+    public DbSet<Pet> Pets { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
+
+        if (!_quiet)
+        {
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
     }
 }

--- a/samples/core/ChangeTracking/IdentityResolutionInEFCore/SerializedGraphExamples.cs
+++ b/samples/core/ChangeTracking/IdentityResolutionInEFCore/SerializedGraphExamples.cs
@@ -8,314 +8,313 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Newtonsoft.Json;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
-namespace Graphs
+namespace Graphs;
+
+public static class SerializedGraphExamples
 {
-    public static class SerializedGraphExamples
+    public static void Attaching_a_serialized_graph_1()
     {
-        public static void Attaching_a_serialized_graph_1()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Attaching_a_serialized_graph_1)}");
-            Console.WriteLine();
+        Console.WriteLine($">>>> Sample: {nameof(Attaching_a_serialized_graph_1)}");
+        Console.WriteLine();
 
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
 
-            #region Attaching_a_serialized_graph_1a
-            using var context = new BlogsContext();
+        #region Attaching_a_serialized_graph_1a
+        using var context = new BlogsContext();
 
-            var blogs = context.Blogs.Include(e => e.Posts).ToList();
+        var blogs = context.Blogs.Include(e => e.Posts).ToList();
 
-            var serialized = JsonConvert.SerializeObject(
-                blogs,
-                new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore, Formatting = Formatting.Indented });
+        var serialized = JsonConvert.SerializeObject(
+            blogs,
+            new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore, Formatting = Formatting.Indented });
 
-            Console.WriteLine(serialized);
-            #endregion
-
-            UpdateBlogsFromJson(serialized);
-        }
-
-        #region Attaching_a_serialized_graph_1b
-        public static void UpdateBlogsFromJson(string json)
-        {
-            using var context = new BlogsContext();
-
-            var blogs = JsonConvert.DeserializeObject<List<Blog>>(json);
-
-            foreach (var blog in blogs)
-            {
-                context.Update(blog);
-            }
-
-            context.SaveChanges();
-        }
+        Console.WriteLine(serialized);
         #endregion
 
-        public static void Attaching_a_serialized_graph_2()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Attaching_a_serialized_graph_2)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            #region Attaching_a_serialized_graph_2
-            using var context = new BlogsContext();
-
-            var posts = context.Posts.Include(e => e.Blog).ToList();
-
-            var serialized = JsonConvert.SerializeObject(
-                posts,
-                new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore, Formatting = Formatting.Indented });
-
-            Console.WriteLine(serialized);
-            #endregion
-
-            UpdatePostsFromJsonBad(serialized);
-        }
-
-        public static void UpdatePostsFromJsonBad(string json)
-        {
-            using var context = new BlogsContext();
-
-            var posts = JsonConvert.DeserializeObject<List<Post>>(json);
-
-            try
-            {
-                foreach (var post in posts)
-                {
-                    context.Update(post); // Will throw
-                }
-
-                context.SaveChanges();
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"{e.GetType().FullName}: {e.Message}");
-            }
-        }
-
-        public static void Attaching_a_serialized_graph_3()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Attaching_a_serialized_graph_3)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var posts = context.Posts.Include(e => e.Blog).ToList();
-
-            #region Attaching_a_serialized_graph_3
-            var serialized = JsonConvert.SerializeObject(
-                posts,
-                new JsonSerializerSettings
-                {
-                    PreserveReferencesHandling = PreserveReferencesHandling.All, Formatting = Formatting.Indented
-                });
-            #endregion
-
-            Console.WriteLine(serialized);
-
-            UpdatePostsFromJson(serialized);
-        }
-
-        public static void UpdatePostsFromJson(string json)
-        {
-            using var context = new BlogsContext();
-
-            var posts = JsonConvert.DeserializeObject<List<Post>>(json);
-
-            foreach (var post in posts)
-            {
-                context.Update(post);
-            }
-
-            context.SaveChanges();
-        }
-
-        public static void Attaching_a_serialized_graph_4()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Attaching_a_serialized_graph_4)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var posts = context.Posts.Include(e => e.Blog).ToList();
-
-            #region Attaching_a_serialized_graph_4
-            var serialized = JsonSerializer.Serialize(
-                posts, new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.Preserve, WriteIndented = true });
-            #endregion
-
-            Console.WriteLine(serialized);
-
-            UpdatePostsFromJson(serialized);
-        }
-
-        public static void Attaching_a_serialized_graph_5()
-        {
-            Console.WriteLine($">>>> Sample: {nameof(Attaching_a_serialized_graph_4)}");
-            Console.WriteLine();
-
-            Helpers.RecreateCleanDatabase();
-            Helpers.PopulateDatabase();
-
-            using var context = new BlogsContext();
-
-            var posts = context.Posts.Include(e => e.Blog).ToList();
-
-            var serialized = JsonConvert.SerializeObject(
-                posts,
-                new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore, Formatting = Formatting.Indented });
-
-            Console.WriteLine(serialized);
-
-            Console.WriteLine()
-                ;
-            UpdatePostsFromJsonWithIdentityResolution(serialized);
-        }
-
-        #region Attaching_a_serialized_graph_5
-        public static void UpdatePostsFromJsonWithIdentityResolution(string json)
-        {
-            using var context = new BlogsContext();
-
-            var posts = JsonConvert.DeserializeObject<List<Post>>(json);
-
-            foreach (var post in posts)
-            {
-                context.ChangeTracker.TrackGraph(
-                    post, node =>
-                    {
-                        var keyValue = node.Entry.Property("Id").CurrentValue;
-                        var entityType = node.Entry.Metadata;
-
-                        var existingEntity = node.Entry.Context.ChangeTracker.Entries()
-                            .FirstOrDefault(
-                                e => Equals(e.Metadata, entityType)
-                                     && Equals(e.Property("Id").CurrentValue, keyValue));
-
-                        if (existingEntity == null)
-                        {
-                            Console.WriteLine($"Tracking {entityType.DisplayName()} entity with key value {keyValue}");
-
-                            node.Entry.State = EntityState.Modified;
-                        }
-                        else
-                        {
-                            Console.WriteLine($"Discarding duplicate {entityType.DisplayName()} entity with key value {keyValue}");
-                        }
-                    });
-            }
-
-            context.SaveChanges();
-        }
-        #endregion
+        UpdateBlogsFromJson(serialized);
     }
 
-    public static class Helpers
+    #region Attaching_a_serialized_graph_1b
+    public static void UpdateBlogsFromJson(string json)
     {
-        public static void RecreateCleanDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        using var context = new BlogsContext();
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
+        var blogs = JsonConvert.DeserializeObject<List<Blog>>(json);
+
+        foreach (var blog in blogs)
+        {
+            context.Update(blog);
         }
 
-        public static void PopulateDatabase()
-        {
-            using var context = new BlogsContext(quiet: true);
+        context.SaveChanges();
+    }
+    #endregion
 
-            context.AddRange(
-                new Blog
+    public static void Attaching_a_serialized_graph_2()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Attaching_a_serialized_graph_2)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        #region Attaching_a_serialized_graph_2
+        using var context = new BlogsContext();
+
+        var posts = context.Posts.Include(e => e.Blog).ToList();
+
+        var serialized = JsonConvert.SerializeObject(
+            posts,
+            new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore, Formatting = Formatting.Indented });
+
+        Console.WriteLine(serialized);
+        #endregion
+
+        UpdatePostsFromJsonBad(serialized);
+    }
+
+    public static void UpdatePostsFromJsonBad(string json)
+    {
+        using var context = new BlogsContext();
+
+        var posts = JsonConvert.DeserializeObject<List<Post>>(json);
+
+        try
+        {
+            foreach (var post in posts)
+            {
+                context.Update(post); // Will throw
+            }
+
+            context.SaveChanges();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"{e.GetType().FullName}: {e.Message}");
+        }
+    }
+
+    public static void Attaching_a_serialized_graph_3()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Attaching_a_serialized_graph_3)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        var posts = context.Posts.Include(e => e.Blog).ToList();
+
+        #region Attaching_a_serialized_graph_3
+        var serialized = JsonConvert.SerializeObject(
+            posts,
+            new JsonSerializerSettings
+            {
+                PreserveReferencesHandling = PreserveReferencesHandling.All, Formatting = Formatting.Indented
+            });
+        #endregion
+
+        Console.WriteLine(serialized);
+
+        UpdatePostsFromJson(serialized);
+    }
+
+    public static void UpdatePostsFromJson(string json)
+    {
+        using var context = new BlogsContext();
+
+        var posts = JsonConvert.DeserializeObject<List<Post>>(json);
+
+        foreach (var post in posts)
+        {
+            context.Update(post);
+        }
+
+        context.SaveChanges();
+    }
+
+    public static void Attaching_a_serialized_graph_4()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Attaching_a_serialized_graph_4)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        var posts = context.Posts.Include(e => e.Blog).ToList();
+
+        #region Attaching_a_serialized_graph_4
+        var serialized = JsonSerializer.Serialize(
+            posts, new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.Preserve, WriteIndented = true });
+        #endregion
+
+        Console.WriteLine(serialized);
+
+        UpdatePostsFromJson(serialized);
+    }
+
+    public static void Attaching_a_serialized_graph_5()
+    {
+        Console.WriteLine($">>>> Sample: {nameof(Attaching_a_serialized_graph_4)}");
+        Console.WriteLine();
+
+        Helpers.RecreateCleanDatabase();
+        Helpers.PopulateDatabase();
+
+        using var context = new BlogsContext();
+
+        var posts = context.Posts.Include(e => e.Blog).ToList();
+
+        var serialized = JsonConvert.SerializeObject(
+            posts,
+            new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore, Formatting = Formatting.Indented });
+
+        Console.WriteLine(serialized);
+
+        Console.WriteLine()
+            ;
+        UpdatePostsFromJsonWithIdentityResolution(serialized);
+    }
+
+    #region Attaching_a_serialized_graph_5
+    public static void UpdatePostsFromJsonWithIdentityResolution(string json)
+    {
+        using var context = new BlogsContext();
+
+        var posts = JsonConvert.DeserializeObject<List<Post>>(json);
+
+        foreach (var post in posts)
+        {
+            context.ChangeTracker.TrackGraph(
+                post, node =>
                 {
-                    Name = ".NET Blog",
-                    Summary = "Posts about .NET",
-                    Posts =
+                    var keyValue = node.Entry.Property("Id").CurrentValue;
+                    var entityType = node.Entry.Metadata;
+
+                    var existingEntity = node.Entry.Context.ChangeTracker.Entries()
+                        .FirstOrDefault(
+                            e => Equals(e.Metadata, entityType)
+                                 && Equals(e.Property("Id").CurrentValue, keyValue));
+
+                    if (existingEntity == null)
                     {
-                        new Post
-                        {
-                            Title = "Announcing the Release of EF Core 5.0",
-                            Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
-                        },
-                        new Post
-                        {
-                            Title = "Announcing F# 5",
-                            Content = "F# 5 is the latest version of F#, the functional programming language..."
-                        },
-                    },
-                },
-                new Blog
-                {
-                    Name = "Visual Studio Blog",
-                    Summary = "Posts about Visual Studio",
-                    Posts =
+                        Console.WriteLine($"Tracking {entityType.DisplayName()} entity with key value {keyValue}");
+
+                        node.Entry.State = EntityState.Modified;
+                    }
+                    else
                     {
-                        new Post
-                        {
-                            Title = "Disassembly improvements for optimized managed debugging",
-                            Content =
-                                "If you are focused on squeezing out the last bits of performance for your .NET service or..."
-                        },
-                        new Post
-                        {
-                            Title = "Database Profiling with Visual Studio",
-                            Content = "Examine when database queries were executed and measure how long the take using..."
-                        },
+                        Console.WriteLine($"Discarding duplicate {entityType.DisplayName()} entity with key value {keyValue}");
                     }
                 });
-
-            context.SaveChanges();
-        }
-    }
-
-    public class Blog
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-        public string Summary { get; set; }
-
-        public IList<Post> Posts { get; } = new List<Post>();
-    }
-
-    public class Post
-    {
-        public int Id { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int? BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
-
-    public class BlogsContext : DbContext
-    {
-        private readonly bool _quiet;
-
-        public BlogsContext(bool quiet = false)
-        {
-            _quiet = quiet;
         }
 
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+        context.SaveChanges();
+    }
+    #endregion
+}
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlite("DataSource=test.db");
+public static class Helpers
+{
+    public static void RecreateCleanDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
 
-            if (!_quiet)
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+    }
+
+    public static void PopulateDatabase()
+    {
+        using var context = new BlogsContext(quiet: true);
+
+        context.AddRange(
+            new Blog
             {
-                optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
-            }
+                Name = ".NET Blog",
+                Summary = "Posts about .NET",
+                Posts =
+                {
+                    new Post
+                    {
+                        Title = "Announcing the Release of EF Core 5.0",
+                        Content = "Announcing the release of EF Core 5.0, a full featured cross-platform..."
+                    },
+                    new Post
+                    {
+                        Title = "Announcing F# 5",
+                        Content = "F# 5 is the latest version of F#, the functional programming language..."
+                    },
+                },
+            },
+            new Blog
+            {
+                Name = "Visual Studio Blog",
+                Summary = "Posts about Visual Studio",
+                Posts =
+                {
+                    new Post
+                    {
+                        Title = "Disassembly improvements for optimized managed debugging",
+                        Content =
+                            "If you are focused on squeezing out the last bits of performance for your .NET service or..."
+                    },
+                    new Post
+                    {
+                        Title = "Database Profiling with Visual Studio",
+                        Content = "Examine when database queries were executed and measure how long the take using..."
+                    },
+                }
+            });
+
+        context.SaveChanges();
+    }
+}
+
+public class Blog
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Summary { get; set; }
+
+    public IList<Post> Posts { get; } = new List<Post>();
+}
+
+public class Post
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int? BlogId { get; set; }
+    public Blog Blog { get; set; }
+}
+
+public class BlogsContext : DbContext
+{
+    private readonly bool _quiet;
+
+    public BlogsContext(bool quiet = false)
+    {
+        _quiet = quiet;
+    }
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlite("DataSource=test.db");
+
+        if (!_quiet)
+        {
+            optionsBuilder.LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted });
         }
     }
 }

--- a/samples/core/Cosmos/ModelBuilding/Distributor.cs
+++ b/samples/core/Cosmos/ModelBuilding/Distributor.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
 
-namespace Cosmos.ModelBuilding
+namespace Cosmos.ModelBuilding;
+
+#region Distributor
+public class Distributor
 {
-    #region Distributor
-    public class Distributor
-    {
-        public int Id { get; set; }
-        public string ETag { get; set; }
-        public ICollection<StreetAddress> ShippingCenters { get; set; }
-    }
-    #endregion
+    public int Id { get; set; }
+    public string ETag { get; set; }
+    public ICollection<StreetAddress> ShippingCenters { get; set; }
 }
+#endregion

--- a/samples/core/Cosmos/ModelBuilding/OptionsContext.cs
+++ b/samples/core/Cosmos/ModelBuilding/OptionsContext.cs
@@ -3,28 +3,27 @@ using System.Net;
 using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore;
 
-namespace Cosmos.ModelBuilding
+namespace Cosmos.ModelBuilding;
+
+public class OptionsContext : DbContext
 {
-    public class OptionsContext : DbContext
-    {
-        #region Configuration
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.UseCosmos(
-                "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
-                databaseName: "OptionsDB",
-                options =>
-                {
-                    options.ConnectionMode(ConnectionMode.Gateway);
-                    options.WebProxy(new WebProxy());
-                    options.LimitToEndpoint();
-                    options.Region(Regions.AustraliaCentral);
-                    options.GatewayModeMaxConnectionLimit(32);
-                    options.MaxRequestsPerTcpConnection(8);
-                    options.MaxTcpConnectionsPerEndpoint(16);
-                    options.IdleTcpConnectionTimeout(TimeSpan.FromMinutes(1));
-                    options.OpenTcpConnectionTimeout(TimeSpan.FromMinutes(1));
-                    options.RequestTimeout(TimeSpan.FromMinutes(1));
-                });
-        #endregion
-    }
+    #region Configuration
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseCosmos(
+            "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
+            databaseName: "OptionsDB",
+            options =>
+            {
+                options.ConnectionMode(ConnectionMode.Gateway);
+                options.WebProxy(new WebProxy());
+                options.LimitToEndpoint();
+                options.Region(Regions.AustraliaCentral);
+                options.GatewayModeMaxConnectionLimit(32);
+                options.MaxRequestsPerTcpConnection(8);
+                options.MaxTcpConnectionsPerEndpoint(16);
+                options.IdleTcpConnectionTimeout(TimeSpan.FromMinutes(1));
+                options.OpenTcpConnectionTimeout(TimeSpan.FromMinutes(1));
+                options.RequestTimeout(TimeSpan.FromMinutes(1));
+            });
+    #endregion
 }

--- a/samples/core/Cosmos/ModelBuilding/Order.cs
+++ b/samples/core/Cosmos/ModelBuilding/Order.cs
@@ -1,12 +1,11 @@
-﻿namespace Cosmos.ModelBuilding
+﻿namespace Cosmos.ModelBuilding;
+
+#region Order
+public class Order
 {
-    #region Order
-    public class Order
-    {
-        public int Id { get; set; }
-        public int? TrackingNumber { get; set; }
-        public string PartitionKey { get; set; }
-        public StreetAddress ShippingAddress { get; set; }
-    }
-    #endregion
+    public int Id { get; set; }
+    public int? TrackingNumber { get; set; }
+    public string PartitionKey { get; set; }
+    public StreetAddress ShippingAddress { get; set; }
 }
+#endregion

--- a/samples/core/Cosmos/ModelBuilding/OrderContext.cs
+++ b/samples/core/Cosmos/ModelBuilding/OrderContext.cs
@@ -1,66 +1,65 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace Cosmos.ModelBuilding
-{
-    public class OrderContext : DbContext
-    {
-        public DbSet<Order> Orders { get; set; }
-        public DbSet<Distributor> Distributors { get; set; }
+namespace Cosmos.ModelBuilding;
 
-        #region Configuration
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.UseCosmos(
-                "https://localhost:8081",
-                "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
-                databaseName: "OrdersDB");
+public class OrderContext : DbContext
+{
+    public DbSet<Order> Orders { get; set; }
+    public DbSet<Distributor> Distributors { get; set; }
+
+    #region Configuration
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseCosmos(
+            "https://localhost:8081",
+            "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
+            databaseName: "OrdersDB");
+    #endregion
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        #region DefaultContainer
+        modelBuilder.HasDefaultContainer("Store");
         #endregion
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            #region DefaultContainer
-            modelBuilder.HasDefaultContainer("Store");
-            #endregion
+        #region Container
+        modelBuilder.Entity<Order>()
+            .ToContainer("Orders");
+        #endregion
 
-            #region Container
-            modelBuilder.Entity<Order>()
-                .ToContainer("Orders");
-            #endregion
+        #region NoDiscriminator
+        modelBuilder.Entity<Order>()
+            .HasNoDiscriminator();
+        #endregion
 
-            #region NoDiscriminator
-            modelBuilder.Entity<Order>()
-                .HasNoDiscriminator();
-            #endregion
+        #region PartitionKey
+        modelBuilder.Entity<Order>()
+            .HasPartitionKey(o => o.PartitionKey);
+        #endregion
 
-            #region PartitionKey
-            modelBuilder.Entity<Order>()
-                .HasPartitionKey(o => o.PartitionKey);
-            #endregion
+        #region ETag
+        modelBuilder.Entity<Order>()
+            .UseETagConcurrency();
+        #endregion
 
-            #region ETag
-            modelBuilder.Entity<Order>()
-                .UseETagConcurrency();
-            #endregion
+        #region PropertyNames
+        modelBuilder.Entity<Order>().OwnsOne(
+            o => o.ShippingAddress,
+            sa =>
+            {
+                sa.ToJsonProperty("Address");
+                sa.Property(p => p.Street).ToJsonProperty("ShipsToStreet");
+                sa.Property(p => p.City).ToJsonProperty("ShipsToCity");
+            });
+        #endregion
 
-            #region PropertyNames
-            modelBuilder.Entity<Order>().OwnsOne(
-                o => o.ShippingAddress,
-                sa =>
-                {
-                    sa.ToJsonProperty("Address");
-                    sa.Property(p => p.Street).ToJsonProperty("ShipsToStreet");
-                    sa.Property(p => p.City).ToJsonProperty("ShipsToCity");
-                });
-            #endregion
+        #region OwnsMany
+        modelBuilder.Entity<Distributor>().OwnsMany(p => p.ShippingCenters);
+        #endregion
 
-            #region OwnsMany
-            modelBuilder.Entity<Distributor>().OwnsMany(p => p.ShippingCenters);
-            #endregion
-
-            #region ETagProperty
-            modelBuilder.Entity<Distributor>()
-                .Property(d => d.ETag)
-                .IsETagConcurrency();
-            #endregion
-        }
+        #region ETagProperty
+        modelBuilder.Entity<Distributor>()
+            .Property(d => d.ETag)
+            .IsETagConcurrency();
+        #endregion
     }
 }

--- a/samples/core/Cosmos/ModelBuilding/Sample.cs
+++ b/samples/core/Cosmos/ModelBuilding/Sample.cs
@@ -4,114 +4,113 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 
-namespace Cosmos.ModelBuilding
+namespace Cosmos.ModelBuilding;
+
+public static class Sample
 {
-    public static class Sample
+    public static async Task Run()
     {
-        public static async Task Run()
+        Console.WriteLine();
+        Console.WriteLine("Getting started with Cosmos:");
+        Console.WriteLine();
+
+        #region HelloCosmos
+        using (var context = new OrderContext())
         {
-            Console.WriteLine();
-            Console.WriteLine("Getting started with Cosmos:");
-            Console.WriteLine();
+            await context.Database.EnsureDeletedAsync();
+            await context.Database.EnsureCreatedAsync();
 
-            #region HelloCosmos
-            using (var context = new OrderContext())
-            {
-                await context.Database.EnsureDeletedAsync();
-                await context.Database.EnsureCreatedAsync();
-
-                context.Add(
-                    new Order
-                    {
-                        Id = 1, ShippingAddress = new StreetAddress { City = "London", Street = "221 B Baker St" }, PartitionKey = "1"
-                    });
-
-                await context.SaveChangesAsync();
-            }
-
-            using (var context = new OrderContext())
-            {
-                var order = await context.Orders.FirstAsync();
-                Console.WriteLine($"First order will ship to: {order.ShippingAddress.Street}, {order.ShippingAddress.City}");
-                Console.WriteLine();
-            }
-            #endregion
-
-            #region PartitionKey
-            using (var context = new OrderContext())
-            {
-                context.Add(
-                    new Order
-                    {
-                        Id = 2, ShippingAddress = new StreetAddress { City = "New York", Street = "11 Wall Street" }, PartitionKey = "2"
-                    });
-
-                await context.SaveChangesAsync();
-            }
-
-            using (var context = new OrderContext())
-            {
-                var order = await context.Orders.WithPartitionKey("2").LastAsync();
-                Console.WriteLine($"Last order will ship to: {order.ShippingAddress.Street}, {order.ShippingAddress.City}");
-                Console.WriteLine();
-            }
-            #endregion
-
-            #region OwnedCollection
-            var distributor = new Distributor
-            {
-                Id = 1,
-                ShippingCenters = new HashSet<StreetAddress>
+            context.Add(
+                new Order
                 {
-                    new StreetAddress { City = "Phoenix", Street = "500 S 48th Street" },
-                    new StreetAddress { City = "Anaheim", Street = "5650 Dolly Ave" }
-                }
-            };
+                    Id = 1, ShippingAddress = new StreetAddress { City = "London", Street = "221 B Baker St" }, PartitionKey = "1"
+                });
 
-            using (var context = new OrderContext())
-            {
-                context.Add(distributor);
-
-                await context.SaveChangesAsync();
-            }
-            #endregion
-
-            #region ImpliedProperties
-            using (var context = new OrderContext())
-            {
-                var firstDistributor = await context.Distributors.FirstAsync();
-                Console.WriteLine($"Number of shipping centers: {firstDistributor.ShippingCenters.Count}");
-
-                var addressEntry = context.Entry(firstDistributor.ShippingCenters.First());
-                var addressPKProperties = addressEntry.Metadata.FindPrimaryKey().Properties;
-
-                Console.WriteLine(
-                    $"First shipping center PK: ({addressEntry.Property(addressPKProperties[0].Name).CurrentValue}, {addressEntry.Property(addressPKProperties[1].Name).CurrentValue})");
-                Console.WriteLine();
-            }
-            #endregion
-
-            #region Attach
-            using (var context = new OrderContext())
-            {
-                var distributorEntry = context.Add(distributor);
-                distributorEntry.State = EntityState.Unchanged;
-
-                distributor.ShippingCenters.Remove(distributor.ShippingCenters.Last());
-
-                await context.SaveChangesAsync();
-            }
-
-            using (var context = new OrderContext())
-            {
-                var firstDistributor = await context.Distributors.FirstAsync();
-                Console.WriteLine($"Number of shipping centers is now: {firstDistributor.ShippingCenters.Count}");
-
-                var distributorEntry = context.Entry(firstDistributor);
-                var idProperty = distributorEntry.Property<string>("__id");
-                Console.WriteLine($"The distributor 'id' is: {idProperty.CurrentValue}");
-            }
-            #endregion
+            await context.SaveChangesAsync();
         }
+
+        using (var context = new OrderContext())
+        {
+            var order = await context.Orders.FirstAsync();
+            Console.WriteLine($"First order will ship to: {order.ShippingAddress.Street}, {order.ShippingAddress.City}");
+            Console.WriteLine();
+        }
+        #endregion
+
+        #region PartitionKey
+        using (var context = new OrderContext())
+        {
+            context.Add(
+                new Order
+                {
+                    Id = 2, ShippingAddress = new StreetAddress { City = "New York", Street = "11 Wall Street" }, PartitionKey = "2"
+                });
+
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new OrderContext())
+        {
+            var order = await context.Orders.WithPartitionKey("2").LastAsync();
+            Console.WriteLine($"Last order will ship to: {order.ShippingAddress.Street}, {order.ShippingAddress.City}");
+            Console.WriteLine();
+        }
+        #endregion
+
+        #region OwnedCollection
+        var distributor = new Distributor
+        {
+            Id = 1,
+            ShippingCenters = new HashSet<StreetAddress>
+            {
+                new StreetAddress { City = "Phoenix", Street = "500 S 48th Street" },
+                new StreetAddress { City = "Anaheim", Street = "5650 Dolly Ave" }
+            }
+        };
+
+        using (var context = new OrderContext())
+        {
+            context.Add(distributor);
+
+            await context.SaveChangesAsync();
+        }
+        #endregion
+
+        #region ImpliedProperties
+        using (var context = new OrderContext())
+        {
+            var firstDistributor = await context.Distributors.FirstAsync();
+            Console.WriteLine($"Number of shipping centers: {firstDistributor.ShippingCenters.Count}");
+
+            var addressEntry = context.Entry(firstDistributor.ShippingCenters.First());
+            var addressPKProperties = addressEntry.Metadata.FindPrimaryKey().Properties;
+
+            Console.WriteLine(
+                $"First shipping center PK: ({addressEntry.Property(addressPKProperties[0].Name).CurrentValue}, {addressEntry.Property(addressPKProperties[1].Name).CurrentValue})");
+            Console.WriteLine();
+        }
+        #endregion
+
+        #region Attach
+        using (var context = new OrderContext())
+        {
+            var distributorEntry = context.Add(distributor);
+            distributorEntry.State = EntityState.Unchanged;
+
+            distributor.ShippingCenters.Remove(distributor.ShippingCenters.Last());
+
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new OrderContext())
+        {
+            var firstDistributor = await context.Distributors.FirstAsync();
+            Console.WriteLine($"Number of shipping centers is now: {firstDistributor.ShippingCenters.Count}");
+
+            var distributorEntry = context.Entry(firstDistributor);
+            var idProperty = distributorEntry.Property<string>("__id");
+            Console.WriteLine($"The distributor 'id' is: {idProperty.CurrentValue}");
+        }
+        #endregion
     }
 }

--- a/samples/core/Cosmos/ModelBuilding/StreetAddress.cs
+++ b/samples/core/Cosmos/ModelBuilding/StreetAddress.cs
@@ -1,10 +1,9 @@
-﻿namespace Cosmos.ModelBuilding
+﻿namespace Cosmos.ModelBuilding;
+
+#region StreetAddress
+public class StreetAddress
 {
-    #region StreetAddress
-    public class StreetAddress
-    {
-        public string Street { get; set; }
-        public string City { get; set; }
-    }
-    #endregion
+    public string Street { get; set; }
+    public string City { get; set; }
 }
+#endregion

--- a/samples/core/Cosmos/Program.cs
+++ b/samples/core/Cosmos/Program.cs
@@ -1,14 +1,13 @@
 ﻿using System.Threading.Tasks;
 using Cosmos.ModelBuilding;
 
-namespace Cosmos
+namespace Cosmos;
+
+public class Program
 {
-    public class Program
+    private static async Task Main()
     {
-        private static async Task Main()
-        {
-            await Sample.Run();
-            await UnstructuredData.Sample.Run();
-        }
+        await Sample.Run();
+        await UnstructuredData.Sample.Run();
     }
 }

--- a/samples/core/Cosmos/UnstructuredData/Sample.cs
+++ b/samples/core/Cosmos/UnstructuredData/Sample.cs
@@ -6,83 +6,82 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json.Linq;
 
-namespace Cosmos.UnstructuredData
+namespace Cosmos.UnstructuredData;
+
+public static class Sample
 {
-    public static class Sample
+    public static async Task Run()
     {
-        public static async Task Run()
+        Console.WriteLine();
+        Console.WriteLine("Unstructured data:");
+        Console.WriteLine();
+
+        #region Unmapped
+        using (var context = new OrderContext())
         {
-            Console.WriteLine();
-            Console.WriteLine("Unstructured data:");
-            Console.WriteLine();
+            await context.Database.EnsureDeletedAsync();
+            await context.Database.EnsureCreatedAsync();
 
-            #region Unmapped
-            using (var context = new OrderContext())
+            var order = new Order
             {
-                await context.Database.EnsureDeletedAsync();
-                await context.Database.EnsureCreatedAsync();
+                Id = 1, ShippingAddress = new StreetAddress { City = "London", Street = "221 B Baker St" }, PartitionKey = "1"
+            };
 
-                var order = new Order
-                {
-                    Id = 1, ShippingAddress = new StreetAddress { City = "London", Street = "221 B Baker St" }, PartitionKey = "1"
-                };
+            context.Add(order);
 
-                context.Add(order);
-
-                await context.SaveChangesAsync();
-            }
-
-            using (var context = new OrderContext())
-            {
-                var order = await context.Orders.FirstAsync();
-                var orderEntry = context.Entry(order);
-
-                var jsonProperty = orderEntry.Property<JObject>("__jObject");
-                jsonProperty.CurrentValue["BillingAddress"] = "Clarence House";
-
-                orderEntry.State = EntityState.Modified;
-
-                await context.SaveChangesAsync();
-            }
-
-            using (var context = new OrderContext())
-            {
-                var order = await context.Orders.FirstAsync();
-                var orderEntry = context.Entry(order);
-                var jsonProperty = orderEntry.Property<JObject>("__jObject");
-
-                Console.WriteLine($"First order will be billed to: {jsonProperty.CurrentValue["BillingAddress"]}");
-            }
-            #endregion
-
-            #region CosmosClient
-            using (var context = new OrderContext())
-            {
-                var cosmosClient = context.Database.GetCosmosClient();
-                var database = cosmosClient.GetDatabase("OrdersDB");
-                var container = database.GetContainer("Orders");
-
-                var resultSet = container.GetItemQueryIterator<JObject>(new QueryDefinition("select * from o"));
-                var order = (await resultSet.ReadNextAsync()).First();
-
-                Console.WriteLine($"First order JSON: {order}");
-
-                order.Remove("TrackingNumber");
-
-                await container.ReplaceItemAsync(order, order["id"].ToString());
-            }
-            #endregion
-
-            #region MissingProperties
-            using (var context = new OrderContext())
-            {
-                var orders = await context.Orders.ToListAsync();
-                var sortedOrders = await context.Orders.OrderBy(o => o.TrackingNumber).ToListAsync();
-
-                Console.WriteLine($"Number of orders: {orders.Count}");
-                Console.WriteLine($"Number of sorted orders: {sortedOrders.Count}");
-            }
-            #endregion
+            await context.SaveChangesAsync();
         }
+
+        using (var context = new OrderContext())
+        {
+            var order = await context.Orders.FirstAsync();
+            var orderEntry = context.Entry(order);
+
+            var jsonProperty = orderEntry.Property<JObject>("__jObject");
+            jsonProperty.CurrentValue["BillingAddress"] = "Clarence House";
+
+            orderEntry.State = EntityState.Modified;
+
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new OrderContext())
+        {
+            var order = await context.Orders.FirstAsync();
+            var orderEntry = context.Entry(order);
+            var jsonProperty = orderEntry.Property<JObject>("__jObject");
+
+            Console.WriteLine($"First order will be billed to: {jsonProperty.CurrentValue["BillingAddress"]}");
+        }
+        #endregion
+
+        #region CosmosClient
+        using (var context = new OrderContext())
+        {
+            var cosmosClient = context.Database.GetCosmosClient();
+            var database = cosmosClient.GetDatabase("OrdersDB");
+            var container = database.GetContainer("Orders");
+
+            var resultSet = container.GetItemQueryIterator<JObject>(new QueryDefinition("select * from o"));
+            var order = (await resultSet.ReadNextAsync()).First();
+
+            Console.WriteLine($"First order JSON: {order}");
+
+            order.Remove("TrackingNumber");
+
+            await container.ReplaceItemAsync(order, order["id"].ToString());
+        }
+        #endregion
+
+        #region MissingProperties
+        using (var context = new OrderContext())
+        {
+            var orders = await context.Orders.ToListAsync();
+            var sortedOrders = await context.Orders.OrderBy(o => o.TrackingNumber).ToListAsync();
+
+            Console.WriteLine($"Number of orders: {orders.Count}");
+            Console.WriteLine($"Number of sorted orders: {sortedOrders.Count}");
+        }
+        #endregion
     }
 }

--- a/samples/core/DbContextPooling/Program.cs
+++ b/samples/core/DbContextPooling/Program.cs
@@ -6,137 +6,136 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Samples
+namespace Samples;
+
+public class Blog
 {
-    public class Blog
+    public int BlogId { get; set; }
+    public string Name { get; set; }
+    public string Url { get; set; }
+}
+
+public class BloggingContext : DbContext
+{
+    public static long InstanceCount;
+
+    public BloggingContext(DbContextOptions options)
+        : base(options)
+        => Interlocked.Increment(ref InstanceCount);
+
+    public DbSet<Blog> Blogs { get; set; }
+}
+
+public class BlogController
+{
+    private readonly BloggingContext _context;
+
+    public BlogController(BloggingContext context) => _context = context;
+
+    public async Task ActionAsync() => await _context.Blogs.FirstAsync();
+}
+
+public class Startup
+{
+    private const string ConnectionString
+        = @"Server=(localdb)\mssqllocaldb;Database=Demo.ContextPooling;Trusted_Connection=True";
+
+    public void ConfigureServices(IServiceCollection services)
     {
-        public int BlogId { get; set; }
-        public string Name { get; set; }
-        public string Url { get; set; }
+        // Switch the lines below to compare pooling with the traditional instance-per-request approach.
+        //services.AddDbContext<BloggingContext>(c => c.UseSqlServer(ConnectionString));
+        services.AddDbContextPool<BloggingContext>(c => c.UseSqlServer(ConnectionString));
+    }
+}
+
+public class Program
+{
+    private const int Threads = 32;
+    private const int Seconds = 10;
+
+    private static long _requestsProcessed;
+
+    private static async Task Main()
+    {
+        var serviceCollection = new ServiceCollection();
+        new Startup().ConfigureServices(serviceCollection);
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        SetupDatabase(serviceProvider);
+
+        var stopwatch = new Stopwatch();
+
+        var monitorTask = MonitorResults(TimeSpan.FromSeconds(Seconds), stopwatch);
+
+        await Task.WhenAll(
+            Enumerable
+                .Range(0, Threads)
+                .Select(_ => SimulateRequestsAsync(serviceProvider, stopwatch)));
+
+        await monitorTask;
     }
 
-    public class BloggingContext : DbContext
+    private static void SetupDatabase(IServiceProvider serviceProvider)
     {
-        public static long InstanceCount;
-
-        public BloggingContext(DbContextOptions options)
-            : base(options)
-            => Interlocked.Increment(ref InstanceCount);
-
-        public DbSet<Blog> Blogs { get; set; }
-    }
-
-    public class BlogController
-    {
-        private readonly BloggingContext _context;
-
-        public BlogController(BloggingContext context) => _context = context;
-
-        public async Task ActionAsync() => await _context.Blogs.FirstAsync();
-    }
-
-    public class Startup
-    {
-        private const string ConnectionString
-            = @"Server=(localdb)\mssqllocaldb;Database=Demo.ContextPooling;Trusted_Connection=True";
-
-        public void ConfigureServices(IServiceCollection services)
+        using (var serviceScope = serviceProvider.CreateScope())
         {
-            // Switch the lines below to compare pooling with the traditional instance-per-request approach.
-            //services.AddDbContext<BloggingContext>(c => c.UseSqlServer(ConnectionString));
-            services.AddDbContextPool<BloggingContext>(c => c.UseSqlServer(ConnectionString));
+            var context = serviceScope.ServiceProvider.GetService<BloggingContext>();
+
+            if (context.Database.EnsureCreated())
+            {
+                context.Blogs.Add(new Blog { Name = "The Dog Blog", Url = "http://sample.com/dogs" });
+                context.Blogs.Add(new Blog { Name = "The Cat Blog", Url = "http://sample.com/cats" });
+                context.SaveChanges();
+            }
         }
     }
 
-    public class Program
+    private static async Task SimulateRequestsAsync(IServiceProvider serviceProvider, Stopwatch stopwatch)
     {
-        private const int Threads = 32;
-        private const int Seconds = 10;
-
-        private static long _requestsProcessed;
-
-        private static async Task Main()
-        {
-            var serviceCollection = new ServiceCollection();
-            new Startup().ConfigureServices(serviceCollection);
-            var serviceProvider = serviceCollection.BuildServiceProvider();
-
-            SetupDatabase(serviceProvider);
-
-            var stopwatch = new Stopwatch();
-
-            var monitorTask = MonitorResults(TimeSpan.FromSeconds(Seconds), stopwatch);
-
-            await Task.WhenAll(
-                Enumerable
-                    .Range(0, Threads)
-                    .Select(_ => SimulateRequestsAsync(serviceProvider, stopwatch)));
-
-            await monitorTask;
-        }
-
-        private static void SetupDatabase(IServiceProvider serviceProvider)
+        while (stopwatch.IsRunning)
         {
             using (var serviceScope = serviceProvider.CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<BloggingContext>();
-
-                if (context.Database.EnsureCreated())
-                {
-                    context.Blogs.Add(new Blog { Name = "The Dog Blog", Url = "http://sample.com/dogs" });
-                    context.Blogs.Add(new Blog { Name = "The Cat Blog", Url = "http://sample.com/cats" });
-                    context.SaveChanges();
-                }
+                await new BlogController(serviceScope.ServiceProvider.GetService<BloggingContext>()).ActionAsync();
             }
+
+            Interlocked.Increment(ref _requestsProcessed);
         }
+    }
 
-        private static async Task SimulateRequestsAsync(IServiceProvider serviceProvider, Stopwatch stopwatch)
+    private static async Task MonitorResults(TimeSpan duration, Stopwatch stopwatch)
+    {
+        var lastInstanceCount = 0L;
+        var lastRequestCount = 0L;
+        var lastElapsed = TimeSpan.Zero;
+
+        stopwatch.Start();
+
+        while (stopwatch.Elapsed < duration)
         {
-            while (stopwatch.IsRunning)
-            {
-                using (var serviceScope = serviceProvider.CreateScope())
-                {
-                    await new BlogController(serviceScope.ServiceProvider.GetService<BloggingContext>()).ActionAsync();
-                }
+            await Task.Delay(TimeSpan.FromSeconds(1));
 
-                Interlocked.Increment(ref _requestsProcessed);
-            }
-        }
+            var instanceCount = BloggingContext.InstanceCount;
+            var requestCount = _requestsProcessed;
+            var elapsed = stopwatch.Elapsed;
+            var currentElapsed = elapsed - lastElapsed;
+            var currentRequests = requestCount - lastRequestCount;
 
-        private static async Task MonitorResults(TimeSpan duration, Stopwatch stopwatch)
-        {
-            var lastInstanceCount = 0L;
-            var lastRequestCount = 0L;
-            var lastElapsed = TimeSpan.Zero;
-
-            stopwatch.Start();
-
-            while (stopwatch.Elapsed < duration)
-            {
-                await Task.Delay(TimeSpan.FromSeconds(1));
-
-                var instanceCount = BloggingContext.InstanceCount;
-                var requestCount = _requestsProcessed;
-                var elapsed = stopwatch.Elapsed;
-                var currentElapsed = elapsed - lastElapsed;
-                var currentRequests = requestCount - lastRequestCount;
-
-                Console.WriteLine(
-                    $"[{DateTime.Now:HH:mm:ss.fff}] "
-                    + $"Context creations/second: {instanceCount - lastInstanceCount} | "
-                    + $"Requests/second: {Math.Round(currentRequests / currentElapsed.TotalSeconds)}");
-
-                lastInstanceCount = instanceCount;
-                lastRequestCount = requestCount;
-                lastElapsed = elapsed;
-            }
-
-            Console.WriteLine();
-            Console.WriteLine($"Total context creations: {BloggingContext.InstanceCount}");
             Console.WriteLine(
-                $"Requests per second:     {Math.Round(_requestsProcessed / stopwatch.Elapsed.TotalSeconds)}");
+                $"[{DateTime.Now:HH:mm:ss.fff}] "
+                + $"Context creations/second: {instanceCount - lastInstanceCount} | "
+                + $"Requests/second: {Math.Round(currentRequests / currentElapsed.TotalSeconds)}");
 
-            stopwatch.Stop();
+            lastInstanceCount = instanceCount;
+            lastRequestCount = requestCount;
+            lastElapsed = elapsed;
         }
+
+        Console.WriteLine();
+        Console.WriteLine($"Total context creations: {BloggingContext.InstanceCount}");
+        Console.WriteLine(
+            $"Requests per second:     {Math.Round(_requestsProcessed / stopwatch.Elapsed.TotalSeconds)}");
+
+        stopwatch.Stop();
     }
 }

--- a/samples/core/GetStarted/Migrations/BloggingContextModelSnapshot.cs
+++ b/samples/core/GetStarted/Migrations/BloggingContextModelSnapshot.cs
@@ -1,65 +1,64 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-namespace EFGetStarted.Migrations
+namespace EFGetStarted.Migrations;
+
+[DbContext(typeof(BloggingContext))]
+internal class BloggingContextModelSnapshot : ModelSnapshot
 {
-    [DbContext(typeof(BloggingContext))]
-    internal class BloggingContextModelSnapshot : ModelSnapshot
+    protected override void BuildModel(ModelBuilder modelBuilder)
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
-        {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation("ProductVersion", "3.0.0-rc1.19456.14");
+        modelBuilder
+            .HasAnnotation("ProductVersion", "3.0.0-rc1.19456.14");
 
-            modelBuilder.Entity(
-                "EFGetStarted.Blog", b =>
-                {
-                    b.Property<int>("BlogId")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+        modelBuilder.Entity(
+            "EFGetStarted.Blog", b =>
+            {
+                b.Property<int>("BlogId")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("INTEGER");
 
-                    b.Property<string>("Url")
-                        .HasColumnType("TEXT");
+                b.Property<string>("Url")
+                    .HasColumnType("TEXT");
 
-                    b.HasKey("BlogId");
+                b.HasKey("BlogId");
 
-                    b.ToTable("Blogs");
-                });
+                b.ToTable("Blogs");
+            });
 
-            modelBuilder.Entity(
-                "EFGetStarted.Post", b =>
-                {
-                    b.Property<int>("PostId")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+        modelBuilder.Entity(
+            "EFGetStarted.Post", b =>
+            {
+                b.Property<int>("PostId")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("INTEGER");
 
-                    b.Property<int>("BlogId")
-                        .HasColumnType("INTEGER");
+                b.Property<int>("BlogId")
+                    .HasColumnType("INTEGER");
 
-                    b.Property<string>("Content")
-                        .HasColumnType("TEXT");
+                b.Property<string>("Content")
+                    .HasColumnType("TEXT");
 
-                    b.Property<string>("Title")
-                        .HasColumnType("TEXT");
+                b.Property<string>("Title")
+                    .HasColumnType("TEXT");
 
-                    b.HasKey("PostId");
+                b.HasKey("PostId");
 
-                    b.HasIndex("BlogId");
+                b.HasIndex("BlogId");
 
-                    b.ToTable("Posts");
-                });
+                b.ToTable("Posts");
+            });
 
-            modelBuilder.Entity(
-                "EFGetStarted.Post", b =>
-                {
-                    b.HasOne("EFGetStarted.Blog", "Blog")
-                        .WithMany("Posts")
-                        .HasForeignKey("BlogId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-                });
+        modelBuilder.Entity(
+            "EFGetStarted.Post", b =>
+            {
+                b.HasOne("EFGetStarted.Blog", "Blog")
+                    .WithMany("Posts")
+                    .HasForeignKey("BlogId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+            });
 #pragma warning restore 612, 618
-        }
     }
 }

--- a/samples/core/GetStarted/Model.cs
+++ b/samples/core/GetStarted/Model.cs
@@ -2,43 +2,42 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFGetStarted
+namespace EFGetStarted;
+
+public class BloggingContext : DbContext
 {
-    public class BloggingContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    public string DbPath { get; }
+
+    public BloggingContext()
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        public string DbPath { get; }
-
-        public BloggingContext()
-        {
-            var folder = Environment.SpecialFolder.LocalApplicationData;
-            var path = Environment.GetFolderPath(folder);
-            DbPath = System.IO.Path.Join(path, "blogging.db");
-        }
-
-        // The following configures EF to create a Sqlite database file in the
-        // special "local" folder for your platform.
-        protected override void OnConfiguring(DbContextOptionsBuilder options)
-            => options.UseSqlite($"Data Source={DbPath}");
+        var folder = Environment.SpecialFolder.LocalApplicationData;
+        var path = Environment.GetFolderPath(folder);
+        DbPath = System.IO.Path.Join(path, "blogging.db");
     }
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+    // The following configures EF to create a Sqlite database file in the
+    // special "local" folder for your platform.
+    protected override void OnConfiguring(DbContextOptionsBuilder options)
+        => options.UseSqlite($"Data Source={DbPath}");
+}
 
-        public List<Post> Posts { get; } = new();
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+    public List<Post> Posts { get; } = new();
+}
 
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
 }

--- a/samples/core/GetStarted/Program.cs
+++ b/samples/core/GetStarted/Program.cs
@@ -1,40 +1,39 @@
 ﻿using System;
 using System.Linq;
 
-namespace EFGetStarted
+namespace EFGetStarted;
+
+internal class Program
 {
-    internal class Program
+    private static void Main()
     {
-        private static void Main()
+        using (var db = new BloggingContext())
         {
-            using (var db = new BloggingContext())
-            {
-                // Note: This sample requires the database to be created before running.
-                Console.WriteLine($"Database path: {db.DbPath}.");
+            // Note: This sample requires the database to be created before running.
+            Console.WriteLine($"Database path: {db.DbPath}.");
                 
-                // Create
-                Console.WriteLine("Inserting a new blog");
-                db.Add(new Blog { Url = "http://blogs.msdn.com/adonet" });
-                db.SaveChanges();
+            // Create
+            Console.WriteLine("Inserting a new blog");
+            db.Add(new Blog { Url = "http://blogs.msdn.com/adonet" });
+            db.SaveChanges();
 
-                // Read
-                Console.WriteLine("Querying for a blog");
-                var blog = db.Blogs
-                    .OrderBy(b => b.BlogId)
-                    .First();
+            // Read
+            Console.WriteLine("Querying for a blog");
+            var blog = db.Blogs
+                .OrderBy(b => b.BlogId)
+                .First();
 
-                // Update
-                Console.WriteLine("Updating the blog and adding a post");
-                blog.Url = "https://devblogs.microsoft.com/dotnet";
-                blog.Posts.Add(
-                    new Post { Title = "Hello World", Content = "I wrote an app using EF Core!" });
-                db.SaveChanges();
+            // Update
+            Console.WriteLine("Updating the blog and adding a post");
+            blog.Url = "https://devblogs.microsoft.com/dotnet";
+            blog.Posts.Add(
+                new Post { Title = "Hello World", Content = "I wrote an app using EF Core!" });
+            db.SaveChanges();
 
-                // Delete
-                Console.WriteLine("Delete the blog");
-                db.Remove(blog);
-                db.SaveChanges();
-            }
+            // Delete
+            Console.WriteLine("Delete the blog");
+            db.Remove(blog);
+            db.SaveChanges();
         }
     }
 }

--- a/samples/core/Intro/Migrations/BloggingContextModelSnapshot.cs
+++ b/samples/core/Intro/Migrations/BloggingContextModelSnapshot.cs
@@ -2,72 +2,71 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 
-namespace Intro.Migrations
+namespace Intro.Migrations;
+
+[DbContext(typeof(BloggingContext))]
+internal class BloggingContextModelSnapshot : ModelSnapshot
 {
-    [DbContext(typeof(BloggingContext))]
-    internal class BloggingContextModelSnapshot : ModelSnapshot
+    protected override void BuildModel(ModelBuilder modelBuilder)
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
-        {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation("ProductVersion", "3.0.0")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128)
-                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+        modelBuilder
+            .HasAnnotation("ProductVersion", "3.0.0")
+            .HasAnnotation("Relational:MaxIdentifierLength", 128)
+            .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
-            modelBuilder.Entity(
-                "Intro.Blog", b =>
-                {
-                    b.Property<int>("BlogId")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+        modelBuilder.Entity(
+            "Intro.Blog", b =>
+            {
+                b.Property<int>("BlogId")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("int")
+                    .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
-                    b.Property<int>("Rating")
-                        .HasColumnType("int");
+                b.Property<int>("Rating")
+                    .HasColumnType("int");
 
-                    b.Property<string>("Url")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Url")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.HasKey("BlogId");
+                b.HasKey("BlogId");
 
-                    b.ToTable("Blogs");
-                });
+                b.ToTable("Blogs");
+            });
 
-            modelBuilder.Entity(
-                "Intro.Post", b =>
-                {
-                    b.Property<int>("PostId")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+        modelBuilder.Entity(
+            "Intro.Post", b =>
+            {
+                b.Property<int>("PostId")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("int")
+                    .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
-                    b.Property<int>("BlogId")
-                        .HasColumnType("int");
+                b.Property<int>("BlogId")
+                    .HasColumnType("int");
 
-                    b.Property<string>("Content")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Content")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("Title")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Title")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.HasKey("PostId");
+                b.HasKey("PostId");
 
-                    b.HasIndex("BlogId");
+                b.HasIndex("BlogId");
 
-                    b.ToTable("Posts");
-                });
+                b.ToTable("Posts");
+            });
 
-            modelBuilder.Entity(
-                "Intro.Post", b =>
-                {
-                    b.HasOne("Intro.Blog", "Blog")
-                        .WithMany("Posts")
-                        .HasForeignKey("BlogId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-                });
+        modelBuilder.Entity(
+            "Intro.Post", b =>
+            {
+                b.HasOne("Intro.Blog", "Blog")
+                    .WithMany("Posts")
+                    .HasForeignKey("BlogId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+            });
 #pragma warning restore 612, 618
-        }
     }
 }

--- a/samples/core/Intro/Model.cs
+++ b/samples/core/Intro/Model.cs
@@ -1,35 +1,34 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace Intro
+namespace Intro;
+
+public class BloggingContext : DbContext
 {
-    public class BloggingContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True");
-        }
+        optionsBuilder.UseSqlServer(
+            @"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True");
     }
+}
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public int Rating { get; set; }
-        public List<Post> Posts { get; set; }
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public int Rating { get; set; }
+    public List<Post> Posts { get; set; }
+}
 
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
 
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
 }

--- a/samples/core/Intro/Program.cs
+++ b/samples/core/Intro/Program.cs
@@ -1,37 +1,36 @@
 ﻿using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace Intro
+namespace Intro;
+
+internal class Program
 {
-    internal class Program
+    private static void Main()
     {
-        private static void Main()
+        using (var db = new BloggingContext())
         {
-            using (var db = new BloggingContext())
-            {
-                // Remove these lines if you are running migrations from the command line
-                db.Database.EnsureDeleted();
-                db.Database.Migrate();
-            }
-
-            #region Querying
-            using (var db = new BloggingContext())
-            {
-                var blogs = db.Blogs
-                    .Where(b => b.Rating > 3)
-                    .OrderBy(b => b.Url)
-                    .ToList();
-            }
-            #endregion
-
-            #region SavingData
-            using (var db = new BloggingContext())
-            {
-                var blog = new Blog { Url = "http://sample.com" };
-                db.Blogs.Add(blog);
-                db.SaveChanges();
-            }
-            #endregion
+            // Remove these lines if you are running migrations from the command line
+            db.Database.EnsureDeleted();
+            db.Database.Migrate();
         }
+
+        #region Querying
+        using (var db = new BloggingContext())
+        {
+            var blogs = db.Blogs
+                .Where(b => b.Rating > 3)
+                .OrderBy(b => b.Url)
+                .ToList();
+        }
+        #endregion
+
+        #region SavingData
+        using (var db = new BloggingContext())
+        {
+            var blog = new Blog { Url = "http://sample.com" };
+            db.Blogs.Add(blog);
+            db.SaveChanges();
+        }
+        #endregion
     }
 }

--- a/samples/core/Miscellaneous/Async/Program.cs
+++ b/samples/core/Miscellaneous/Async/Program.cs
@@ -2,42 +2,41 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFAsync
+namespace EFAsync;
+
+public class Program
 {
-    public class Program
+    public static async Task Main(string[] args)
     {
-        public static async Task Main(string[] args)
-        {
-            await using var context = new BloggingContext();
-            await context.Database.EnsureDeletedAsync();
-            await context.Database.EnsureCreatedAsync();
+        await using var context = new BloggingContext();
+        await context.Database.EnsureDeletedAsync();
+        await context.Database.EnsureCreatedAsync();
 
-            #region SaveChangesAsync
-            var blog = new Blog { Url = "http://sample.com" };
-            context.Blogs.Add(blog);
-            await context.SaveChangesAsync();
-            #endregion
+        #region SaveChangesAsync
+        var blog = new Blog { Url = "http://sample.com" };
+        context.Blogs.Add(blog);
+        await context.SaveChangesAsync();
+        #endregion
 
-            #region ToListAsync
-            var blogs = await context.Blogs.Where(b => b.Rating > 3).ToListAsync();
-            #endregion
-        }
+        #region ToListAsync
+        var blogs = await context.Blogs.Where(b => b.Rating > 3).ToListAsync();
+        #endregion
     }
+}
 
-    public class BloggingContext : DbContext
+public class BloggingContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFAsync;Trusted_Connection=True");
-        }
+        optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFAsync;Trusted_Connection=True");
     }
+}
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public int Rating { get; set; }
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public int Rating { get; set; }
 }

--- a/samples/core/Miscellaneous/AsyncWithSystemInteractive/Program.cs
+++ b/samples/core/Miscellaneous/AsyncWithSystemInteractive/Program.cs
@@ -2,41 +2,40 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFAsync
+namespace EFAsync;
+
+public class Program
 {
-    public class Program
+    public static async Task Main(string[] args)
     {
-        public static async Task Main(string[] args)
-        {
-            await using var context = new BloggingContext();
-            await context.Database.EnsureDeletedAsync();
-            await context.Database.EnsureCreatedAsync();
+        await using var context = new BloggingContext();
+        await context.Database.EnsureDeletedAsync();
+        await context.Database.EnsureCreatedAsync();
 
-            #region SystemInteractiveAsync
-            var groupedHighlyRatedBlogs = await context.Blogs
-                .AsQueryable()
-                .Where(b => b.Rating > 3) // server-evaluated
-                .AsAsyncEnumerable()
-                .GroupBy(b => b.Rating) // client-evaluated
-                .ToListAsync();
-            #endregion
-        }
+        #region SystemInteractiveAsync
+        var groupedHighlyRatedBlogs = await context.Blogs
+            .AsQueryable()
+            .Where(b => b.Rating > 3) // server-evaluated
+            .AsAsyncEnumerable()
+            .GroupBy(b => b.Rating) // client-evaluated
+            .ToListAsync();
+        #endregion
     }
+}
 
-    public class BloggingContext : DbContext
+public class BloggingContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFAsync;Trusted_Connection=True");
-        }
+        optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFAsync;Trusted_Connection=True");
     }
+}
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public int Rating { get; set; }
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public int Rating { get; set; }
 }

--- a/samples/core/Miscellaneous/Collations/Program.cs
+++ b/samples/core/Miscellaneous/Collations/Program.cs
@@ -1,54 +1,53 @@
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFCollations
+namespace EFCollations;
+
+public class Program
 {
-    public class Program
+    public static void Main(string[] args)
     {
-        public static void Main(string[] args)
+        using (var db = new CustomerContext())
         {
-            using (var db = new CustomerContext())
-            {
-                db.Database.EnsureDeleted();
-                db.Database.EnsureCreated();
-            }
-
-            using (var context = new CustomerContext())
-            {
-                #region SimpleQueryCollation
-                var customers = context.Customers
-                    .Where(c => EF.Functions.Collate(c.Name, "SQL_Latin1_General_CP1_CS_AS") == "John")
-                    .ToList();
-                #endregion
-            }
-        }
-    }
-
-    public class CustomerContext : DbContext
-    {
-        public DbSet<Customer> Customers { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFCollations;Trusted_Connection=True");
+            db.Database.EnsureDeleted();
+            db.Database.EnsureCreated();
         }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        using (var context = new CustomerContext())
         {
-            #region DatabaseCollation
-            modelBuilder.UseCollation("SQL_Latin1_General_CP1_CS_AS");
-            #endregion
-
-            #region ColumnCollation
-            modelBuilder.Entity<Customer>().Property(c => c.Name)
-                .UseCollation("SQL_Latin1_General_CP1_CI_AS");
+            #region SimpleQueryCollation
+            var customers = context.Customers
+                .Where(c => EF.Functions.Collate(c.Name, "SQL_Latin1_General_CP1_CS_AS") == "John")
+                .ToList();
             #endregion
         }
     }
+}
 
-    public class Customer
+public class CustomerContext : DbContext
+{
+    public DbSet<Customer> Customers { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        public int Id { get; set; }
-        public string Name { get; set; }
+        optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFCollations;Trusted_Connection=True");
     }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        #region DatabaseCollation
+        modelBuilder.UseCollation("SQL_Latin1_General_CP1_CS_AS");
+        #endregion
+
+        #region ColumnCollation
+        modelBuilder.Entity<Customer>().Property(c => c.Name)
+            .UseCollation("SQL_Latin1_General_CP1_CI_AS");
+        #endregion
+    }
+}
+
+public class Customer
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
 }

--- a/samples/core/Miscellaneous/CommandLine/BloggingContextFactory.cs
+++ b/samples/core/Miscellaneous/CommandLine/BloggingContextFactory.cs
@@ -1,26 +1,25 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 
-namespace MyProject
+namespace MyProject;
+
+#region BloggingContextFactory
+public class BloggingContextFactory : IDesignTimeDbContextFactory<BloggingContext>
 {
-    #region BloggingContextFactory
-    public class BloggingContextFactory : IDesignTimeDbContextFactory<BloggingContext>
+    public BloggingContext CreateDbContext(string[] args)
     {
-        public BloggingContext CreateDbContext(string[] args)
-        {
-            var optionsBuilder = new DbContextOptionsBuilder<BloggingContext>();
-            optionsBuilder.UseSqlite("Data Source=blog.db");
+        var optionsBuilder = new DbContextOptionsBuilder<BloggingContext>();
+        optionsBuilder.UseSqlite("Data Source=blog.db");
 
-            return new BloggingContext(optionsBuilder.Options);
-        }
+        return new BloggingContext(optionsBuilder.Options);
     }
-    #endregion
+}
+#endregion
 
-    public class BloggingContext : DbContext
+public class BloggingContext : DbContext
+{
+    public BloggingContext(DbContextOptions<BloggingContext> options)
+        : base(options)
     {
-        public BloggingContext(DbContextOptions<BloggingContext> options)
-            : base(options)
-        {
-        }
     }
 }

--- a/samples/core/Miscellaneous/CommandLine/CustomTools.cs
+++ b/samples/core/Miscellaneous/CommandLine/CustomTools.cs
@@ -4,34 +4,33 @@ using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Migrations.Design;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace CommandLine
+namespace CommandLine;
+
+public class CustomTools
 {
-    public class CustomTools
+    public static void AddMigration(string migrationName)
     {
-        public static void AddMigration(string migrationName)
-        {
-            var projectDir = Directory.GetCurrentDirectory();
-            var rootNamespace = "ConsoleApp1";
-            var outputDir = "Migraitons";
+        var projectDir = Directory.GetCurrentDirectory();
+        var rootNamespace = "ConsoleApp1";
+        var outputDir = "Migraitons";
 
-            #region CustomTools
-            var db = new MyDbContext();
+        #region CustomTools
+        var db = new MyDbContext();
 
-            // Create design-time services
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddEntityFrameworkDesignTimeServices();
-            serviceCollection.AddDbContextDesignTimeServices(db);
-            var serviceProvider = serviceCollection.BuildServiceProvider();
+        // Create design-time services
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddEntityFrameworkDesignTimeServices();
+        serviceCollection.AddDbContextDesignTimeServices(db);
+        var serviceProvider = serviceCollection.BuildServiceProvider();
 
-            // Add a migration
-            var migrationsScaffolder = serviceProvider.GetService<IMigrationsScaffolder>();
-            var migration = migrationsScaffolder.ScaffoldMigration(migrationName, rootNamespace);
-            migrationsScaffolder.Save(projectDir, migration, outputDir);
-            #endregion
-        }
+        // Add a migration
+        var migrationsScaffolder = serviceProvider.GetService<IMigrationsScaffolder>();
+        var migration = migrationsScaffolder.ScaffoldMigration(migrationName, rootNamespace);
+        migrationsScaffolder.Save(projectDir, migration, outputDir);
+        #endregion
     }
+}
 
-    internal class MyDbContext : DbContext
-    {
-    }
+internal class MyDbContext : DbContext
+{
 }

--- a/samples/core/Miscellaneous/CompiledModels/Blog000.cs
+++ b/samples/core/Miscellaneous/CompiledModels/Blog000.cs
@@ -1,4685 +1,4684 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
-namespace CompiledModelTest
+namespace CompiledModelTest;
+
+public class Blog0000
 {
-    public class Blog0000
-    {
-        public int Id { get; set; }
+    public int Id { get; set; }
 
-        public ICollection<Tag0000> Tags { get; set; }
+    public ICollection<Tag0000> Tags { get; set; }
 
-        public ICollection<Post0000> Posts00 { get; } = new List<Post0000>();
-        public ICollection<Post0000> Posts01 { get; } = new List<Post0000>();
-        public ICollection<Post0000> Posts02 { get; } = new List<Post0000>();
-        public ICollection<Post0000> Posts03 { get; } = new List<Post0000>();
+    public ICollection<Post0000> Posts00 { get; } = new List<Post0000>();
+    public ICollection<Post0000> Posts01 { get; } = new List<Post0000>();
+    public ICollection<Post0000> Posts02 { get; } = new List<Post0000>();
+    public ICollection<Post0000> Posts03 { get; } = new List<Post0000>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0001
-    {
-        public int Id { get; set; }
+public class Blog0001
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0001> Tags { get; set; }
+    public ICollection<Tag0001> Tags { get; set; }
 
-        public ICollection<Post0001> Posts00 { get; } = new List<Post0001>();
-        public ICollection<Post0001> Posts01 { get; } = new List<Post0001>();
-        public ICollection<Post0001> Posts02 { get; } = new List<Post0001>();
-        public ICollection<Post0001> Posts03 { get; } = new List<Post0001>();
+    public ICollection<Post0001> Posts00 { get; } = new List<Post0001>();
+    public ICollection<Post0001> Posts01 { get; } = new List<Post0001>();
+    public ICollection<Post0001> Posts02 { get; } = new List<Post0001>();
+    public ICollection<Post0001> Posts03 { get; } = new List<Post0001>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0002
-    {
-        public int Id { get; set; }
+public class Blog0002
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0002> Tags { get; set; }
+    public ICollection<Tag0002> Tags { get; set; }
 
-        public ICollection<Post0002> Posts00 { get; } = new List<Post0002>();
-        public ICollection<Post0002> Posts01 { get; } = new List<Post0002>();
-        public ICollection<Post0002> Posts02 { get; } = new List<Post0002>();
-        public ICollection<Post0002> Posts03 { get; } = new List<Post0002>();
+    public ICollection<Post0002> Posts00 { get; } = new List<Post0002>();
+    public ICollection<Post0002> Posts01 { get; } = new List<Post0002>();
+    public ICollection<Post0002> Posts02 { get; } = new List<Post0002>();
+    public ICollection<Post0002> Posts03 { get; } = new List<Post0002>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0003
-    {
-        public int Id { get; set; }
+public class Blog0003
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0003> Tags { get; set; }
+    public ICollection<Tag0003> Tags { get; set; }
 
-        public ICollection<Post0003> Posts00 { get; } = new List<Post0003>();
-        public ICollection<Post0003> Posts01 { get; } = new List<Post0003>();
-        public ICollection<Post0003> Posts02 { get; } = new List<Post0003>();
-        public ICollection<Post0003> Posts03 { get; } = new List<Post0003>();
+    public ICollection<Post0003> Posts00 { get; } = new List<Post0003>();
+    public ICollection<Post0003> Posts01 { get; } = new List<Post0003>();
+    public ICollection<Post0003> Posts02 { get; } = new List<Post0003>();
+    public ICollection<Post0003> Posts03 { get; } = new List<Post0003>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0004
-    {
-        public int Id { get; set; }
+public class Blog0004
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0004> Tags { get; set; }
+    public ICollection<Tag0004> Tags { get; set; }
 
-        public ICollection<Post0004> Posts00 { get; } = new List<Post0004>();
-        public ICollection<Post0004> Posts01 { get; } = new List<Post0004>();
-        public ICollection<Post0004> Posts02 { get; } = new List<Post0004>();
-        public ICollection<Post0004> Posts03 { get; } = new List<Post0004>();
+    public ICollection<Post0004> Posts00 { get; } = new List<Post0004>();
+    public ICollection<Post0004> Posts01 { get; } = new List<Post0004>();
+    public ICollection<Post0004> Posts02 { get; } = new List<Post0004>();
+    public ICollection<Post0004> Posts03 { get; } = new List<Post0004>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0005
-    {
-        public int Id { get; set; }
+public class Blog0005
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0005> Tags { get; set; }
+    public ICollection<Tag0005> Tags { get; set; }
 
-        public ICollection<Post0005> Posts00 { get; } = new List<Post0005>();
-        public ICollection<Post0005> Posts01 { get; } = new List<Post0005>();
-        public ICollection<Post0005> Posts02 { get; } = new List<Post0005>();
-        public ICollection<Post0005> Posts03 { get; } = new List<Post0005>();
+    public ICollection<Post0005> Posts00 { get; } = new List<Post0005>();
+    public ICollection<Post0005> Posts01 { get; } = new List<Post0005>();
+    public ICollection<Post0005> Posts02 { get; } = new List<Post0005>();
+    public ICollection<Post0005> Posts03 { get; } = new List<Post0005>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0006
-    {
-        public int Id { get; set; }
+public class Blog0006
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0006> Tags { get; set; }
+    public ICollection<Tag0006> Tags { get; set; }
 
-        public ICollection<Post0006> Posts00 { get; } = new List<Post0006>();
-        public ICollection<Post0006> Posts01 { get; } = new List<Post0006>();
-        public ICollection<Post0006> Posts02 { get; } = new List<Post0006>();
-        public ICollection<Post0006> Posts03 { get; } = new List<Post0006>();
+    public ICollection<Post0006> Posts00 { get; } = new List<Post0006>();
+    public ICollection<Post0006> Posts01 { get; } = new List<Post0006>();
+    public ICollection<Post0006> Posts02 { get; } = new List<Post0006>();
+    public ICollection<Post0006> Posts03 { get; } = new List<Post0006>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0007
-    {
-        public int Id { get; set; }
+public class Blog0007
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0007> Tags { get; set; }
+    public ICollection<Tag0007> Tags { get; set; }
 
-        public ICollection<Post0007> Posts00 { get; } = new List<Post0007>();
-        public ICollection<Post0007> Posts01 { get; } = new List<Post0007>();
-        public ICollection<Post0007> Posts02 { get; } = new List<Post0007>();
-        public ICollection<Post0007> Posts03 { get; } = new List<Post0007>();
+    public ICollection<Post0007> Posts00 { get; } = new List<Post0007>();
+    public ICollection<Post0007> Posts01 { get; } = new List<Post0007>();
+    public ICollection<Post0007> Posts02 { get; } = new List<Post0007>();
+    public ICollection<Post0007> Posts03 { get; } = new List<Post0007>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0008
-    {
-        public int Id { get; set; }
+public class Blog0008
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0008> Tags { get; set; }
+    public ICollection<Tag0008> Tags { get; set; }
 
-        public ICollection<Post0008> Posts00 { get; } = new List<Post0008>();
-        public ICollection<Post0008> Posts01 { get; } = new List<Post0008>();
-        public ICollection<Post0008> Posts02 { get; } = new List<Post0008>();
-        public ICollection<Post0008> Posts03 { get; } = new List<Post0008>();
+    public ICollection<Post0008> Posts00 { get; } = new List<Post0008>();
+    public ICollection<Post0008> Posts01 { get; } = new List<Post0008>();
+    public ICollection<Post0008> Posts02 { get; } = new List<Post0008>();
+    public ICollection<Post0008> Posts03 { get; } = new List<Post0008>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0009
-    {
-        public int Id { get; set; }
+public class Blog0009
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0009> Tags { get; set; }
+    public ICollection<Tag0009> Tags { get; set; }
 
-        public ICollection<Post0009> Posts00 { get; } = new List<Post0009>();
-        public ICollection<Post0009> Posts01 { get; } = new List<Post0009>();
-        public ICollection<Post0009> Posts02 { get; } = new List<Post0009>();
-        public ICollection<Post0009> Posts03 { get; } = new List<Post0009>();
+    public ICollection<Post0009> Posts00 { get; } = new List<Post0009>();
+    public ICollection<Post0009> Posts01 { get; } = new List<Post0009>();
+    public ICollection<Post0009> Posts02 { get; } = new List<Post0009>();
+    public ICollection<Post0009> Posts03 { get; } = new List<Post0009>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0010
-    {
-        public int Id { get; set; }
+public class Blog0010
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0010> Tags { get; set; }
+    public ICollection<Tag0010> Tags { get; set; }
 
-        public ICollection<Post0010> Posts00 { get; } = new List<Post0010>();
-        public ICollection<Post0010> Posts01 { get; } = new List<Post0010>();
-        public ICollection<Post0010> Posts02 { get; } = new List<Post0010>();
-        public ICollection<Post0010> Posts03 { get; } = new List<Post0010>();
+    public ICollection<Post0010> Posts00 { get; } = new List<Post0010>();
+    public ICollection<Post0010> Posts01 { get; } = new List<Post0010>();
+    public ICollection<Post0010> Posts02 { get; } = new List<Post0010>();
+    public ICollection<Post0010> Posts03 { get; } = new List<Post0010>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0011
-    {
-        public int Id { get; set; }
+public class Blog0011
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0011> Tags { get; set; }
+    public ICollection<Tag0011> Tags { get; set; }
 
-        public ICollection<Post0011> Posts00 { get; } = new List<Post0011>();
-        public ICollection<Post0011> Posts01 { get; } = new List<Post0011>();
-        public ICollection<Post0011> Posts02 { get; } = new List<Post0011>();
-        public ICollection<Post0011> Posts03 { get; } = new List<Post0011>();
+    public ICollection<Post0011> Posts00 { get; } = new List<Post0011>();
+    public ICollection<Post0011> Posts01 { get; } = new List<Post0011>();
+    public ICollection<Post0011> Posts02 { get; } = new List<Post0011>();
+    public ICollection<Post0011> Posts03 { get; } = new List<Post0011>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0012
-    {
-        public int Id { get; set; }
+public class Blog0012
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0012> Tags { get; set; }
+    public ICollection<Tag0012> Tags { get; set; }
 
-        public ICollection<Post0012> Posts00 { get; } = new List<Post0012>();
-        public ICollection<Post0012> Posts01 { get; } = new List<Post0012>();
-        public ICollection<Post0012> Posts02 { get; } = new List<Post0012>();
-        public ICollection<Post0012> Posts03 { get; } = new List<Post0012>();
+    public ICollection<Post0012> Posts00 { get; } = new List<Post0012>();
+    public ICollection<Post0012> Posts01 { get; } = new List<Post0012>();
+    public ICollection<Post0012> Posts02 { get; } = new List<Post0012>();
+    public ICollection<Post0012> Posts03 { get; } = new List<Post0012>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0013
-    {
-        public int Id { get; set; }
+public class Blog0013
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0013> Tags { get; set; }
+    public ICollection<Tag0013> Tags { get; set; }
 
-        public ICollection<Post0013> Posts00 { get; } = new List<Post0013>();
-        public ICollection<Post0013> Posts01 { get; } = new List<Post0013>();
-        public ICollection<Post0013> Posts02 { get; } = new List<Post0013>();
-        public ICollection<Post0013> Posts03 { get; } = new List<Post0013>();
+    public ICollection<Post0013> Posts00 { get; } = new List<Post0013>();
+    public ICollection<Post0013> Posts01 { get; } = new List<Post0013>();
+    public ICollection<Post0013> Posts02 { get; } = new List<Post0013>();
+    public ICollection<Post0013> Posts03 { get; } = new List<Post0013>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0014
-    {
-        public int Id { get; set; }
+public class Blog0014
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0014> Tags { get; set; }
+    public ICollection<Tag0014> Tags { get; set; }
 
-        public ICollection<Post0014> Posts00 { get; } = new List<Post0014>();
-        public ICollection<Post0014> Posts01 { get; } = new List<Post0014>();
-        public ICollection<Post0014> Posts02 { get; } = new List<Post0014>();
-        public ICollection<Post0014> Posts03 { get; } = new List<Post0014>();
+    public ICollection<Post0014> Posts00 { get; } = new List<Post0014>();
+    public ICollection<Post0014> Posts01 { get; } = new List<Post0014>();
+    public ICollection<Post0014> Posts02 { get; } = new List<Post0014>();
+    public ICollection<Post0014> Posts03 { get; } = new List<Post0014>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0015
-    {
-        public int Id { get; set; }
+public class Blog0015
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0015> Tags { get; set; }
+    public ICollection<Tag0015> Tags { get; set; }
 
-        public ICollection<Post0015> Posts00 { get; } = new List<Post0015>();
-        public ICollection<Post0015> Posts01 { get; } = new List<Post0015>();
-        public ICollection<Post0015> Posts02 { get; } = new List<Post0015>();
-        public ICollection<Post0015> Posts03 { get; } = new List<Post0015>();
+    public ICollection<Post0015> Posts00 { get; } = new List<Post0015>();
+    public ICollection<Post0015> Posts01 { get; } = new List<Post0015>();
+    public ICollection<Post0015> Posts02 { get; } = new List<Post0015>();
+    public ICollection<Post0015> Posts03 { get; } = new List<Post0015>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0016
-    {
-        public int Id { get; set; }
+public class Blog0016
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0016> Tags { get; set; }
+    public ICollection<Tag0016> Tags { get; set; }
 
-        public ICollection<Post0016> Posts00 { get; } = new List<Post0016>();
-        public ICollection<Post0016> Posts01 { get; } = new List<Post0016>();
-        public ICollection<Post0016> Posts02 { get; } = new List<Post0016>();
-        public ICollection<Post0016> Posts03 { get; } = new List<Post0016>();
+    public ICollection<Post0016> Posts00 { get; } = new List<Post0016>();
+    public ICollection<Post0016> Posts01 { get; } = new List<Post0016>();
+    public ICollection<Post0016> Posts02 { get; } = new List<Post0016>();
+    public ICollection<Post0016> Posts03 { get; } = new List<Post0016>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0017
-    {
-        public int Id { get; set; }
+public class Blog0017
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0017> Tags { get; set; }
+    public ICollection<Tag0017> Tags { get; set; }
 
-        public ICollection<Post0017> Posts00 { get; } = new List<Post0017>();
-        public ICollection<Post0017> Posts01 { get; } = new List<Post0017>();
-        public ICollection<Post0017> Posts02 { get; } = new List<Post0017>();
-        public ICollection<Post0017> Posts03 { get; } = new List<Post0017>();
+    public ICollection<Post0017> Posts00 { get; } = new List<Post0017>();
+    public ICollection<Post0017> Posts01 { get; } = new List<Post0017>();
+    public ICollection<Post0017> Posts02 { get; } = new List<Post0017>();
+    public ICollection<Post0017> Posts03 { get; } = new List<Post0017>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0018
-    {
-        public int Id { get; set; }
+public class Blog0018
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0018> Tags { get; set; }
+    public ICollection<Tag0018> Tags { get; set; }
 
-        public ICollection<Post0018> Posts00 { get; } = new List<Post0018>();
-        public ICollection<Post0018> Posts01 { get; } = new List<Post0018>();
-        public ICollection<Post0018> Posts02 { get; } = new List<Post0018>();
-        public ICollection<Post0018> Posts03 { get; } = new List<Post0018>();
+    public ICollection<Post0018> Posts00 { get; } = new List<Post0018>();
+    public ICollection<Post0018> Posts01 { get; } = new List<Post0018>();
+    public ICollection<Post0018> Posts02 { get; } = new List<Post0018>();
+    public ICollection<Post0018> Posts03 { get; } = new List<Post0018>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0019
-    {
-        public int Id { get; set; }
+public class Blog0019
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0019> Tags { get; set; }
+    public ICollection<Tag0019> Tags { get; set; }
 
-        public ICollection<Post0019> Posts00 { get; } = new List<Post0019>();
-        public ICollection<Post0019> Posts01 { get; } = new List<Post0019>();
-        public ICollection<Post0019> Posts02 { get; } = new List<Post0019>();
-        public ICollection<Post0019> Posts03 { get; } = new List<Post0019>();
+    public ICollection<Post0019> Posts00 { get; } = new List<Post0019>();
+    public ICollection<Post0019> Posts01 { get; } = new List<Post0019>();
+    public ICollection<Post0019> Posts02 { get; } = new List<Post0019>();
+    public ICollection<Post0019> Posts03 { get; } = new List<Post0019>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0020
-    {
-        public int Id { get; set; }
+public class Blog0020
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0020> Tags { get; set; }
+    public ICollection<Tag0020> Tags { get; set; }
 
-        public ICollection<Post0020> Posts00 { get; } = new List<Post0020>();
-        public ICollection<Post0020> Posts01 { get; } = new List<Post0020>();
-        public ICollection<Post0020> Posts02 { get; } = new List<Post0020>();
-        public ICollection<Post0020> Posts03 { get; } = new List<Post0020>();
+    public ICollection<Post0020> Posts00 { get; } = new List<Post0020>();
+    public ICollection<Post0020> Posts01 { get; } = new List<Post0020>();
+    public ICollection<Post0020> Posts02 { get; } = new List<Post0020>();
+    public ICollection<Post0020> Posts03 { get; } = new List<Post0020>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0021
-    {
-        public int Id { get; set; }
+public class Blog0021
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0021> Tags { get; set; }
+    public ICollection<Tag0021> Tags { get; set; }
 
-        public ICollection<Post0021> Posts00 { get; } = new List<Post0021>();
-        public ICollection<Post0021> Posts01 { get; } = new List<Post0021>();
-        public ICollection<Post0021> Posts02 { get; } = new List<Post0021>();
-        public ICollection<Post0021> Posts03 { get; } = new List<Post0021>();
+    public ICollection<Post0021> Posts00 { get; } = new List<Post0021>();
+    public ICollection<Post0021> Posts01 { get; } = new List<Post0021>();
+    public ICollection<Post0021> Posts02 { get; } = new List<Post0021>();
+    public ICollection<Post0021> Posts03 { get; } = new List<Post0021>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0022
-    {
-        public int Id { get; set; }
+public class Blog0022
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0022> Tags { get; set; }
+    public ICollection<Tag0022> Tags { get; set; }
 
-        public ICollection<Post0022> Posts00 { get; } = new List<Post0022>();
-        public ICollection<Post0022> Posts01 { get; } = new List<Post0022>();
-        public ICollection<Post0022> Posts02 { get; } = new List<Post0022>();
-        public ICollection<Post0022> Posts03 { get; } = new List<Post0022>();
+    public ICollection<Post0022> Posts00 { get; } = new List<Post0022>();
+    public ICollection<Post0022> Posts01 { get; } = new List<Post0022>();
+    public ICollection<Post0022> Posts02 { get; } = new List<Post0022>();
+    public ICollection<Post0022> Posts03 { get; } = new List<Post0022>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0023
-    {
-        public int Id { get; set; }
+public class Blog0023
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0023> Tags { get; set; }
+    public ICollection<Tag0023> Tags { get; set; }
 
-        public ICollection<Post0023> Posts00 { get; } = new List<Post0023>();
-        public ICollection<Post0023> Posts01 { get; } = new List<Post0023>();
-        public ICollection<Post0023> Posts02 { get; } = new List<Post0023>();
-        public ICollection<Post0023> Posts03 { get; } = new List<Post0023>();
+    public ICollection<Post0023> Posts00 { get; } = new List<Post0023>();
+    public ICollection<Post0023> Posts01 { get; } = new List<Post0023>();
+    public ICollection<Post0023> Posts02 { get; } = new List<Post0023>();
+    public ICollection<Post0023> Posts03 { get; } = new List<Post0023>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0024
-    {
-        public int Id { get; set; }
+public class Blog0024
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0024> Tags { get; set; }
+    public ICollection<Tag0024> Tags { get; set; }
 
-        public ICollection<Post0024> Posts00 { get; } = new List<Post0024>();
-        public ICollection<Post0024> Posts01 { get; } = new List<Post0024>();
-        public ICollection<Post0024> Posts02 { get; } = new List<Post0024>();
-        public ICollection<Post0024> Posts03 { get; } = new List<Post0024>();
+    public ICollection<Post0024> Posts00 { get; } = new List<Post0024>();
+    public ICollection<Post0024> Posts01 { get; } = new List<Post0024>();
+    public ICollection<Post0024> Posts02 { get; } = new List<Post0024>();
+    public ICollection<Post0024> Posts03 { get; } = new List<Post0024>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0025
-    {
-        public int Id { get; set; }
+public class Blog0025
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0025> Tags { get; set; }
+    public ICollection<Tag0025> Tags { get; set; }
 
-        public ICollection<Post0025> Posts00 { get; } = new List<Post0025>();
-        public ICollection<Post0025> Posts01 { get; } = new List<Post0025>();
-        public ICollection<Post0025> Posts02 { get; } = new List<Post0025>();
-        public ICollection<Post0025> Posts03 { get; } = new List<Post0025>();
+    public ICollection<Post0025> Posts00 { get; } = new List<Post0025>();
+    public ICollection<Post0025> Posts01 { get; } = new List<Post0025>();
+    public ICollection<Post0025> Posts02 { get; } = new List<Post0025>();
+    public ICollection<Post0025> Posts03 { get; } = new List<Post0025>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0026
-    {
-        public int Id { get; set; }
+public class Blog0026
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0026> Tags { get; set; }
+    public ICollection<Tag0026> Tags { get; set; }
 
-        public ICollection<Post0026> Posts00 { get; } = new List<Post0026>();
-        public ICollection<Post0026> Posts01 { get; } = new List<Post0026>();
-        public ICollection<Post0026> Posts02 { get; } = new List<Post0026>();
-        public ICollection<Post0026> Posts03 { get; } = new List<Post0026>();
+    public ICollection<Post0026> Posts00 { get; } = new List<Post0026>();
+    public ICollection<Post0026> Posts01 { get; } = new List<Post0026>();
+    public ICollection<Post0026> Posts02 { get; } = new List<Post0026>();
+    public ICollection<Post0026> Posts03 { get; } = new List<Post0026>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0027
-    {
-        public int Id { get; set; }
+public class Blog0027
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0027> Tags { get; set; }
+    public ICollection<Tag0027> Tags { get; set; }
 
-        public ICollection<Post0027> Posts00 { get; } = new List<Post0027>();
-        public ICollection<Post0027> Posts01 { get; } = new List<Post0027>();
-        public ICollection<Post0027> Posts02 { get; } = new List<Post0027>();
-        public ICollection<Post0027> Posts03 { get; } = new List<Post0027>();
+    public ICollection<Post0027> Posts00 { get; } = new List<Post0027>();
+    public ICollection<Post0027> Posts01 { get; } = new List<Post0027>();
+    public ICollection<Post0027> Posts02 { get; } = new List<Post0027>();
+    public ICollection<Post0027> Posts03 { get; } = new List<Post0027>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0028
-    {
-        public int Id { get; set; }
+public class Blog0028
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0028> Tags { get; set; }
+    public ICollection<Tag0028> Tags { get; set; }
 
-        public ICollection<Post0028> Posts00 { get; } = new List<Post0028>();
-        public ICollection<Post0028> Posts01 { get; } = new List<Post0028>();
-        public ICollection<Post0028> Posts02 { get; } = new List<Post0028>();
-        public ICollection<Post0028> Posts03 { get; } = new List<Post0028>();
+    public ICollection<Post0028> Posts00 { get; } = new List<Post0028>();
+    public ICollection<Post0028> Posts01 { get; } = new List<Post0028>();
+    public ICollection<Post0028> Posts02 { get; } = new List<Post0028>();
+    public ICollection<Post0028> Posts03 { get; } = new List<Post0028>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0029
-    {
-        public int Id { get; set; }
+public class Blog0029
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0029> Tags { get; set; }
+    public ICollection<Tag0029> Tags { get; set; }
 
-        public ICollection<Post0029> Posts00 { get; } = new List<Post0029>();
-        public ICollection<Post0029> Posts01 { get; } = new List<Post0029>();
-        public ICollection<Post0029> Posts02 { get; } = new List<Post0029>();
-        public ICollection<Post0029> Posts03 { get; } = new List<Post0029>();
+    public ICollection<Post0029> Posts00 { get; } = new List<Post0029>();
+    public ICollection<Post0029> Posts01 { get; } = new List<Post0029>();
+    public ICollection<Post0029> Posts02 { get; } = new List<Post0029>();
+    public ICollection<Post0029> Posts03 { get; } = new List<Post0029>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0030
-    {
-        public int Id { get; set; }
+public class Blog0030
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0030> Tags { get; set; }
+    public ICollection<Tag0030> Tags { get; set; }
 
-        public ICollection<Post0030> Posts00 { get; } = new List<Post0030>();
-        public ICollection<Post0030> Posts01 { get; } = new List<Post0030>();
-        public ICollection<Post0030> Posts02 { get; } = new List<Post0030>();
-        public ICollection<Post0030> Posts03 { get; } = new List<Post0030>();
+    public ICollection<Post0030> Posts00 { get; } = new List<Post0030>();
+    public ICollection<Post0030> Posts01 { get; } = new List<Post0030>();
+    public ICollection<Post0030> Posts02 { get; } = new List<Post0030>();
+    public ICollection<Post0030> Posts03 { get; } = new List<Post0030>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0031
-    {
-        public int Id { get; set; }
+public class Blog0031
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0031> Tags { get; set; }
+    public ICollection<Tag0031> Tags { get; set; }
 
-        public ICollection<Post0031> Posts00 { get; } = new List<Post0031>();
-        public ICollection<Post0031> Posts01 { get; } = new List<Post0031>();
-        public ICollection<Post0031> Posts02 { get; } = new List<Post0031>();
-        public ICollection<Post0031> Posts03 { get; } = new List<Post0031>();
+    public ICollection<Post0031> Posts00 { get; } = new List<Post0031>();
+    public ICollection<Post0031> Posts01 { get; } = new List<Post0031>();
+    public ICollection<Post0031> Posts02 { get; } = new List<Post0031>();
+    public ICollection<Post0031> Posts03 { get; } = new List<Post0031>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0032
-    {
-        public int Id { get; set; }
+public class Blog0032
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0032> Tags { get; set; }
+    public ICollection<Tag0032> Tags { get; set; }
 
-        public ICollection<Post0032> Posts00 { get; } = new List<Post0032>();
-        public ICollection<Post0032> Posts01 { get; } = new List<Post0032>();
-        public ICollection<Post0032> Posts02 { get; } = new List<Post0032>();
-        public ICollection<Post0032> Posts03 { get; } = new List<Post0032>();
+    public ICollection<Post0032> Posts00 { get; } = new List<Post0032>();
+    public ICollection<Post0032> Posts01 { get; } = new List<Post0032>();
+    public ICollection<Post0032> Posts02 { get; } = new List<Post0032>();
+    public ICollection<Post0032> Posts03 { get; } = new List<Post0032>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0033
-    {
-        public int Id { get; set; }
+public class Blog0033
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0033> Tags { get; set; }
+    public ICollection<Tag0033> Tags { get; set; }
 
-        public ICollection<Post0033> Posts00 { get; } = new List<Post0033>();
-        public ICollection<Post0033> Posts01 { get; } = new List<Post0033>();
-        public ICollection<Post0033> Posts02 { get; } = new List<Post0033>();
-        public ICollection<Post0033> Posts03 { get; } = new List<Post0033>();
+    public ICollection<Post0033> Posts00 { get; } = new List<Post0033>();
+    public ICollection<Post0033> Posts01 { get; } = new List<Post0033>();
+    public ICollection<Post0033> Posts02 { get; } = new List<Post0033>();
+    public ICollection<Post0033> Posts03 { get; } = new List<Post0033>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0034
-    {
-        public int Id { get; set; }
+public class Blog0034
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0034> Tags { get; set; }
+    public ICollection<Tag0034> Tags { get; set; }
 
-        public ICollection<Post0034> Posts00 { get; } = new List<Post0034>();
-        public ICollection<Post0034> Posts01 { get; } = new List<Post0034>();
-        public ICollection<Post0034> Posts02 { get; } = new List<Post0034>();
-        public ICollection<Post0034> Posts03 { get; } = new List<Post0034>();
+    public ICollection<Post0034> Posts00 { get; } = new List<Post0034>();
+    public ICollection<Post0034> Posts01 { get; } = new List<Post0034>();
+    public ICollection<Post0034> Posts02 { get; } = new List<Post0034>();
+    public ICollection<Post0034> Posts03 { get; } = new List<Post0034>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0035
-    {
-        public int Id { get; set; }
+public class Blog0035
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0035> Tags { get; set; }
+    public ICollection<Tag0035> Tags { get; set; }
 
-        public ICollection<Post0035> Posts00 { get; } = new List<Post0035>();
-        public ICollection<Post0035> Posts01 { get; } = new List<Post0035>();
-        public ICollection<Post0035> Posts02 { get; } = new List<Post0035>();
-        public ICollection<Post0035> Posts03 { get; } = new List<Post0035>();
+    public ICollection<Post0035> Posts00 { get; } = new List<Post0035>();
+    public ICollection<Post0035> Posts01 { get; } = new List<Post0035>();
+    public ICollection<Post0035> Posts02 { get; } = new List<Post0035>();
+    public ICollection<Post0035> Posts03 { get; } = new List<Post0035>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0036
-    {
-        public int Id { get; set; }
+public class Blog0036
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0036> Tags { get; set; }
+    public ICollection<Tag0036> Tags { get; set; }
 
-        public ICollection<Post0036> Posts00 { get; } = new List<Post0036>();
-        public ICollection<Post0036> Posts01 { get; } = new List<Post0036>();
-        public ICollection<Post0036> Posts02 { get; } = new List<Post0036>();
-        public ICollection<Post0036> Posts03 { get; } = new List<Post0036>();
+    public ICollection<Post0036> Posts00 { get; } = new List<Post0036>();
+    public ICollection<Post0036> Posts01 { get; } = new List<Post0036>();
+    public ICollection<Post0036> Posts02 { get; } = new List<Post0036>();
+    public ICollection<Post0036> Posts03 { get; } = new List<Post0036>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0037
-    {
-        public int Id { get; set; }
+public class Blog0037
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0037> Tags { get; set; }
+    public ICollection<Tag0037> Tags { get; set; }
 
-        public ICollection<Post0037> Posts00 { get; } = new List<Post0037>();
-        public ICollection<Post0037> Posts01 { get; } = new List<Post0037>();
-        public ICollection<Post0037> Posts02 { get; } = new List<Post0037>();
-        public ICollection<Post0037> Posts03 { get; } = new List<Post0037>();
+    public ICollection<Post0037> Posts00 { get; } = new List<Post0037>();
+    public ICollection<Post0037> Posts01 { get; } = new List<Post0037>();
+    public ICollection<Post0037> Posts02 { get; } = new List<Post0037>();
+    public ICollection<Post0037> Posts03 { get; } = new List<Post0037>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0038
-    {
-        public int Id { get; set; }
+public class Blog0038
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0038> Tags { get; set; }
+    public ICollection<Tag0038> Tags { get; set; }
 
-        public ICollection<Post0038> Posts00 { get; } = new List<Post0038>();
-        public ICollection<Post0038> Posts01 { get; } = new List<Post0038>();
-        public ICollection<Post0038> Posts02 { get; } = new List<Post0038>();
-        public ICollection<Post0038> Posts03 { get; } = new List<Post0038>();
+    public ICollection<Post0038> Posts00 { get; } = new List<Post0038>();
+    public ICollection<Post0038> Posts01 { get; } = new List<Post0038>();
+    public ICollection<Post0038> Posts02 { get; } = new List<Post0038>();
+    public ICollection<Post0038> Posts03 { get; } = new List<Post0038>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0039
-    {
-        public int Id { get; set; }
+public class Blog0039
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0039> Tags { get; set; }
+    public ICollection<Tag0039> Tags { get; set; }
 
-        public ICollection<Post0039> Posts00 { get; } = new List<Post0039>();
-        public ICollection<Post0039> Posts01 { get; } = new List<Post0039>();
-        public ICollection<Post0039> Posts02 { get; } = new List<Post0039>();
-        public ICollection<Post0039> Posts03 { get; } = new List<Post0039>();
+    public ICollection<Post0039> Posts00 { get; } = new List<Post0039>();
+    public ICollection<Post0039> Posts01 { get; } = new List<Post0039>();
+    public ICollection<Post0039> Posts02 { get; } = new List<Post0039>();
+    public ICollection<Post0039> Posts03 { get; } = new List<Post0039>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0040
-    {
-        public int Id { get; set; }
+public class Blog0040
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0040> Tags { get; set; }
+    public ICollection<Tag0040> Tags { get; set; }
 
-        public ICollection<Post0040> Posts00 { get; } = new List<Post0040>();
-        public ICollection<Post0040> Posts01 { get; } = new List<Post0040>();
-        public ICollection<Post0040> Posts02 { get; } = new List<Post0040>();
-        public ICollection<Post0040> Posts03 { get; } = new List<Post0040>();
+    public ICollection<Post0040> Posts00 { get; } = new List<Post0040>();
+    public ICollection<Post0040> Posts01 { get; } = new List<Post0040>();
+    public ICollection<Post0040> Posts02 { get; } = new List<Post0040>();
+    public ICollection<Post0040> Posts03 { get; } = new List<Post0040>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0041
-    {
-        public int Id { get; set; }
+public class Blog0041
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0041> Tags { get; set; }
+    public ICollection<Tag0041> Tags { get; set; }
 
-        public ICollection<Post0041> Posts00 { get; } = new List<Post0041>();
-        public ICollection<Post0041> Posts01 { get; } = new List<Post0041>();
-        public ICollection<Post0041> Posts02 { get; } = new List<Post0041>();
-        public ICollection<Post0041> Posts03 { get; } = new List<Post0041>();
+    public ICollection<Post0041> Posts00 { get; } = new List<Post0041>();
+    public ICollection<Post0041> Posts01 { get; } = new List<Post0041>();
+    public ICollection<Post0041> Posts02 { get; } = new List<Post0041>();
+    public ICollection<Post0041> Posts03 { get; } = new List<Post0041>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0042
-    {
-        public int Id { get; set; }
+public class Blog0042
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0042> Tags { get; set; }
+    public ICollection<Tag0042> Tags { get; set; }
 
-        public ICollection<Post0042> Posts00 { get; } = new List<Post0042>();
-        public ICollection<Post0042> Posts01 { get; } = new List<Post0042>();
-        public ICollection<Post0042> Posts02 { get; } = new List<Post0042>();
-        public ICollection<Post0042> Posts03 { get; } = new List<Post0042>();
+    public ICollection<Post0042> Posts00 { get; } = new List<Post0042>();
+    public ICollection<Post0042> Posts01 { get; } = new List<Post0042>();
+    public ICollection<Post0042> Posts02 { get; } = new List<Post0042>();
+    public ICollection<Post0042> Posts03 { get; } = new List<Post0042>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0043
-    {
-        public int Id { get; set; }
+public class Blog0043
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0043> Tags { get; set; }
+    public ICollection<Tag0043> Tags { get; set; }
 
-        public ICollection<Post0043> Posts00 { get; } = new List<Post0043>();
-        public ICollection<Post0043> Posts01 { get; } = new List<Post0043>();
-        public ICollection<Post0043> Posts02 { get; } = new List<Post0043>();
-        public ICollection<Post0043> Posts03 { get; } = new List<Post0043>();
+    public ICollection<Post0043> Posts00 { get; } = new List<Post0043>();
+    public ICollection<Post0043> Posts01 { get; } = new List<Post0043>();
+    public ICollection<Post0043> Posts02 { get; } = new List<Post0043>();
+    public ICollection<Post0043> Posts03 { get; } = new List<Post0043>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0044
-    {
-        public int Id { get; set; }
+public class Blog0044
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0044> Tags { get; set; }
+    public ICollection<Tag0044> Tags { get; set; }
 
-        public ICollection<Post0044> Posts00 { get; } = new List<Post0044>();
-        public ICollection<Post0044> Posts01 { get; } = new List<Post0044>();
-        public ICollection<Post0044> Posts02 { get; } = new List<Post0044>();
-        public ICollection<Post0044> Posts03 { get; } = new List<Post0044>();
+    public ICollection<Post0044> Posts00 { get; } = new List<Post0044>();
+    public ICollection<Post0044> Posts01 { get; } = new List<Post0044>();
+    public ICollection<Post0044> Posts02 { get; } = new List<Post0044>();
+    public ICollection<Post0044> Posts03 { get; } = new List<Post0044>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0045
-    {
-        public int Id { get; set; }
+public class Blog0045
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0045> Tags { get; set; }
+    public ICollection<Tag0045> Tags { get; set; }
 
-        public ICollection<Post0045> Posts00 { get; } = new List<Post0045>();
-        public ICollection<Post0045> Posts01 { get; } = new List<Post0045>();
-        public ICollection<Post0045> Posts02 { get; } = new List<Post0045>();
-        public ICollection<Post0045> Posts03 { get; } = new List<Post0045>();
+    public ICollection<Post0045> Posts00 { get; } = new List<Post0045>();
+    public ICollection<Post0045> Posts01 { get; } = new List<Post0045>();
+    public ICollection<Post0045> Posts02 { get; } = new List<Post0045>();
+    public ICollection<Post0045> Posts03 { get; } = new List<Post0045>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0046
-    {
-        public int Id { get; set; }
+public class Blog0046
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0046> Tags { get; set; }
+    public ICollection<Tag0046> Tags { get; set; }
 
-        public ICollection<Post0046> Posts00 { get; } = new List<Post0046>();
-        public ICollection<Post0046> Posts01 { get; } = new List<Post0046>();
-        public ICollection<Post0046> Posts02 { get; } = new List<Post0046>();
-        public ICollection<Post0046> Posts03 { get; } = new List<Post0046>();
+    public ICollection<Post0046> Posts00 { get; } = new List<Post0046>();
+    public ICollection<Post0046> Posts01 { get; } = new List<Post0046>();
+    public ICollection<Post0046> Posts02 { get; } = new List<Post0046>();
+    public ICollection<Post0046> Posts03 { get; } = new List<Post0046>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0047
-    {
-        public int Id { get; set; }
+public class Blog0047
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0047> Tags { get; set; }
+    public ICollection<Tag0047> Tags { get; set; }
 
-        public ICollection<Post0047> Posts00 { get; } = new List<Post0047>();
-        public ICollection<Post0047> Posts01 { get; } = new List<Post0047>();
-        public ICollection<Post0047> Posts02 { get; } = new List<Post0047>();
-        public ICollection<Post0047> Posts03 { get; } = new List<Post0047>();
+    public ICollection<Post0047> Posts00 { get; } = new List<Post0047>();
+    public ICollection<Post0047> Posts01 { get; } = new List<Post0047>();
+    public ICollection<Post0047> Posts02 { get; } = new List<Post0047>();
+    public ICollection<Post0047> Posts03 { get; } = new List<Post0047>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0048
-    {
-        public int Id { get; set; }
+public class Blog0048
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0048> Tags { get; set; }
+    public ICollection<Tag0048> Tags { get; set; }
 
-        public ICollection<Post0048> Posts00 { get; } = new List<Post0048>();
-        public ICollection<Post0048> Posts01 { get; } = new List<Post0048>();
-        public ICollection<Post0048> Posts02 { get; } = new List<Post0048>();
-        public ICollection<Post0048> Posts03 { get; } = new List<Post0048>();
+    public ICollection<Post0048> Posts00 { get; } = new List<Post0048>();
+    public ICollection<Post0048> Posts01 { get; } = new List<Post0048>();
+    public ICollection<Post0048> Posts02 { get; } = new List<Post0048>();
+    public ICollection<Post0048> Posts03 { get; } = new List<Post0048>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0049
-    {
-        public int Id { get; set; }
+public class Blog0049
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0049> Tags { get; set; }
+    public ICollection<Tag0049> Tags { get; set; }
 
-        public ICollection<Post0049> Posts00 { get; } = new List<Post0049>();
-        public ICollection<Post0049> Posts01 { get; } = new List<Post0049>();
-        public ICollection<Post0049> Posts02 { get; } = new List<Post0049>();
-        public ICollection<Post0049> Posts03 { get; } = new List<Post0049>();
+    public ICollection<Post0049> Posts00 { get; } = new List<Post0049>();
+    public ICollection<Post0049> Posts01 { get; } = new List<Post0049>();
+    public ICollection<Post0049> Posts02 { get; } = new List<Post0049>();
+    public ICollection<Post0049> Posts03 { get; } = new List<Post0049>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0050
-    {
-        public int Id { get; set; }
+public class Blog0050
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0050> Tags { get; set; }
+    public ICollection<Tag0050> Tags { get; set; }
 
-        public ICollection<Post0050> Posts00 { get; } = new List<Post0050>();
-        public ICollection<Post0050> Posts01 { get; } = new List<Post0050>();
-        public ICollection<Post0050> Posts02 { get; } = new List<Post0050>();
-        public ICollection<Post0050> Posts03 { get; } = new List<Post0050>();
+    public ICollection<Post0050> Posts00 { get; } = new List<Post0050>();
+    public ICollection<Post0050> Posts01 { get; } = new List<Post0050>();
+    public ICollection<Post0050> Posts02 { get; } = new List<Post0050>();
+    public ICollection<Post0050> Posts03 { get; } = new List<Post0050>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0051
-    {
-        public int Id { get; set; }
+public class Blog0051
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0051> Tags { get; set; }
+    public ICollection<Tag0051> Tags { get; set; }
 
-        public ICollection<Post0051> Posts00 { get; } = new List<Post0051>();
-        public ICollection<Post0051> Posts01 { get; } = new List<Post0051>();
-        public ICollection<Post0051> Posts02 { get; } = new List<Post0051>();
-        public ICollection<Post0051> Posts03 { get; } = new List<Post0051>();
+    public ICollection<Post0051> Posts00 { get; } = new List<Post0051>();
+    public ICollection<Post0051> Posts01 { get; } = new List<Post0051>();
+    public ICollection<Post0051> Posts02 { get; } = new List<Post0051>();
+    public ICollection<Post0051> Posts03 { get; } = new List<Post0051>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0052
-    {
-        public int Id { get; set; }
+public class Blog0052
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0052> Tags { get; set; }
+    public ICollection<Tag0052> Tags { get; set; }
 
-        public ICollection<Post0052> Posts00 { get; } = new List<Post0052>();
-        public ICollection<Post0052> Posts01 { get; } = new List<Post0052>();
-        public ICollection<Post0052> Posts02 { get; } = new List<Post0052>();
-        public ICollection<Post0052> Posts03 { get; } = new List<Post0052>();
+    public ICollection<Post0052> Posts00 { get; } = new List<Post0052>();
+    public ICollection<Post0052> Posts01 { get; } = new List<Post0052>();
+    public ICollection<Post0052> Posts02 { get; } = new List<Post0052>();
+    public ICollection<Post0052> Posts03 { get; } = new List<Post0052>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0053
-    {
-        public int Id { get; set; }
+public class Blog0053
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0053> Tags { get; set; }
+    public ICollection<Tag0053> Tags { get; set; }
 
-        public ICollection<Post0053> Posts00 { get; } = new List<Post0053>();
-        public ICollection<Post0053> Posts01 { get; } = new List<Post0053>();
-        public ICollection<Post0053> Posts02 { get; } = new List<Post0053>();
-        public ICollection<Post0053> Posts03 { get; } = new List<Post0053>();
+    public ICollection<Post0053> Posts00 { get; } = new List<Post0053>();
+    public ICollection<Post0053> Posts01 { get; } = new List<Post0053>();
+    public ICollection<Post0053> Posts02 { get; } = new List<Post0053>();
+    public ICollection<Post0053> Posts03 { get; } = new List<Post0053>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0054
-    {
-        public int Id { get; set; }
+public class Blog0054
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0054> Tags { get; set; }
+    public ICollection<Tag0054> Tags { get; set; }
 
-        public ICollection<Post0054> Posts00 { get; } = new List<Post0054>();
-        public ICollection<Post0054> Posts01 { get; } = new List<Post0054>();
-        public ICollection<Post0054> Posts02 { get; } = new List<Post0054>();
-        public ICollection<Post0054> Posts03 { get; } = new List<Post0054>();
+    public ICollection<Post0054> Posts00 { get; } = new List<Post0054>();
+    public ICollection<Post0054> Posts01 { get; } = new List<Post0054>();
+    public ICollection<Post0054> Posts02 { get; } = new List<Post0054>();
+    public ICollection<Post0054> Posts03 { get; } = new List<Post0054>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0055
-    {
-        public int Id { get; set; }
+public class Blog0055
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0055> Tags { get; set; }
+    public ICollection<Tag0055> Tags { get; set; }
 
-        public ICollection<Post0055> Posts00 { get; } = new List<Post0055>();
-        public ICollection<Post0055> Posts01 { get; } = new List<Post0055>();
-        public ICollection<Post0055> Posts02 { get; } = new List<Post0055>();
-        public ICollection<Post0055> Posts03 { get; } = new List<Post0055>();
+    public ICollection<Post0055> Posts00 { get; } = new List<Post0055>();
+    public ICollection<Post0055> Posts01 { get; } = new List<Post0055>();
+    public ICollection<Post0055> Posts02 { get; } = new List<Post0055>();
+    public ICollection<Post0055> Posts03 { get; } = new List<Post0055>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0056
-    {
-        public int Id { get; set; }
+public class Blog0056
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0056> Tags { get; set; }
+    public ICollection<Tag0056> Tags { get; set; }
 
-        public ICollection<Post0056> Posts00 { get; } = new List<Post0056>();
-        public ICollection<Post0056> Posts01 { get; } = new List<Post0056>();
-        public ICollection<Post0056> Posts02 { get; } = new List<Post0056>();
-        public ICollection<Post0056> Posts03 { get; } = new List<Post0056>();
+    public ICollection<Post0056> Posts00 { get; } = new List<Post0056>();
+    public ICollection<Post0056> Posts01 { get; } = new List<Post0056>();
+    public ICollection<Post0056> Posts02 { get; } = new List<Post0056>();
+    public ICollection<Post0056> Posts03 { get; } = new List<Post0056>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0057
-    {
-        public int Id { get; set; }
+public class Blog0057
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0057> Tags { get; set; }
+    public ICollection<Tag0057> Tags { get; set; }
 
-        public ICollection<Post0057> Posts00 { get; } = new List<Post0057>();
-        public ICollection<Post0057> Posts01 { get; } = new List<Post0057>();
-        public ICollection<Post0057> Posts02 { get; } = new List<Post0057>();
-        public ICollection<Post0057> Posts03 { get; } = new List<Post0057>();
+    public ICollection<Post0057> Posts00 { get; } = new List<Post0057>();
+    public ICollection<Post0057> Posts01 { get; } = new List<Post0057>();
+    public ICollection<Post0057> Posts02 { get; } = new List<Post0057>();
+    public ICollection<Post0057> Posts03 { get; } = new List<Post0057>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0058
-    {
-        public int Id { get; set; }
+public class Blog0058
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0058> Tags { get; set; }
+    public ICollection<Tag0058> Tags { get; set; }
 
-        public ICollection<Post0058> Posts00 { get; } = new List<Post0058>();
-        public ICollection<Post0058> Posts01 { get; } = new List<Post0058>();
-        public ICollection<Post0058> Posts02 { get; } = new List<Post0058>();
-        public ICollection<Post0058> Posts03 { get; } = new List<Post0058>();
+    public ICollection<Post0058> Posts00 { get; } = new List<Post0058>();
+    public ICollection<Post0058> Posts01 { get; } = new List<Post0058>();
+    public ICollection<Post0058> Posts02 { get; } = new List<Post0058>();
+    public ICollection<Post0058> Posts03 { get; } = new List<Post0058>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0059
-    {
-        public int Id { get; set; }
+public class Blog0059
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0059> Tags { get; set; }
+    public ICollection<Tag0059> Tags { get; set; }
 
-        public ICollection<Post0059> Posts00 { get; } = new List<Post0059>();
-        public ICollection<Post0059> Posts01 { get; } = new List<Post0059>();
-        public ICollection<Post0059> Posts02 { get; } = new List<Post0059>();
-        public ICollection<Post0059> Posts03 { get; } = new List<Post0059>();
+    public ICollection<Post0059> Posts00 { get; } = new List<Post0059>();
+    public ICollection<Post0059> Posts01 { get; } = new List<Post0059>();
+    public ICollection<Post0059> Posts02 { get; } = new List<Post0059>();
+    public ICollection<Post0059> Posts03 { get; } = new List<Post0059>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0060
-    {
-        public int Id { get; set; }
+public class Blog0060
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0060> Tags { get; set; }
+    public ICollection<Tag0060> Tags { get; set; }
 
-        public ICollection<Post0060> Posts00 { get; } = new List<Post0060>();
-        public ICollection<Post0060> Posts01 { get; } = new List<Post0060>();
-        public ICollection<Post0060> Posts02 { get; } = new List<Post0060>();
-        public ICollection<Post0060> Posts03 { get; } = new List<Post0060>();
+    public ICollection<Post0060> Posts00 { get; } = new List<Post0060>();
+    public ICollection<Post0060> Posts01 { get; } = new List<Post0060>();
+    public ICollection<Post0060> Posts02 { get; } = new List<Post0060>();
+    public ICollection<Post0060> Posts03 { get; } = new List<Post0060>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0061
-    {
-        public int Id { get; set; }
+public class Blog0061
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0061> Tags { get; set; }
+    public ICollection<Tag0061> Tags { get; set; }
 
-        public ICollection<Post0061> Posts00 { get; } = new List<Post0061>();
-        public ICollection<Post0061> Posts01 { get; } = new List<Post0061>();
-        public ICollection<Post0061> Posts02 { get; } = new List<Post0061>();
-        public ICollection<Post0061> Posts03 { get; } = new List<Post0061>();
+    public ICollection<Post0061> Posts00 { get; } = new List<Post0061>();
+    public ICollection<Post0061> Posts01 { get; } = new List<Post0061>();
+    public ICollection<Post0061> Posts02 { get; } = new List<Post0061>();
+    public ICollection<Post0061> Posts03 { get; } = new List<Post0061>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0062
-    {
-        public int Id { get; set; }
+public class Blog0062
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0062> Tags { get; set; }
+    public ICollection<Tag0062> Tags { get; set; }
 
-        public ICollection<Post0062> Posts00 { get; } = new List<Post0062>();
-        public ICollection<Post0062> Posts01 { get; } = new List<Post0062>();
-        public ICollection<Post0062> Posts02 { get; } = new List<Post0062>();
-        public ICollection<Post0062> Posts03 { get; } = new List<Post0062>();
+    public ICollection<Post0062> Posts00 { get; } = new List<Post0062>();
+    public ICollection<Post0062> Posts01 { get; } = new List<Post0062>();
+    public ICollection<Post0062> Posts02 { get; } = new List<Post0062>();
+    public ICollection<Post0062> Posts03 { get; } = new List<Post0062>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0063
-    {
-        public int Id { get; set; }
+public class Blog0063
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0063> Tags { get; set; }
+    public ICollection<Tag0063> Tags { get; set; }
 
-        public ICollection<Post0063> Posts00 { get; } = new List<Post0063>();
-        public ICollection<Post0063> Posts01 { get; } = new List<Post0063>();
-        public ICollection<Post0063> Posts02 { get; } = new List<Post0063>();
-        public ICollection<Post0063> Posts03 { get; } = new List<Post0063>();
+    public ICollection<Post0063> Posts00 { get; } = new List<Post0063>();
+    public ICollection<Post0063> Posts01 { get; } = new List<Post0063>();
+    public ICollection<Post0063> Posts02 { get; } = new List<Post0063>();
+    public ICollection<Post0063> Posts03 { get; } = new List<Post0063>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0064
-    {
-        public int Id { get; set; }
+public class Blog0064
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0064> Tags { get; set; }
+    public ICollection<Tag0064> Tags { get; set; }
 
-        public ICollection<Post0064> Posts00 { get; } = new List<Post0064>();
-        public ICollection<Post0064> Posts01 { get; } = new List<Post0064>();
-        public ICollection<Post0064> Posts02 { get; } = new List<Post0064>();
-        public ICollection<Post0064> Posts03 { get; } = new List<Post0064>();
+    public ICollection<Post0064> Posts00 { get; } = new List<Post0064>();
+    public ICollection<Post0064> Posts01 { get; } = new List<Post0064>();
+    public ICollection<Post0064> Posts02 { get; } = new List<Post0064>();
+    public ICollection<Post0064> Posts03 { get; } = new List<Post0064>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0065
-    {
-        public int Id { get; set; }
+public class Blog0065
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0065> Tags { get; set; }
+    public ICollection<Tag0065> Tags { get; set; }
 
-        public ICollection<Post0065> Posts00 { get; } = new List<Post0065>();
-        public ICollection<Post0065> Posts01 { get; } = new List<Post0065>();
-        public ICollection<Post0065> Posts02 { get; } = new List<Post0065>();
-        public ICollection<Post0065> Posts03 { get; } = new List<Post0065>();
+    public ICollection<Post0065> Posts00 { get; } = new List<Post0065>();
+    public ICollection<Post0065> Posts01 { get; } = new List<Post0065>();
+    public ICollection<Post0065> Posts02 { get; } = new List<Post0065>();
+    public ICollection<Post0065> Posts03 { get; } = new List<Post0065>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0066
-    {
-        public int Id { get; set; }
+public class Blog0066
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0066> Tags { get; set; }
+    public ICollection<Tag0066> Tags { get; set; }
 
-        public ICollection<Post0066> Posts00 { get; } = new List<Post0066>();
-        public ICollection<Post0066> Posts01 { get; } = new List<Post0066>();
-        public ICollection<Post0066> Posts02 { get; } = new List<Post0066>();
-        public ICollection<Post0066> Posts03 { get; } = new List<Post0066>();
+    public ICollection<Post0066> Posts00 { get; } = new List<Post0066>();
+    public ICollection<Post0066> Posts01 { get; } = new List<Post0066>();
+    public ICollection<Post0066> Posts02 { get; } = new List<Post0066>();
+    public ICollection<Post0066> Posts03 { get; } = new List<Post0066>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0067
-    {
-        public int Id { get; set; }
+public class Blog0067
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0067> Tags { get; set; }
+    public ICollection<Tag0067> Tags { get; set; }
 
-        public ICollection<Post0067> Posts00 { get; } = new List<Post0067>();
-        public ICollection<Post0067> Posts01 { get; } = new List<Post0067>();
-        public ICollection<Post0067> Posts02 { get; } = new List<Post0067>();
-        public ICollection<Post0067> Posts03 { get; } = new List<Post0067>();
+    public ICollection<Post0067> Posts00 { get; } = new List<Post0067>();
+    public ICollection<Post0067> Posts01 { get; } = new List<Post0067>();
+    public ICollection<Post0067> Posts02 { get; } = new List<Post0067>();
+    public ICollection<Post0067> Posts03 { get; } = new List<Post0067>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0068
-    {
-        public int Id { get; set; }
+public class Blog0068
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0068> Tags { get; set; }
+    public ICollection<Tag0068> Tags { get; set; }
 
-        public ICollection<Post0068> Posts00 { get; } = new List<Post0068>();
-        public ICollection<Post0068> Posts01 { get; } = new List<Post0068>();
-        public ICollection<Post0068> Posts02 { get; } = new List<Post0068>();
-        public ICollection<Post0068> Posts03 { get; } = new List<Post0068>();
+    public ICollection<Post0068> Posts00 { get; } = new List<Post0068>();
+    public ICollection<Post0068> Posts01 { get; } = new List<Post0068>();
+    public ICollection<Post0068> Posts02 { get; } = new List<Post0068>();
+    public ICollection<Post0068> Posts03 { get; } = new List<Post0068>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0069
-    {
-        public int Id { get; set; }
+public class Blog0069
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0069> Tags { get; set; }
+    public ICollection<Tag0069> Tags { get; set; }
 
-        public ICollection<Post0069> Posts00 { get; } = new List<Post0069>();
-        public ICollection<Post0069> Posts01 { get; } = new List<Post0069>();
-        public ICollection<Post0069> Posts02 { get; } = new List<Post0069>();
-        public ICollection<Post0069> Posts03 { get; } = new List<Post0069>();
+    public ICollection<Post0069> Posts00 { get; } = new List<Post0069>();
+    public ICollection<Post0069> Posts01 { get; } = new List<Post0069>();
+    public ICollection<Post0069> Posts02 { get; } = new List<Post0069>();
+    public ICollection<Post0069> Posts03 { get; } = new List<Post0069>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0070
-    {
-        public int Id { get; set; }
+public class Blog0070
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0070> Tags { get; set; }
+    public ICollection<Tag0070> Tags { get; set; }
 
-        public ICollection<Post0070> Posts00 { get; } = new List<Post0070>();
-        public ICollection<Post0070> Posts01 { get; } = new List<Post0070>();
-        public ICollection<Post0070> Posts02 { get; } = new List<Post0070>();
-        public ICollection<Post0070> Posts03 { get; } = new List<Post0070>();
+    public ICollection<Post0070> Posts00 { get; } = new List<Post0070>();
+    public ICollection<Post0070> Posts01 { get; } = new List<Post0070>();
+    public ICollection<Post0070> Posts02 { get; } = new List<Post0070>();
+    public ICollection<Post0070> Posts03 { get; } = new List<Post0070>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0071
-    {
-        public int Id { get; set; }
+public class Blog0071
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0071> Tags { get; set; }
+    public ICollection<Tag0071> Tags { get; set; }
 
-        public ICollection<Post0071> Posts00 { get; } = new List<Post0071>();
-        public ICollection<Post0071> Posts01 { get; } = new List<Post0071>();
-        public ICollection<Post0071> Posts02 { get; } = new List<Post0071>();
-        public ICollection<Post0071> Posts03 { get; } = new List<Post0071>();
+    public ICollection<Post0071> Posts00 { get; } = new List<Post0071>();
+    public ICollection<Post0071> Posts01 { get; } = new List<Post0071>();
+    public ICollection<Post0071> Posts02 { get; } = new List<Post0071>();
+    public ICollection<Post0071> Posts03 { get; } = new List<Post0071>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0072
-    {
-        public int Id { get; set; }
+public class Blog0072
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0072> Tags { get; set; }
+    public ICollection<Tag0072> Tags { get; set; }
 
-        public ICollection<Post0072> Posts00 { get; } = new List<Post0072>();
-        public ICollection<Post0072> Posts01 { get; } = new List<Post0072>();
-        public ICollection<Post0072> Posts02 { get; } = new List<Post0072>();
-        public ICollection<Post0072> Posts03 { get; } = new List<Post0072>();
+    public ICollection<Post0072> Posts00 { get; } = new List<Post0072>();
+    public ICollection<Post0072> Posts01 { get; } = new List<Post0072>();
+    public ICollection<Post0072> Posts02 { get; } = new List<Post0072>();
+    public ICollection<Post0072> Posts03 { get; } = new List<Post0072>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0073
-    {
-        public int Id { get; set; }
+public class Blog0073
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0073> Tags { get; set; }
+    public ICollection<Tag0073> Tags { get; set; }
 
-        public ICollection<Post0073> Posts00 { get; } = new List<Post0073>();
-        public ICollection<Post0073> Posts01 { get; } = new List<Post0073>();
-        public ICollection<Post0073> Posts02 { get; } = new List<Post0073>();
-        public ICollection<Post0073> Posts03 { get; } = new List<Post0073>();
+    public ICollection<Post0073> Posts00 { get; } = new List<Post0073>();
+    public ICollection<Post0073> Posts01 { get; } = new List<Post0073>();
+    public ICollection<Post0073> Posts02 { get; } = new List<Post0073>();
+    public ICollection<Post0073> Posts03 { get; } = new List<Post0073>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0074
-    {
-        public int Id { get; set; }
+public class Blog0074
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0074> Tags { get; set; }
+    public ICollection<Tag0074> Tags { get; set; }
 
-        public ICollection<Post0074> Posts00 { get; } = new List<Post0074>();
-        public ICollection<Post0074> Posts01 { get; } = new List<Post0074>();
-        public ICollection<Post0074> Posts02 { get; } = new List<Post0074>();
-        public ICollection<Post0074> Posts03 { get; } = new List<Post0074>();
+    public ICollection<Post0074> Posts00 { get; } = new List<Post0074>();
+    public ICollection<Post0074> Posts01 { get; } = new List<Post0074>();
+    public ICollection<Post0074> Posts02 { get; } = new List<Post0074>();
+    public ICollection<Post0074> Posts03 { get; } = new List<Post0074>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0075
-    {
-        public int Id { get; set; }
+public class Blog0075
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0075> Tags { get; set; }
+    public ICollection<Tag0075> Tags { get; set; }
 
-        public ICollection<Post0075> Posts00 { get; } = new List<Post0075>();
-        public ICollection<Post0075> Posts01 { get; } = new List<Post0075>();
-        public ICollection<Post0075> Posts02 { get; } = new List<Post0075>();
-        public ICollection<Post0075> Posts03 { get; } = new List<Post0075>();
+    public ICollection<Post0075> Posts00 { get; } = new List<Post0075>();
+    public ICollection<Post0075> Posts01 { get; } = new List<Post0075>();
+    public ICollection<Post0075> Posts02 { get; } = new List<Post0075>();
+    public ICollection<Post0075> Posts03 { get; } = new List<Post0075>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0076
-    {
-        public int Id { get; set; }
+public class Blog0076
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0076> Tags { get; set; }
+    public ICollection<Tag0076> Tags { get; set; }
 
-        public ICollection<Post0076> Posts00 { get; } = new List<Post0076>();
-        public ICollection<Post0076> Posts01 { get; } = new List<Post0076>();
-        public ICollection<Post0076> Posts02 { get; } = new List<Post0076>();
-        public ICollection<Post0076> Posts03 { get; } = new List<Post0076>();
+    public ICollection<Post0076> Posts00 { get; } = new List<Post0076>();
+    public ICollection<Post0076> Posts01 { get; } = new List<Post0076>();
+    public ICollection<Post0076> Posts02 { get; } = new List<Post0076>();
+    public ICollection<Post0076> Posts03 { get; } = new List<Post0076>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0077
-    {
-        public int Id { get; set; }
+public class Blog0077
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0077> Tags { get; set; }
+    public ICollection<Tag0077> Tags { get; set; }
 
-        public ICollection<Post0077> Posts00 { get; } = new List<Post0077>();
-        public ICollection<Post0077> Posts01 { get; } = new List<Post0077>();
-        public ICollection<Post0077> Posts02 { get; } = new List<Post0077>();
-        public ICollection<Post0077> Posts03 { get; } = new List<Post0077>();
+    public ICollection<Post0077> Posts00 { get; } = new List<Post0077>();
+    public ICollection<Post0077> Posts01 { get; } = new List<Post0077>();
+    public ICollection<Post0077> Posts02 { get; } = new List<Post0077>();
+    public ICollection<Post0077> Posts03 { get; } = new List<Post0077>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0078
-    {
-        public int Id { get; set; }
+public class Blog0078
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0078> Tags { get; set; }
+    public ICollection<Tag0078> Tags { get; set; }
 
-        public ICollection<Post0078> Posts00 { get; } = new List<Post0078>();
-        public ICollection<Post0078> Posts01 { get; } = new List<Post0078>();
-        public ICollection<Post0078> Posts02 { get; } = new List<Post0078>();
-        public ICollection<Post0078> Posts03 { get; } = new List<Post0078>();
+    public ICollection<Post0078> Posts00 { get; } = new List<Post0078>();
+    public ICollection<Post0078> Posts01 { get; } = new List<Post0078>();
+    public ICollection<Post0078> Posts02 { get; } = new List<Post0078>();
+    public ICollection<Post0078> Posts03 { get; } = new List<Post0078>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0079
-    {
-        public int Id { get; set; }
+public class Blog0079
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0079> Tags { get; set; }
+    public ICollection<Tag0079> Tags { get; set; }
 
-        public ICollection<Post0079> Posts00 { get; } = new List<Post0079>();
-        public ICollection<Post0079> Posts01 { get; } = new List<Post0079>();
-        public ICollection<Post0079> Posts02 { get; } = new List<Post0079>();
-        public ICollection<Post0079> Posts03 { get; } = new List<Post0079>();
+    public ICollection<Post0079> Posts00 { get; } = new List<Post0079>();
+    public ICollection<Post0079> Posts01 { get; } = new List<Post0079>();
+    public ICollection<Post0079> Posts02 { get; } = new List<Post0079>();
+    public ICollection<Post0079> Posts03 { get; } = new List<Post0079>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0080
-    {
-        public int Id { get; set; }
+public class Blog0080
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0080> Tags { get; set; }
+    public ICollection<Tag0080> Tags { get; set; }
 
-        public ICollection<Post0080> Posts00 { get; } = new List<Post0080>();
-        public ICollection<Post0080> Posts01 { get; } = new List<Post0080>();
-        public ICollection<Post0080> Posts02 { get; } = new List<Post0080>();
-        public ICollection<Post0080> Posts03 { get; } = new List<Post0080>();
+    public ICollection<Post0080> Posts00 { get; } = new List<Post0080>();
+    public ICollection<Post0080> Posts01 { get; } = new List<Post0080>();
+    public ICollection<Post0080> Posts02 { get; } = new List<Post0080>();
+    public ICollection<Post0080> Posts03 { get; } = new List<Post0080>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0081
-    {
-        public int Id { get; set; }
+public class Blog0081
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0081> Tags { get; set; }
+    public ICollection<Tag0081> Tags { get; set; }
 
-        public ICollection<Post0081> Posts00 { get; } = new List<Post0081>();
-        public ICollection<Post0081> Posts01 { get; } = new List<Post0081>();
-        public ICollection<Post0081> Posts02 { get; } = new List<Post0081>();
-        public ICollection<Post0081> Posts03 { get; } = new List<Post0081>();
+    public ICollection<Post0081> Posts00 { get; } = new List<Post0081>();
+    public ICollection<Post0081> Posts01 { get; } = new List<Post0081>();
+    public ICollection<Post0081> Posts02 { get; } = new List<Post0081>();
+    public ICollection<Post0081> Posts03 { get; } = new List<Post0081>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0082
-    {
-        public int Id { get; set; }
+public class Blog0082
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0082> Tags { get; set; }
+    public ICollection<Tag0082> Tags { get; set; }
 
-        public ICollection<Post0082> Posts00 { get; } = new List<Post0082>();
-        public ICollection<Post0082> Posts01 { get; } = new List<Post0082>();
-        public ICollection<Post0082> Posts02 { get; } = new List<Post0082>();
-        public ICollection<Post0082> Posts03 { get; } = new List<Post0082>();
+    public ICollection<Post0082> Posts00 { get; } = new List<Post0082>();
+    public ICollection<Post0082> Posts01 { get; } = new List<Post0082>();
+    public ICollection<Post0082> Posts02 { get; } = new List<Post0082>();
+    public ICollection<Post0082> Posts03 { get; } = new List<Post0082>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0083
-    {
-        public int Id { get; set; }
+public class Blog0083
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0083> Tags { get; set; }
+    public ICollection<Tag0083> Tags { get; set; }
 
-        public ICollection<Post0083> Posts00 { get; } = new List<Post0083>();
-        public ICollection<Post0083> Posts01 { get; } = new List<Post0083>();
-        public ICollection<Post0083> Posts02 { get; } = new List<Post0083>();
-        public ICollection<Post0083> Posts03 { get; } = new List<Post0083>();
+    public ICollection<Post0083> Posts00 { get; } = new List<Post0083>();
+    public ICollection<Post0083> Posts01 { get; } = new List<Post0083>();
+    public ICollection<Post0083> Posts02 { get; } = new List<Post0083>();
+    public ICollection<Post0083> Posts03 { get; } = new List<Post0083>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0084
-    {
-        public int Id { get; set; }
+public class Blog0084
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0084> Tags { get; set; }
+    public ICollection<Tag0084> Tags { get; set; }
 
-        public ICollection<Post0084> Posts00 { get; } = new List<Post0084>();
-        public ICollection<Post0084> Posts01 { get; } = new List<Post0084>();
-        public ICollection<Post0084> Posts02 { get; } = new List<Post0084>();
-        public ICollection<Post0084> Posts03 { get; } = new List<Post0084>();
+    public ICollection<Post0084> Posts00 { get; } = new List<Post0084>();
+    public ICollection<Post0084> Posts01 { get; } = new List<Post0084>();
+    public ICollection<Post0084> Posts02 { get; } = new List<Post0084>();
+    public ICollection<Post0084> Posts03 { get; } = new List<Post0084>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0085
-    {
-        public int Id { get; set; }
+public class Blog0085
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0085> Tags { get; set; }
+    public ICollection<Tag0085> Tags { get; set; }
 
-        public ICollection<Post0085> Posts00 { get; } = new List<Post0085>();
-        public ICollection<Post0085> Posts01 { get; } = new List<Post0085>();
-        public ICollection<Post0085> Posts02 { get; } = new List<Post0085>();
-        public ICollection<Post0085> Posts03 { get; } = new List<Post0085>();
+    public ICollection<Post0085> Posts00 { get; } = new List<Post0085>();
+    public ICollection<Post0085> Posts01 { get; } = new List<Post0085>();
+    public ICollection<Post0085> Posts02 { get; } = new List<Post0085>();
+    public ICollection<Post0085> Posts03 { get; } = new List<Post0085>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0086
-    {
-        public int Id { get; set; }
+public class Blog0086
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0086> Tags { get; set; }
+    public ICollection<Tag0086> Tags { get; set; }
 
-        public ICollection<Post0086> Posts00 { get; } = new List<Post0086>();
-        public ICollection<Post0086> Posts01 { get; } = new List<Post0086>();
-        public ICollection<Post0086> Posts02 { get; } = new List<Post0086>();
-        public ICollection<Post0086> Posts03 { get; } = new List<Post0086>();
+    public ICollection<Post0086> Posts00 { get; } = new List<Post0086>();
+    public ICollection<Post0086> Posts01 { get; } = new List<Post0086>();
+    public ICollection<Post0086> Posts02 { get; } = new List<Post0086>();
+    public ICollection<Post0086> Posts03 { get; } = new List<Post0086>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0087
-    {
-        public int Id { get; set; }
+public class Blog0087
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0087> Tags { get; set; }
+    public ICollection<Tag0087> Tags { get; set; }
 
-        public ICollection<Post0087> Posts00 { get; } = new List<Post0087>();
-        public ICollection<Post0087> Posts01 { get; } = new List<Post0087>();
-        public ICollection<Post0087> Posts02 { get; } = new List<Post0087>();
-        public ICollection<Post0087> Posts03 { get; } = new List<Post0087>();
+    public ICollection<Post0087> Posts00 { get; } = new List<Post0087>();
+    public ICollection<Post0087> Posts01 { get; } = new List<Post0087>();
+    public ICollection<Post0087> Posts02 { get; } = new List<Post0087>();
+    public ICollection<Post0087> Posts03 { get; } = new List<Post0087>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0088
-    {
-        public int Id { get; set; }
+public class Blog0088
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0088> Tags { get; set; }
+    public ICollection<Tag0088> Tags { get; set; }
 
-        public ICollection<Post0088> Posts00 { get; } = new List<Post0088>();
-        public ICollection<Post0088> Posts01 { get; } = new List<Post0088>();
-        public ICollection<Post0088> Posts02 { get; } = new List<Post0088>();
-        public ICollection<Post0088> Posts03 { get; } = new List<Post0088>();
+    public ICollection<Post0088> Posts00 { get; } = new List<Post0088>();
+    public ICollection<Post0088> Posts01 { get; } = new List<Post0088>();
+    public ICollection<Post0088> Posts02 { get; } = new List<Post0088>();
+    public ICollection<Post0088> Posts03 { get; } = new List<Post0088>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Blog0089
-    {
-        public int Id { get; set; }
+public class Blog0089
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0089> Tags { get; set; }
+    public ICollection<Tag0089> Tags { get; set; }
 
-        public ICollection<Post0089> Posts00 { get; } = new List<Post0089>();
-        public ICollection<Post0089> Posts01 { get; } = new List<Post0089>();
-        public ICollection<Post0089> Posts02 { get; } = new List<Post0089>();
-        public ICollection<Post0089> Posts03 { get; } = new List<Post0089>();
+    public ICollection<Post0089> Posts00 { get; } = new List<Post0089>();
+    public ICollection<Post0089> Posts01 { get; } = new List<Post0089>();
+    public ICollection<Post0089> Posts02 { get; } = new List<Post0089>();
+    public ICollection<Post0089> Posts03 { get; } = new List<Post0089>();
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
 }

--- a/samples/core/Miscellaneous/CompiledModels/BlogsContext.cs
+++ b/samples/core/Miscellaneous/CompiledModels/BlogsContext.cs
@@ -3,475 +3,474 @@ using System.IO;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-namespace CompiledModelTest
+namespace CompiledModelTest;
+
+public class BlogsContext : DbContext
 {
-    public class BlogsContext : DbContext
+
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            var currentDirectory = Environment.CurrentDirectory;
-            var location = currentDirectory.Substring(
-                0, currentDirectory.IndexOf("CompiledModels", StringComparison.Ordinal) + "CompiledModels".Length);
-
-            optionsBuilder
-                //.UseModel(MyCompiledModels.BlogsContextModel.Instance)
-                .EnableServiceProviderCaching(false)
-                .UseSqlite(@$"Data Source={Path.Combine(location, "compiled_model.db")}");
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog0000>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0000>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0000>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0000>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0001>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0001>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0001>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0001>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0002>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0002>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0002>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0002>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0003>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0003>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0003>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0003>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0004>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0004>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0004>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0004>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0005>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0005>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0005>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0005>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0006>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0006>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0006>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0006>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0007>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0007>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0007>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0007>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0008>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0008>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0008>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0008>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0009>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0009>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0009>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0009>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0010>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0010>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0010>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0010>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0011>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0011>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0011>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0011>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0012>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0012>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0012>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0012>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0013>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0013>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0013>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0013>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0014>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0014>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0014>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0014>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0015>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0015>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0015>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0015>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0016>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0016>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0016>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0016>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0017>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0017>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0017>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0017>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0018>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0018>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0018>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0018>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0019>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0019>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0019>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0019>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0020>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0020>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0020>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0020>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0021>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0021>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0021>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0021>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0022>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0022>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0022>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0022>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0023>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0023>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0023>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0023>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0024>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0024>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0024>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0024>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0025>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0025>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0025>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0025>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0026>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0026>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0026>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0026>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0027>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0027>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0027>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0027>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0028>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0028>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0028>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0028>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0029>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0029>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0029>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0029>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0030>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0030>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0030>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0030>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0031>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0031>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0031>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0031>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0032>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0032>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0032>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0032>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0033>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0033>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0033>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0033>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0034>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0034>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0034>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0034>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0035>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0035>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0035>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0035>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0036>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0036>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0036>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0036>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0037>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0037>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0037>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0037>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0038>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0038>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0038>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0038>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0039>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0039>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0039>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0039>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0040>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0040>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0040>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0040>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0041>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0041>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0041>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0041>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0042>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0042>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0042>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0042>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0043>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0043>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0043>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0043>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0044>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0044>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0044>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0044>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0045>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0045>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0045>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0045>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0046>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0046>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0046>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0046>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0047>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0047>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0047>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0047>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0048>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0048>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0048>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0048>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0049>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0049>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0049>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0049>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0050>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0050>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0050>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0050>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0051>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0051>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0051>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0051>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0052>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0052>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0052>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0052>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0053>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0053>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0053>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0053>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0054>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0054>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0054>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0054>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0055>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0055>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0055>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0055>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0056>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0056>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0056>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0056>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0057>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0057>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0057>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0057>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0058>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0058>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0058>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0058>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0059>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0059>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0059>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0059>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0060>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0060>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0060>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0060>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0061>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0061>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0061>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0061>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0062>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0062>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0062>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0062>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0063>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0063>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0063>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0063>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0064>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0064>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0064>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0064>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0065>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0065>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0065>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0065>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0066>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0066>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0066>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0066>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0067>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0067>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0067>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0067>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0068>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0068>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0068>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0068>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0069>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0069>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0069>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0069>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0070>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0070>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0070>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0070>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0071>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0071>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0071>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0071>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0072>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0072>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0072>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0072>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0073>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0073>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0073>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0073>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0074>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0074>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0074>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0074>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0075>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0075>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0075>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0075>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0076>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0076>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0076>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0076>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0077>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0077>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0077>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0077>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0078>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0078>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0078>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0078>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0079>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0079>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0079>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0079>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0080>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0080>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0080>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0080>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0081>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0081>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0081>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0081>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0082>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0082>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0082>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0082>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0083>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0083>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0083>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0083>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0084>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0084>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0084>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0084>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0085>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0085>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0085>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0085>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0086>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0086>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0086>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0086>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0087>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0087>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0087>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0087>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0088>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0088>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0088>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0088>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-
-            modelBuilder.Entity<Blog0089>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
-            modelBuilder.Entity<Blog0089>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
-            modelBuilder.Entity<Blog0089>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
-            modelBuilder.Entity<Blog0089>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
-        }
+        var currentDirectory = Environment.CurrentDirectory;
+        var location = currentDirectory.Substring(
+            0, currentDirectory.IndexOf("CompiledModels", StringComparison.Ordinal) + "CompiledModels".Length);
+
+        optionsBuilder
+            //.UseModel(MyCompiledModels.BlogsContextModel.Instance)
+            .EnableServiceProviderCaching(false)
+            .UseSqlite(@$"Data Source={Path.Combine(location, "compiled_model.db")}");
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Blog0000>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0000>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0000>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0000>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0001>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0001>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0001>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0001>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0002>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0002>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0002>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0002>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0003>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0003>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0003>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0003>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0004>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0004>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0004>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0004>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0005>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0005>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0005>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0005>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0006>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0006>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0006>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0006>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0007>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0007>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0007>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0007>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0008>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0008>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0008>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0008>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0009>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0009>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0009>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0009>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0010>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0010>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0010>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0010>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0011>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0011>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0011>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0011>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0012>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0012>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0012>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0012>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0013>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0013>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0013>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0013>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0014>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0014>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0014>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0014>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0015>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0015>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0015>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0015>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0016>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0016>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0016>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0016>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0017>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0017>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0017>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0017>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0018>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0018>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0018>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0018>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0019>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0019>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0019>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0019>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0020>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0020>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0020>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0020>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0021>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0021>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0021>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0021>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0022>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0022>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0022>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0022>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0023>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0023>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0023>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0023>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0024>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0024>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0024>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0024>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0025>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0025>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0025>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0025>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0026>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0026>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0026>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0026>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0027>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0027>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0027>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0027>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0028>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0028>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0028>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0028>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0029>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0029>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0029>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0029>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0030>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0030>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0030>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0030>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0031>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0031>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0031>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0031>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0032>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0032>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0032>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0032>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0033>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0033>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0033>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0033>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0034>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0034>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0034>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0034>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0035>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0035>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0035>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0035>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0036>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0036>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0036>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0036>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0037>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0037>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0037>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0037>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0038>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0038>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0038>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0038>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0039>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0039>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0039>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0039>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0040>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0040>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0040>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0040>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0041>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0041>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0041>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0041>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0042>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0042>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0042>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0042>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0043>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0043>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0043>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0043>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0044>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0044>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0044>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0044>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0045>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0045>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0045>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0045>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0046>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0046>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0046>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0046>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0047>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0047>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0047>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0047>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0048>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0048>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0048>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0048>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0049>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0049>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0049>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0049>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0050>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0050>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0050>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0050>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0051>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0051>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0051>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0051>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0052>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0052>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0052>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0052>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0053>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0053>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0053>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0053>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0054>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0054>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0054>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0054>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0055>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0055>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0055>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0055>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0056>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0056>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0056>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0056>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0057>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0057>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0057>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0057>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0058>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0058>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0058>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0058>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0059>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0059>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0059>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0059>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0060>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0060>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0060>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0060>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0061>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0061>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0061>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0061>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0062>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0062>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0062>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0062>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0063>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0063>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0063>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0063>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0064>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0064>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0064>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0064>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0065>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0065>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0065>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0065>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0066>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0066>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0066>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0066>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0067>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0067>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0067>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0067>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0068>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0068>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0068>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0068>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0069>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0069>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0069>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0069>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0070>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0070>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0070>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0070>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0071>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0071>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0071>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0071>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0072>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0072>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0072>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0072>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0073>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0073>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0073>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0073>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0074>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0074>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0074>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0074>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0075>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0075>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0075>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0075>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0076>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0076>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0076>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0076>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0077>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0077>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0077>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0077>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0078>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0078>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0078>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0078>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0079>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0079>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0079>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0079>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0080>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0080>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0080>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0080>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0081>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0081>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0081>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0081>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0082>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0082>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0082>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0082>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0083>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0083>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0083>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0083>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0084>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0084>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0084>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0084>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0085>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0085>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0085>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0085>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0086>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0086>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0086>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0086>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0087>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0087>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0087>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0087>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0088>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0088>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0088>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0088>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
+
+        modelBuilder.Entity<Blog0089>().HasMany(e => e.Posts00).WithOne(e => e.Blog00);
+        modelBuilder.Entity<Blog0089>().HasMany(e => e.Posts01).WithOne(e => e.Blog01);
+        modelBuilder.Entity<Blog0089>().HasMany(e => e.Posts02).WithOne(e => e.Blog02);
+        modelBuilder.Entity<Blog0089>().HasMany(e => e.Posts03).WithOne(e => e.Blog03);
     }
 }

--- a/samples/core/Miscellaneous/CompiledModels/MultipleRuntimeModels.cs
+++ b/samples/core/Miscellaneous/CompiledModels/MultipleRuntimeModels.cs
@@ -7,78 +7,77 @@ using Microsoft.EntityFrameworkCore.Metadata;
 #pragma warning disable 219, 612, 618
 #nullable disable
 
-namespace MultipleRuntimeModels
+namespace MultipleRuntimeModels;
+
+#region RuntimeModelCache
+public static class RuntimeModelCache
 {
-    #region RuntimeModelCache
-    public static class RuntimeModelCache
-    {
-        private static readonly ConcurrentDictionary<string, IModel> _runtimeModels
-            = new();
+    private static readonly ConcurrentDictionary<string, IModel> _runtimeModels
+        = new();
 
-        public static IModel GetOrCreateModel(string connectionString)
-            => _runtimeModels.GetOrAdd(
-                connectionString, cs =>
-                    {
-                        if (cs.Contains("X"))
-                        {
-                            return BlogsContextModel1.Instance;
-                        }
-
-                        if (cs.Contains("Y"))
-                        {
-                            return BlogsContextModel2.Instance;
-                        }
-
-                        throw new InvalidOperationException("No appropriate compiled model found.");
-                    });
-    }
-    #endregion
-
-    [DbContext(typeof(BlogsContext))]
-    partial class BlogsContextModel1 : RuntimeModel
-    {
-        private static BlogsContextModel1 _instance;
-        public static IModel Instance
-        {
-            get
+    public static IModel GetOrCreateModel(string connectionString)
+        => _runtimeModels.GetOrAdd(
+            connectionString, cs =>
             {
-                if (_instance == null)
+                if (cs.Contains("X"))
                 {
-                    _instance = new BlogsContextModel1();
-                    _instance.Initialize();
-                    _instance.Customize();
+                    return BlogsContextModel1.Instance;
                 }
 
-                return _instance;
+                if (cs.Contains("Y"))
+                {
+                    return BlogsContextModel2.Instance;
+                }
+
+                throw new InvalidOperationException("No appropriate compiled model found.");
+            });
+}
+#endregion
+
+[DbContext(typeof(BlogsContext))]
+partial class BlogsContextModel1 : RuntimeModel
+{
+    private static BlogsContextModel1 _instance;
+    public static IModel Instance
+    {
+        get
+        {
+            if (_instance == null)
+            {
+                _instance = new BlogsContextModel1();
+                _instance.Initialize();
+                _instance.Customize();
             }
+
+            return _instance;
         }
-
-        partial void Initialize();
-
-        partial void Customize();
     }
+
+    partial void Initialize();
+
+    partial void Customize();
+}
     
-    [DbContext(typeof(BlogsContext))]
-    partial class BlogsContextModel2 : RuntimeModel
+[DbContext(typeof(BlogsContext))]
+partial class BlogsContextModel2 : RuntimeModel
+{
+    private static BlogsContextModel2 _instance;
+    public static IModel Instance
     {
-        private static BlogsContextModel2 _instance;
-        public static IModel Instance
+        get
         {
-            get
+            if (_instance == null)
             {
-                if (_instance == null)
-                {
-                    _instance = new BlogsContextModel2();
-                    _instance.Initialize();
-                    _instance.Customize();
-                }
-
-                return _instance;
+                _instance = new BlogsContextModel2();
+                _instance.Initialize();
+                _instance.Customize();
             }
+
+            return _instance;
         }
-
-        partial void Initialize();
-
-        partial void Customize();
     }
+
+    partial void Initialize();
+
+    partial void Customize();
 }

--- a/samples/core/Miscellaneous/CompiledModels/Post000.cs
+++ b/samples/core/Miscellaneous/CompiledModels/Post000.cs
@@ -2,4685 +2,4684 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 
-namespace CompiledModelTest
+namespace CompiledModelTest;
+
+public class Post0000
 {
-    public class Post0000
-    {
-        public int Id { get; set; }
+    public int Id { get; set; }
         
-        public ICollection<Tag0000> Tags { get; set; }
+    public ICollection<Tag0000> Tags { get; set; }
 
-        public Blog0000 Blog00 { get; set; }
-        public Blog0000 Blog01 { get; set; }
-        public Blog0000 Blog02 { get; set; }
-        public Blog0000 Blog03 { get; set; }
+    public Blog0000 Blog00 { get; set; }
+    public Blog0000 Blog01 { get; set; }
+    public Blog0000 Blog02 { get; set; }
+    public Blog0000 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0001
-    {
-        public int Id { get; set; }
+public class Post0001
+{
+    public int Id { get; set; }
         
-        public ICollection<Tag0001> Tags { get; set; }
+    public ICollection<Tag0001> Tags { get; set; }
 
-        public Blog0001 Blog00 { get; set; }
-        public Blog0001 Blog01 { get; set; }
-        public Blog0001 Blog02 { get; set; }
-        public Blog0001 Blog03 { get; set; }
+    public Blog0001 Blog00 { get; set; }
+    public Blog0001 Blog01 { get; set; }
+    public Blog0001 Blog02 { get; set; }
+    public Blog0001 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0002
-    {
-        public int Id { get; set; }
+public class Post0002
+{
+    public int Id { get; set; }
         
-        public ICollection<Tag0002> Tags { get; set; }
+    public ICollection<Tag0002> Tags { get; set; }
 
-        public Blog0002 Blog00 { get; set; }
-        public Blog0002 Blog01 { get; set; }
-        public Blog0002 Blog02 { get; set; }
-        public Blog0002 Blog03 { get; set; }
+    public Blog0002 Blog00 { get; set; }
+    public Blog0002 Blog01 { get; set; }
+    public Blog0002 Blog02 { get; set; }
+    public Blog0002 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0003
-    {
-        public int Id { get; set; }
+public class Post0003
+{
+    public int Id { get; set; }
         
-        public ICollection<Tag0003> Tags { get; set; }
+    public ICollection<Tag0003> Tags { get; set; }
 
-        public Blog0003 Blog00 { get; set; }
-        public Blog0003 Blog01 { get; set; }
-        public Blog0003 Blog02 { get; set; }
-        public Blog0003 Blog03 { get; set; }
+    public Blog0003 Blog00 { get; set; }
+    public Blog0003 Blog01 { get; set; }
+    public Blog0003 Blog02 { get; set; }
+    public Blog0003 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0004
-    {
-        public int Id { get; set; }
+public class Post0004
+{
+    public int Id { get; set; }
         
-        public ICollection<Tag0004> Tags { get; set; }
+    public ICollection<Tag0004> Tags { get; set; }
 
-        public Blog0004 Blog00 { get; set; }
-        public Blog0004 Blog01 { get; set; }
-        public Blog0004 Blog02 { get; set; }
-        public Blog0004 Blog03 { get; set; }
+    public Blog0004 Blog00 { get; set; }
+    public Blog0004 Blog01 { get; set; }
+    public Blog0004 Blog02 { get; set; }
+    public Blog0004 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0005
-    {
-        public int Id { get; set; }
+public class Post0005
+{
+    public int Id { get; set; }
         
-        public ICollection<Tag0005> Tags { get; set; }
+    public ICollection<Tag0005> Tags { get; set; }
 
-        public Blog0005 Blog00 { get; set; }
-        public Blog0005 Blog01 { get; set; }
-        public Blog0005 Blog02 { get; set; }
-        public Blog0005 Blog03 { get; set; }
+    public Blog0005 Blog00 { get; set; }
+    public Blog0005 Blog01 { get; set; }
+    public Blog0005 Blog02 { get; set; }
+    public Blog0005 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0006
-    {
-        public int Id { get; set; }
+public class Post0006
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0006> Tags { get; set; }
+    public ICollection<Tag0006> Tags { get; set; }
         
-        public Blog0006 Blog00 { get; set; }
-        public Blog0006 Blog01 { get; set; }
-        public Blog0006 Blog02 { get; set; }
-        public Blog0006 Blog03 { get; set; }
+    public Blog0006 Blog00 { get; set; }
+    public Blog0006 Blog01 { get; set; }
+    public Blog0006 Blog02 { get; set; }
+    public Blog0006 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0007
-    {
-        public int Id { get; set; }
+public class Post0007
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0007> Tags { get; set; }
+    public ICollection<Tag0007> Tags { get; set; }
 
-        public Blog0007 Blog00 { get; set; }
-        public Blog0007 Blog01 { get; set; }
-        public Blog0007 Blog02 { get; set; }
-        public Blog0007 Blog03 { get; set; }
+    public Blog0007 Blog00 { get; set; }
+    public Blog0007 Blog01 { get; set; }
+    public Blog0007 Blog02 { get; set; }
+    public Blog0007 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0008
-    {
-        public int Id { get; set; }
+public class Post0008
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0008> Tags { get; set; }
+    public ICollection<Tag0008> Tags { get; set; }
 
-        public Blog0008 Blog00 { get; set; }
-        public Blog0008 Blog01 { get; set; }
-        public Blog0008 Blog02 { get; set; }
-        public Blog0008 Blog03 { get; set; }
+    public Blog0008 Blog00 { get; set; }
+    public Blog0008 Blog01 { get; set; }
+    public Blog0008 Blog02 { get; set; }
+    public Blog0008 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0009
-    {
-        public int Id { get; set; }
+public class Post0009
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0009> Tags { get; set; }
+    public ICollection<Tag0009> Tags { get; set; }
 
-        public Blog0009 Blog00 { get; set; }
-        public Blog0009 Blog01 { get; set; }
-        public Blog0009 Blog02 { get; set; }
-        public Blog0009 Blog03 { get; set; }
+    public Blog0009 Blog00 { get; set; }
+    public Blog0009 Blog01 { get; set; }
+    public Blog0009 Blog02 { get; set; }
+    public Blog0009 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0010
-    {
-        public int Id { get; set; }
+public class Post0010
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0010> Tags { get; set; }
+    public ICollection<Tag0010> Tags { get; set; }
 
-        public Blog0010 Blog00 { get; set; }
-        public Blog0010 Blog01 { get; set; }
-        public Blog0010 Blog02 { get; set; }
-        public Blog0010 Blog03 { get; set; }
+    public Blog0010 Blog00 { get; set; }
+    public Blog0010 Blog01 { get; set; }
+    public Blog0010 Blog02 { get; set; }
+    public Blog0010 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0011
-    {
-        public int Id { get; set; }
+public class Post0011
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0011> Tags { get; set; }
+    public ICollection<Tag0011> Tags { get; set; }
 
-        public Blog0011 Blog00 { get; set; }
-        public Blog0011 Blog01 { get; set; }
-        public Blog0011 Blog02 { get; set; }
-        public Blog0011 Blog03 { get; set; }
+    public Blog0011 Blog00 { get; set; }
+    public Blog0011 Blog01 { get; set; }
+    public Blog0011 Blog02 { get; set; }
+    public Blog0011 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0012
-    {
-        public int Id { get; set; }
+public class Post0012
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0012> Tags { get; set; }
+    public ICollection<Tag0012> Tags { get; set; }
 
-        public Blog0012 Blog00 { get; set; }
-        public Blog0012 Blog01 { get; set; }
-        public Blog0012 Blog02 { get; set; }
-        public Blog0012 Blog03 { get; set; }
+    public Blog0012 Blog00 { get; set; }
+    public Blog0012 Blog01 { get; set; }
+    public Blog0012 Blog02 { get; set; }
+    public Blog0012 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0013
-    {
-        public int Id { get; set; }
+public class Post0013
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0013> Tags { get; set; }
+    public ICollection<Tag0013> Tags { get; set; }
 
-        public Blog0013 Blog00 { get; set; }
-        public Blog0013 Blog01 { get; set; }
-        public Blog0013 Blog02 { get; set; }
-        public Blog0013 Blog03 { get; set; }
+    public Blog0013 Blog00 { get; set; }
+    public Blog0013 Blog01 { get; set; }
+    public Blog0013 Blog02 { get; set; }
+    public Blog0013 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0014
-    {
-        public int Id { get; set; }
+public class Post0014
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0014> Tags { get; set; }
+    public ICollection<Tag0014> Tags { get; set; }
 
-        public Blog0014 Blog00 { get; set; }
-        public Blog0014 Blog01 { get; set; }
-        public Blog0014 Blog02 { get; set; }
-        public Blog0014 Blog03 { get; set; }
+    public Blog0014 Blog00 { get; set; }
+    public Blog0014 Blog01 { get; set; }
+    public Blog0014 Blog02 { get; set; }
+    public Blog0014 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0015
-    {
-        public int Id { get; set; }
+public class Post0015
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0015> Tags { get; set; }
+    public ICollection<Tag0015> Tags { get; set; }
 
-        public Blog0015 Blog00 { get; set; }
-        public Blog0015 Blog01 { get; set; }
-        public Blog0015 Blog02 { get; set; }
-        public Blog0015 Blog03 { get; set; }
+    public Blog0015 Blog00 { get; set; }
+    public Blog0015 Blog01 { get; set; }
+    public Blog0015 Blog02 { get; set; }
+    public Blog0015 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0016
-    {
-        public int Id { get; set; }
+public class Post0016
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0016> Tags { get; set; }
+    public ICollection<Tag0016> Tags { get; set; }
 
-        public Blog0016 Blog00 { get; set; }
-        public Blog0016 Blog01 { get; set; }
-        public Blog0016 Blog02 { get; set; }
-        public Blog0016 Blog03 { get; set; }
+    public Blog0016 Blog00 { get; set; }
+    public Blog0016 Blog01 { get; set; }
+    public Blog0016 Blog02 { get; set; }
+    public Blog0016 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0017
-    {
-        public int Id { get; set; }
+public class Post0017
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0017> Tags { get; set; }
+    public ICollection<Tag0017> Tags { get; set; }
 
-        public Blog0017 Blog00 { get; set; }
-        public Blog0017 Blog01 { get; set; }
-        public Blog0017 Blog02 { get; set; }
-        public Blog0017 Blog03 { get; set; }
+    public Blog0017 Blog00 { get; set; }
+    public Blog0017 Blog01 { get; set; }
+    public Blog0017 Blog02 { get; set; }
+    public Blog0017 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0018
-    {
-        public int Id { get; set; }
+public class Post0018
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0018> Tags { get; set; }
+    public ICollection<Tag0018> Tags { get; set; }
 
-        public Blog0018 Blog00 { get; set; }
-        public Blog0018 Blog01 { get; set; }
-        public Blog0018 Blog02 { get; set; }
-        public Blog0018 Blog03 { get; set; }
+    public Blog0018 Blog00 { get; set; }
+    public Blog0018 Blog01 { get; set; }
+    public Blog0018 Blog02 { get; set; }
+    public Blog0018 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0019
-    {
-        public int Id { get; set; }
+public class Post0019
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0019> Tags { get; set; }
+    public ICollection<Tag0019> Tags { get; set; }
 
-        public Blog0019 Blog00 { get; set; }
-        public Blog0019 Blog01 { get; set; }
-        public Blog0019 Blog02 { get; set; }
-        public Blog0019 Blog03 { get; set; }
+    public Blog0019 Blog00 { get; set; }
+    public Blog0019 Blog01 { get; set; }
+    public Blog0019 Blog02 { get; set; }
+    public Blog0019 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0020
-    {
-        public int Id { get; set; }
+public class Post0020
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0020> Tags { get; set; }
+    public ICollection<Tag0020> Tags { get; set; }
 
-        public Blog0020 Blog00 { get; set; }
-        public Blog0020 Blog01 { get; set; }
-        public Blog0020 Blog02 { get; set; }
-        public Blog0020 Blog03 { get; set; }
+    public Blog0020 Blog00 { get; set; }
+    public Blog0020 Blog01 { get; set; }
+    public Blog0020 Blog02 { get; set; }
+    public Blog0020 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0021
-    {
-        public int Id { get; set; }
+public class Post0021
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0021> Tags { get; set; }
+    public ICollection<Tag0021> Tags { get; set; }
 
-        public Blog0021 Blog00 { get; set; }
-        public Blog0021 Blog01 { get; set; }
-        public Blog0021 Blog02 { get; set; }
-        public Blog0021 Blog03 { get; set; }
+    public Blog0021 Blog00 { get; set; }
+    public Blog0021 Blog01 { get; set; }
+    public Blog0021 Blog02 { get; set; }
+    public Blog0021 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0022
-    {
-        public int Id { get; set; }
+public class Post0022
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0022> Tags { get; set; }
+    public ICollection<Tag0022> Tags { get; set; }
 
-        public Blog0022 Blog00 { get; set; }
-        public Blog0022 Blog01 { get; set; }
-        public Blog0022 Blog02 { get; set; }
-        public Blog0022 Blog03 { get; set; }
+    public Blog0022 Blog00 { get; set; }
+    public Blog0022 Blog01 { get; set; }
+    public Blog0022 Blog02 { get; set; }
+    public Blog0022 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0023
-    {
-        public int Id { get; set; }
+public class Post0023
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0023> Tags { get; set; }
+    public ICollection<Tag0023> Tags { get; set; }
 
-        public Blog0023 Blog00 { get; set; }
-        public Blog0023 Blog01 { get; set; }
-        public Blog0023 Blog02 { get; set; }
-        public Blog0023 Blog03 { get; set; }
+    public Blog0023 Blog00 { get; set; }
+    public Blog0023 Blog01 { get; set; }
+    public Blog0023 Blog02 { get; set; }
+    public Blog0023 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0024
-    {
-        public int Id { get; set; }
+public class Post0024
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0024> Tags { get; set; }
+    public ICollection<Tag0024> Tags { get; set; }
 
-        public Blog0024 Blog00 { get; set; }
-        public Blog0024 Blog01 { get; set; }
-        public Blog0024 Blog02 { get; set; }
-        public Blog0024 Blog03 { get; set; }
+    public Blog0024 Blog00 { get; set; }
+    public Blog0024 Blog01 { get; set; }
+    public Blog0024 Blog02 { get; set; }
+    public Blog0024 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0025
-    {
-        public int Id { get; set; }
+public class Post0025
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0025> Tags { get; set; }
+    public ICollection<Tag0025> Tags { get; set; }
 
-        public Blog0025 Blog00 { get; set; }
-        public Blog0025 Blog01 { get; set; }
-        public Blog0025 Blog02 { get; set; }
-        public Blog0025 Blog03 { get; set; }
+    public Blog0025 Blog00 { get; set; }
+    public Blog0025 Blog01 { get; set; }
+    public Blog0025 Blog02 { get; set; }
+    public Blog0025 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0026
-    {
-        public int Id { get; set; }
+public class Post0026
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0026> Tags { get; set; }
+    public ICollection<Tag0026> Tags { get; set; }
 
-        public Blog0026 Blog00 { get; set; }
-        public Blog0026 Blog01 { get; set; }
-        public Blog0026 Blog02 { get; set; }
-        public Blog0026 Blog03 { get; set; }
+    public Blog0026 Blog00 { get; set; }
+    public Blog0026 Blog01 { get; set; }
+    public Blog0026 Blog02 { get; set; }
+    public Blog0026 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0027
-    {
-        public int Id { get; set; }
+public class Post0027
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0027> Tags { get; set; }
+    public ICollection<Tag0027> Tags { get; set; }
 
-        public Blog0027 Blog00 { get; set; }
-        public Blog0027 Blog01 { get; set; }
-        public Blog0027 Blog02 { get; set; }
-        public Blog0027 Blog03 { get; set; }
+    public Blog0027 Blog00 { get; set; }
+    public Blog0027 Blog01 { get; set; }
+    public Blog0027 Blog02 { get; set; }
+    public Blog0027 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0028
-    {
-        public int Id { get; set; }
+public class Post0028
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0028> Tags { get; set; }
+    public ICollection<Tag0028> Tags { get; set; }
 
-        public Blog0028 Blog00 { get; set; }
-        public Blog0028 Blog01 { get; set; }
-        public Blog0028 Blog02 { get; set; }
-        public Blog0028 Blog03 { get; set; }
+    public Blog0028 Blog00 { get; set; }
+    public Blog0028 Blog01 { get; set; }
+    public Blog0028 Blog02 { get; set; }
+    public Blog0028 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0029
-    {
-        public int Id { get; set; }
+public class Post0029
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0029> Tags { get; set; }
+    public ICollection<Tag0029> Tags { get; set; }
 
-        public Blog0029 Blog00 { get; set; }
-        public Blog0029 Blog01 { get; set; }
-        public Blog0029 Blog02 { get; set; }
-        public Blog0029 Blog03 { get; set; }
+    public Blog0029 Blog00 { get; set; }
+    public Blog0029 Blog01 { get; set; }
+    public Blog0029 Blog02 { get; set; }
+    public Blog0029 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0030
-    {
-        public int Id { get; set; }
+public class Post0030
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0030> Tags { get; set; }
+    public ICollection<Tag0030> Tags { get; set; }
 
-        public Blog0030 Blog00 { get; set; }
-        public Blog0030 Blog01 { get; set; }
-        public Blog0030 Blog02 { get; set; }
-        public Blog0030 Blog03 { get; set; }
+    public Blog0030 Blog00 { get; set; }
+    public Blog0030 Blog01 { get; set; }
+    public Blog0030 Blog02 { get; set; }
+    public Blog0030 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0031
-    {
-        public int Id { get; set; }
+public class Post0031
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0031> Tags { get; set; }
+    public ICollection<Tag0031> Tags { get; set; }
 
-        public Blog0031 Blog00 { get; set; }
-        public Blog0031 Blog01 { get; set; }
-        public Blog0031 Blog02 { get; set; }
-        public Blog0031 Blog03 { get; set; }
+    public Blog0031 Blog00 { get; set; }
+    public Blog0031 Blog01 { get; set; }
+    public Blog0031 Blog02 { get; set; }
+    public Blog0031 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0032
-    {
-        public int Id { get; set; }
+public class Post0032
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0032> Tags { get; set; }
+    public ICollection<Tag0032> Tags { get; set; }
 
-        public Blog0032 Blog00 { get; set; }
-        public Blog0032 Blog01 { get; set; }
-        public Blog0032 Blog02 { get; set; }
-        public Blog0032 Blog03 { get; set; }
+    public Blog0032 Blog00 { get; set; }
+    public Blog0032 Blog01 { get; set; }
+    public Blog0032 Blog02 { get; set; }
+    public Blog0032 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0033
-    {
-        public int Id { get; set; }
+public class Post0033
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0033> Tags { get; set; }
+    public ICollection<Tag0033> Tags { get; set; }
 
-        public Blog0033 Blog00 { get; set; }
-        public Blog0033 Blog01 { get; set; }
-        public Blog0033 Blog02 { get; set; }
-        public Blog0033 Blog03 { get; set; }
+    public Blog0033 Blog00 { get; set; }
+    public Blog0033 Blog01 { get; set; }
+    public Blog0033 Blog02 { get; set; }
+    public Blog0033 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0034
-    {
-        public int Id { get; set; }
+public class Post0034
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0034> Tags { get; set; }
+    public ICollection<Tag0034> Tags { get; set; }
 
-        public Blog0034 Blog00 { get; set; }
-        public Blog0034 Blog01 { get; set; }
-        public Blog0034 Blog02 { get; set; }
-        public Blog0034 Blog03 { get; set; }
+    public Blog0034 Blog00 { get; set; }
+    public Blog0034 Blog01 { get; set; }
+    public Blog0034 Blog02 { get; set; }
+    public Blog0034 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0035
-    {
-        public int Id { get; set; }
+public class Post0035
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0035> Tags { get; set; }
+    public ICollection<Tag0035> Tags { get; set; }
 
-        public Blog0035 Blog00 { get; set; }
-        public Blog0035 Blog01 { get; set; }
-        public Blog0035 Blog02 { get; set; }
-        public Blog0035 Blog03 { get; set; }
+    public Blog0035 Blog00 { get; set; }
+    public Blog0035 Blog01 { get; set; }
+    public Blog0035 Blog02 { get; set; }
+    public Blog0035 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0036
-    {
-        public int Id { get; set; }
+public class Post0036
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0036> Tags { get; set; }
+    public ICollection<Tag0036> Tags { get; set; }
 
-        public Blog0036 Blog00 { get; set; }
-        public Blog0036 Blog01 { get; set; }
-        public Blog0036 Blog02 { get; set; }
-        public Blog0036 Blog03 { get; set; }
+    public Blog0036 Blog00 { get; set; }
+    public Blog0036 Blog01 { get; set; }
+    public Blog0036 Blog02 { get; set; }
+    public Blog0036 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0037
-    {
-        public int Id { get; set; }
+public class Post0037
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0037> Tags { get; set; }
+    public ICollection<Tag0037> Tags { get; set; }
 
-        public Blog0037 Blog00 { get; set; }
-        public Blog0037 Blog01 { get; set; }
-        public Blog0037 Blog02 { get; set; }
-        public Blog0037 Blog03 { get; set; }
+    public Blog0037 Blog00 { get; set; }
+    public Blog0037 Blog01 { get; set; }
+    public Blog0037 Blog02 { get; set; }
+    public Blog0037 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0038
-    {
-        public int Id { get; set; }
+public class Post0038
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0038> Tags { get; set; }
+    public ICollection<Tag0038> Tags { get; set; }
 
-        public Blog0038 Blog00 { get; set; }
-        public Blog0038 Blog01 { get; set; }
-        public Blog0038 Blog02 { get; set; }
-        public Blog0038 Blog03 { get; set; }
+    public Blog0038 Blog00 { get; set; }
+    public Blog0038 Blog01 { get; set; }
+    public Blog0038 Blog02 { get; set; }
+    public Blog0038 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0039
-    {
-        public int Id { get; set; }
+public class Post0039
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0039> Tags { get; set; }
+    public ICollection<Tag0039> Tags { get; set; }
 
-        public Blog0039 Blog00 { get; set; }
-        public Blog0039 Blog01 { get; set; }
-        public Blog0039 Blog02 { get; set; }
-        public Blog0039 Blog03 { get; set; }
+    public Blog0039 Blog00 { get; set; }
+    public Blog0039 Blog01 { get; set; }
+    public Blog0039 Blog02 { get; set; }
+    public Blog0039 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0040
-    {
-        public int Id { get; set; }
+public class Post0040
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0040> Tags { get; set; }
+    public ICollection<Tag0040> Tags { get; set; }
 
-        public Blog0040 Blog00 { get; set; }
-        public Blog0040 Blog01 { get; set; }
-        public Blog0040 Blog02 { get; set; }
-        public Blog0040 Blog03 { get; set; }
+    public Blog0040 Blog00 { get; set; }
+    public Blog0040 Blog01 { get; set; }
+    public Blog0040 Blog02 { get; set; }
+    public Blog0040 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0041
-    {
-        public int Id { get; set; }
+public class Post0041
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0041> Tags { get; set; }
+    public ICollection<Tag0041> Tags { get; set; }
 
-        public Blog0041 Blog00 { get; set; }
-        public Blog0041 Blog01 { get; set; }
-        public Blog0041 Blog02 { get; set; }
-        public Blog0041 Blog03 { get; set; }
+    public Blog0041 Blog00 { get; set; }
+    public Blog0041 Blog01 { get; set; }
+    public Blog0041 Blog02 { get; set; }
+    public Blog0041 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0042
-    {
-        public int Id { get; set; }
+public class Post0042
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0042> Tags { get; set; }
+    public ICollection<Tag0042> Tags { get; set; }
 
-        public Blog0042 Blog00 { get; set; }
-        public Blog0042 Blog01 { get; set; }
-        public Blog0042 Blog02 { get; set; }
-        public Blog0042 Blog03 { get; set; }
+    public Blog0042 Blog00 { get; set; }
+    public Blog0042 Blog01 { get; set; }
+    public Blog0042 Blog02 { get; set; }
+    public Blog0042 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0043
-    {
-        public int Id { get; set; }
+public class Post0043
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0043> Tags { get; set; }
+    public ICollection<Tag0043> Tags { get; set; }
 
-        public Blog0043 Blog00 { get; set; }
-        public Blog0043 Blog01 { get; set; }
-        public Blog0043 Blog02 { get; set; }
-        public Blog0043 Blog03 { get; set; }
+    public Blog0043 Blog00 { get; set; }
+    public Blog0043 Blog01 { get; set; }
+    public Blog0043 Blog02 { get; set; }
+    public Blog0043 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0044
-    {
-        public int Id { get; set; }
+public class Post0044
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0044> Tags { get; set; }
+    public ICollection<Tag0044> Tags { get; set; }
 
-        public Blog0044 Blog00 { get; set; }
-        public Blog0044 Blog01 { get; set; }
-        public Blog0044 Blog02 { get; set; }
-        public Blog0044 Blog03 { get; set; }
+    public Blog0044 Blog00 { get; set; }
+    public Blog0044 Blog01 { get; set; }
+    public Blog0044 Blog02 { get; set; }
+    public Blog0044 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0045
-    {
-        public int Id { get; set; }
+public class Post0045
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0045> Tags { get; set; }
+    public ICollection<Tag0045> Tags { get; set; }
 
-        public Blog0045 Blog00 { get; set; }
-        public Blog0045 Blog01 { get; set; }
-        public Blog0045 Blog02 { get; set; }
-        public Blog0045 Blog03 { get; set; }
+    public Blog0045 Blog00 { get; set; }
+    public Blog0045 Blog01 { get; set; }
+    public Blog0045 Blog02 { get; set; }
+    public Blog0045 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0046
-    {
-        public int Id { get; set; }
+public class Post0046
+{
+    public int Id { get; set; }
 
-        public Blog0046 Blog00 { get; set; }
-        public Blog0046 Blog01 { get; set; }
-        public Blog0046 Blog02 { get; set; }
-        public Blog0046 Blog03 { get; set; }
+    public Blog0046 Blog00 { get; set; }
+    public Blog0046 Blog01 { get; set; }
+    public Blog0046 Blog02 { get; set; }
+    public Blog0046 Blog03 { get; set; }
 
-        public ICollection<Tag0046> Tags { get; set; }
+    public ICollection<Tag0046> Tags { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0047
-    {
-        public int Id { get; set; }
+public class Post0047
+{
+    public int Id { get; set; }
 
-        public Blog0047 Blog00 { get; set; }
-        public Blog0047 Blog01 { get; set; }
-        public Blog0047 Blog02 { get; set; }
-        public Blog0047 Blog03 { get; set; }
+    public Blog0047 Blog00 { get; set; }
+    public Blog0047 Blog01 { get; set; }
+    public Blog0047 Blog02 { get; set; }
+    public Blog0047 Blog03 { get; set; }
 
-        public ICollection<Tag0047> Tags { get; set; }
+    public ICollection<Tag0047> Tags { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0048
-    {
-        public int Id { get; set; }
+public class Post0048
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0048> Tags { get; set; }
+    public ICollection<Tag0048> Tags { get; set; }
 
-        public Blog0048 Blog00 { get; set; }
-        public Blog0048 Blog01 { get; set; }
-        public Blog0048 Blog02 { get; set; }
-        public Blog0048 Blog03 { get; set; }
+    public Blog0048 Blog00 { get; set; }
+    public Blog0048 Blog01 { get; set; }
+    public Blog0048 Blog02 { get; set; }
+    public Blog0048 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0049
-    {
-        public int Id { get; set; }
+public class Post0049
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0049> Tags { get; set; }
+    public ICollection<Tag0049> Tags { get; set; }
 
-        public Blog0049 Blog00 { get; set; }
-        public Blog0049 Blog01 { get; set; }
-        public Blog0049 Blog02 { get; set; }
-        public Blog0049 Blog03 { get; set; }
+    public Blog0049 Blog00 { get; set; }
+    public Blog0049 Blog01 { get; set; }
+    public Blog0049 Blog02 { get; set; }
+    public Blog0049 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0050
-    {
-        public int Id { get; set; }
+public class Post0050
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0050> Tags { get; set; }
+    public ICollection<Tag0050> Tags { get; set; }
 
-        public Blog0050 Blog00 { get; set; }
-        public Blog0050 Blog01 { get; set; }
-        public Blog0050 Blog02 { get; set; }
-        public Blog0050 Blog03 { get; set; }
+    public Blog0050 Blog00 { get; set; }
+    public Blog0050 Blog01 { get; set; }
+    public Blog0050 Blog02 { get; set; }
+    public Blog0050 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0051
-    {
-        public int Id { get; set; }
+public class Post0051
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0051> Tags { get; set; }
+    public ICollection<Tag0051> Tags { get; set; }
 
-        public Blog0051 Blog00 { get; set; }
-        public Blog0051 Blog01 { get; set; }
-        public Blog0051 Blog02 { get; set; }
-        public Blog0051 Blog03 { get; set; }
+    public Blog0051 Blog00 { get; set; }
+    public Blog0051 Blog01 { get; set; }
+    public Blog0051 Blog02 { get; set; }
+    public Blog0051 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0052
-    {
-        public int Id { get; set; }
+public class Post0052
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0052> Tags { get; set; }
+    public ICollection<Tag0052> Tags { get; set; }
 
-        public Blog0052 Blog00 { get; set; }
-        public Blog0052 Blog01 { get; set; }
-        public Blog0052 Blog02 { get; set; }
-        public Blog0052 Blog03 { get; set; }
+    public Blog0052 Blog00 { get; set; }
+    public Blog0052 Blog01 { get; set; }
+    public Blog0052 Blog02 { get; set; }
+    public Blog0052 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0053
-    {
-        public int Id { get; set; }
+public class Post0053
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0053> Tags { get; set; }
+    public ICollection<Tag0053> Tags { get; set; }
 
-        public Blog0053 Blog00 { get; set; }
-        public Blog0053 Blog01 { get; set; }
-        public Blog0053 Blog02 { get; set; }
-        public Blog0053 Blog03 { get; set; }
+    public Blog0053 Blog00 { get; set; }
+    public Blog0053 Blog01 { get; set; }
+    public Blog0053 Blog02 { get; set; }
+    public Blog0053 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0054
-    {
-        public int Id { get; set; }
+public class Post0054
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0054> Tags { get; set; }
+    public ICollection<Tag0054> Tags { get; set; }
 
-        public Blog0054 Blog00 { get; set; }
-        public Blog0054 Blog01 { get; set; }
-        public Blog0054 Blog02 { get; set; }
-        public Blog0054 Blog03 { get; set; }
+    public Blog0054 Blog00 { get; set; }
+    public Blog0054 Blog01 { get; set; }
+    public Blog0054 Blog02 { get; set; }
+    public Blog0054 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0055
-    {
-        public int Id { get; set; }
+public class Post0055
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0055> Tags { get; set; }
+    public ICollection<Tag0055> Tags { get; set; }
 
-        public Blog0055 Blog00 { get; set; }
-        public Blog0055 Blog01 { get; set; }
-        public Blog0055 Blog02 { get; set; }
-        public Blog0055 Blog03 { get; set; }
+    public Blog0055 Blog00 { get; set; }
+    public Blog0055 Blog01 { get; set; }
+    public Blog0055 Blog02 { get; set; }
+    public Blog0055 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0056
-    {
-        public int Id { get; set; }
+public class Post0056
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0056> Tags { get; set; }
+    public ICollection<Tag0056> Tags { get; set; }
 
-        public Blog0056 Blog00 { get; set; }
-        public Blog0056 Blog01 { get; set; }
-        public Blog0056 Blog02 { get; set; }
-        public Blog0056 Blog03 { get; set; }
+    public Blog0056 Blog00 { get; set; }
+    public Blog0056 Blog01 { get; set; }
+    public Blog0056 Blog02 { get; set; }
+    public Blog0056 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0057
-    {
-        public int Id { get; set; }
+public class Post0057
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0057> Tags { get; set; }
+    public ICollection<Tag0057> Tags { get; set; }
 
-        public Blog0057 Blog00 { get; set; }
-        public Blog0057 Blog01 { get; set; }
-        public Blog0057 Blog02 { get; set; }
-        public Blog0057 Blog03 { get; set; }
+    public Blog0057 Blog00 { get; set; }
+    public Blog0057 Blog01 { get; set; }
+    public Blog0057 Blog02 { get; set; }
+    public Blog0057 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0058
-    {
-        public int Id { get; set; }
+public class Post0058
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0058> Tags { get; set; }
+    public ICollection<Tag0058> Tags { get; set; }
 
-        public Blog0058 Blog00 { get; set; }
-        public Blog0058 Blog01 { get; set; }
-        public Blog0058 Blog02 { get; set; }
-        public Blog0058 Blog03 { get; set; }
+    public Blog0058 Blog00 { get; set; }
+    public Blog0058 Blog01 { get; set; }
+    public Blog0058 Blog02 { get; set; }
+    public Blog0058 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0059
-    {
-        public int Id { get; set; }
+public class Post0059
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0059> Tags { get; set; }
+    public ICollection<Tag0059> Tags { get; set; }
 
-        public Blog0059 Blog00 { get; set; }
-        public Blog0059 Blog01 { get; set; }
-        public Blog0059 Blog02 { get; set; }
-        public Blog0059 Blog03 { get; set; }
+    public Blog0059 Blog00 { get; set; }
+    public Blog0059 Blog01 { get; set; }
+    public Blog0059 Blog02 { get; set; }
+    public Blog0059 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0060
-    {
-        public int Id { get; set; }
+public class Post0060
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0060> Tags { get; set; }
+    public ICollection<Tag0060> Tags { get; set; }
 
-        public Blog0060 Blog00 { get; set; }
-        public Blog0060 Blog01 { get; set; }
-        public Blog0060 Blog02 { get; set; }
-        public Blog0060 Blog03 { get; set; }
+    public Blog0060 Blog00 { get; set; }
+    public Blog0060 Blog01 { get; set; }
+    public Blog0060 Blog02 { get; set; }
+    public Blog0060 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0061
-    {
-        public int Id { get; set; }
+public class Post0061
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0061> Tags { get; set; }
+    public ICollection<Tag0061> Tags { get; set; }
 
-        public Blog0061 Blog00 { get; set; }
-        public Blog0061 Blog01 { get; set; }
-        public Blog0061 Blog02 { get; set; }
-        public Blog0061 Blog03 { get; set; }
+    public Blog0061 Blog00 { get; set; }
+    public Blog0061 Blog01 { get; set; }
+    public Blog0061 Blog02 { get; set; }
+    public Blog0061 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0062
-    {
-        public int Id { get; set; }
+public class Post0062
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0062> Tags { get; set; }
+    public ICollection<Tag0062> Tags { get; set; }
 
-        public Blog0062 Blog00 { get; set; }
-        public Blog0062 Blog01 { get; set; }
-        public Blog0062 Blog02 { get; set; }
-        public Blog0062 Blog03 { get; set; }
+    public Blog0062 Blog00 { get; set; }
+    public Blog0062 Blog01 { get; set; }
+    public Blog0062 Blog02 { get; set; }
+    public Blog0062 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0063
-    {
-        public int Id { get; set; }
+public class Post0063
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0063> Tags { get; set; }
+    public ICollection<Tag0063> Tags { get; set; }
 
-        public Blog0063 Blog00 { get; set; }
-        public Blog0063 Blog01 { get; set; }
-        public Blog0063 Blog02 { get; set; }
-        public Blog0063 Blog03 { get; set; }
+    public Blog0063 Blog00 { get; set; }
+    public Blog0063 Blog01 { get; set; }
+    public Blog0063 Blog02 { get; set; }
+    public Blog0063 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0064
-    {
-        public int Id { get; set; }
+public class Post0064
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0064> Tags { get; set; }
+    public ICollection<Tag0064> Tags { get; set; }
 
-        public Blog0064 Blog00 { get; set; }
-        public Blog0064 Blog01 { get; set; }
-        public Blog0064 Blog02 { get; set; }
-        public Blog0064 Blog03 { get; set; }
+    public Blog0064 Blog00 { get; set; }
+    public Blog0064 Blog01 { get; set; }
+    public Blog0064 Blog02 { get; set; }
+    public Blog0064 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0065
-    {
-        public int Id { get; set; }
+public class Post0065
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0065> Tags { get; set; }
+    public ICollection<Tag0065> Tags { get; set; }
 
-        public Blog0065 Blog00 { get; set; }
-        public Blog0065 Blog01 { get; set; }
-        public Blog0065 Blog02 { get; set; }
-        public Blog0065 Blog03 { get; set; }
+    public Blog0065 Blog00 { get; set; }
+    public Blog0065 Blog01 { get; set; }
+    public Blog0065 Blog02 { get; set; }
+    public Blog0065 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0066
-    {
-        public int Id { get; set; }
+public class Post0066
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0066> Tags { get; set; }
+    public ICollection<Tag0066> Tags { get; set; }
 
-        public Blog0066 Blog00 { get; set; }
-        public Blog0066 Blog01 { get; set; }
-        public Blog0066 Blog02 { get; set; }
-        public Blog0066 Blog03 { get; set; }
+    public Blog0066 Blog00 { get; set; }
+    public Blog0066 Blog01 { get; set; }
+    public Blog0066 Blog02 { get; set; }
+    public Blog0066 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0067
-    {
-        public int Id { get; set; }
+public class Post0067
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0067> Tags { get; set; }
+    public ICollection<Tag0067> Tags { get; set; }
 
-        public Blog0067 Blog00 { get; set; }
-        public Blog0067 Blog01 { get; set; }
-        public Blog0067 Blog02 { get; set; }
-        public Blog0067 Blog03 { get; set; }
+    public Blog0067 Blog00 { get; set; }
+    public Blog0067 Blog01 { get; set; }
+    public Blog0067 Blog02 { get; set; }
+    public Blog0067 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0068
-    {
-        public int Id { get; set; }
+public class Post0068
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0068> Tags { get; set; }
+    public ICollection<Tag0068> Tags { get; set; }
 
-        public Blog0068 Blog00 { get; set; }
-        public Blog0068 Blog01 { get; set; }
-        public Blog0068 Blog02 { get; set; }
-        public Blog0068 Blog03 { get; set; }
+    public Blog0068 Blog00 { get; set; }
+    public Blog0068 Blog01 { get; set; }
+    public Blog0068 Blog02 { get; set; }
+    public Blog0068 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0069
-    {
-        public int Id { get; set; }
+public class Post0069
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0069> Tags { get; set; }
+    public ICollection<Tag0069> Tags { get; set; }
 
-        public Blog0069 Blog00 { get; set; }
-        public Blog0069 Blog01 { get; set; }
-        public Blog0069 Blog02 { get; set; }
-        public Blog0069 Blog03 { get; set; }
+    public Blog0069 Blog00 { get; set; }
+    public Blog0069 Blog01 { get; set; }
+    public Blog0069 Blog02 { get; set; }
+    public Blog0069 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0070
-    {
-        public int Id { get; set; }
+public class Post0070
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0070> Tags { get; set; }
+    public ICollection<Tag0070> Tags { get; set; }
 
-        public Blog0070 Blog00 { get; set; }
-        public Blog0070 Blog01 { get; set; }
-        public Blog0070 Blog02 { get; set; }
-        public Blog0070 Blog03 { get; set; }
+    public Blog0070 Blog00 { get; set; }
+    public Blog0070 Blog01 { get; set; }
+    public Blog0070 Blog02 { get; set; }
+    public Blog0070 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0071
-    {
-        public int Id { get; set; }
+public class Post0071
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0071> Tags { get; set; }
+    public ICollection<Tag0071> Tags { get; set; }
 
-        public Blog0071 Blog00 { get; set; }
-        public Blog0071 Blog01 { get; set; }
-        public Blog0071 Blog02 { get; set; }
-        public Blog0071 Blog03 { get; set; }
+    public Blog0071 Blog00 { get; set; }
+    public Blog0071 Blog01 { get; set; }
+    public Blog0071 Blog02 { get; set; }
+    public Blog0071 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0072
-    {
-        public int Id { get; set; }
+public class Post0072
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0072> Tags { get; set; }
+    public ICollection<Tag0072> Tags { get; set; }
 
-        public Blog0072 Blog00 { get; set; }
-        public Blog0072 Blog01 { get; set; }
-        public Blog0072 Blog02 { get; set; }
-        public Blog0072 Blog03 { get; set; }
+    public Blog0072 Blog00 { get; set; }
+    public Blog0072 Blog01 { get; set; }
+    public Blog0072 Blog02 { get; set; }
+    public Blog0072 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0073
-    {
-        public int Id { get; set; }
+public class Post0073
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0073> Tags { get; set; }
+    public ICollection<Tag0073> Tags { get; set; }
 
-        public Blog0073 Blog00 { get; set; }
-        public Blog0073 Blog01 { get; set; }
-        public Blog0073 Blog02 { get; set; }
-        public Blog0073 Blog03 { get; set; }
+    public Blog0073 Blog00 { get; set; }
+    public Blog0073 Blog01 { get; set; }
+    public Blog0073 Blog02 { get; set; }
+    public Blog0073 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0074
-    {
-        public int Id { get; set; }
+public class Post0074
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0074> Tags { get; set; }
+    public ICollection<Tag0074> Tags { get; set; }
 
-        public Blog0074 Blog00 { get; set; }
-        public Blog0074 Blog01 { get; set; }
-        public Blog0074 Blog02 { get; set; }
-        public Blog0074 Blog03 { get; set; }
+    public Blog0074 Blog00 { get; set; }
+    public Blog0074 Blog01 { get; set; }
+    public Blog0074 Blog02 { get; set; }
+    public Blog0074 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0075
-    {
-        public int Id { get; set; }
+public class Post0075
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0075> Tags { get; set; }
+    public ICollection<Tag0075> Tags { get; set; }
 
-        public Blog0075 Blog00 { get; set; }
-        public Blog0075 Blog01 { get; set; }
-        public Blog0075 Blog02 { get; set; }
-        public Blog0075 Blog03 { get; set; }
+    public Blog0075 Blog00 { get; set; }
+    public Blog0075 Blog01 { get; set; }
+    public Blog0075 Blog02 { get; set; }
+    public Blog0075 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0076
-    {
-        public int Id { get; set; }
+public class Post0076
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0076> Tags { get; set; }
+    public ICollection<Tag0076> Tags { get; set; }
 
-        public Blog0076 Blog00 { get; set; }
-        public Blog0076 Blog01 { get; set; }
-        public Blog0076 Blog02 { get; set; }
-        public Blog0076 Blog03 { get; set; }
+    public Blog0076 Blog00 { get; set; }
+    public Blog0076 Blog01 { get; set; }
+    public Blog0076 Blog02 { get; set; }
+    public Blog0076 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0077
-    {
-        public int Id { get; set; }
+public class Post0077
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0077> Tags { get; set; }
+    public ICollection<Tag0077> Tags { get; set; }
 
-        public Blog0077 Blog00 { get; set; }
-        public Blog0077 Blog01 { get; set; }
-        public Blog0077 Blog02 { get; set; }
-        public Blog0077 Blog03 { get; set; }
+    public Blog0077 Blog00 { get; set; }
+    public Blog0077 Blog01 { get; set; }
+    public Blog0077 Blog02 { get; set; }
+    public Blog0077 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0078
-    {
-        public int Id { get; set; }
+public class Post0078
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0078> Tags { get; set; }
+    public ICollection<Tag0078> Tags { get; set; }
 
-        public Blog0078 Blog00 { get; set; }
-        public Blog0078 Blog01 { get; set; }
-        public Blog0078 Blog02 { get; set; }
-        public Blog0078 Blog03 { get; set; }
+    public Blog0078 Blog00 { get; set; }
+    public Blog0078 Blog01 { get; set; }
+    public Blog0078 Blog02 { get; set; }
+    public Blog0078 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0079
-    {
-        public int Id { get; set; }
+public class Post0079
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0079> Tags { get; set; }
+    public ICollection<Tag0079> Tags { get; set; }
 
-        public Blog0079 Blog00 { get; set; }
-        public Blog0079 Blog01 { get; set; }
-        public Blog0079 Blog02 { get; set; }
-        public Blog0079 Blog03 { get; set; }
+    public Blog0079 Blog00 { get; set; }
+    public Blog0079 Blog01 { get; set; }
+    public Blog0079 Blog02 { get; set; }
+    public Blog0079 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0080
-    {
-        public int Id { get; set; }
+public class Post0080
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0080> Tags { get; set; }
+    public ICollection<Tag0080> Tags { get; set; }
 
-        public Blog0080 Blog00 { get; set; }
-        public Blog0080 Blog01 { get; set; }
-        public Blog0080 Blog02 { get; set; }
-        public Blog0080 Blog03 { get; set; }
+    public Blog0080 Blog00 { get; set; }
+    public Blog0080 Blog01 { get; set; }
+    public Blog0080 Blog02 { get; set; }
+    public Blog0080 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0081
-    {
-        public int Id { get; set; }
+public class Post0081
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0081> Tags { get; set; }
+    public ICollection<Tag0081> Tags { get; set; }
 
-        public Blog0081 Blog00 { get; set; }
-        public Blog0081 Blog01 { get; set; }
-        public Blog0081 Blog02 { get; set; }
-        public Blog0081 Blog03 { get; set; }
+    public Blog0081 Blog00 { get; set; }
+    public Blog0081 Blog01 { get; set; }
+    public Blog0081 Blog02 { get; set; }
+    public Blog0081 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0082
-    {
-        public int Id { get; set; }
+public class Post0082
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0082> Tags { get; set; }
+    public ICollection<Tag0082> Tags { get; set; }
 
-        public Blog0082 Blog00 { get; set; }
-        public Blog0082 Blog01 { get; set; }
-        public Blog0082 Blog02 { get; set; }
-        public Blog0082 Blog03 { get; set; }
+    public Blog0082 Blog00 { get; set; }
+    public Blog0082 Blog01 { get; set; }
+    public Blog0082 Blog02 { get; set; }
+    public Blog0082 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0083
-    {
-        public int Id { get; set; }
+public class Post0083
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0083> Tags { get; set; }
+    public ICollection<Tag0083> Tags { get; set; }
 
-        public Blog0083 Blog00 { get; set; }
-        public Blog0083 Blog01 { get; set; }
-        public Blog0083 Blog02 { get; set; }
-        public Blog0083 Blog03 { get; set; }
+    public Blog0083 Blog00 { get; set; }
+    public Blog0083 Blog01 { get; set; }
+    public Blog0083 Blog02 { get; set; }
+    public Blog0083 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0084
-    {
-        public int Id { get; set; }
+public class Post0084
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0084> Tags { get; set; }
+    public ICollection<Tag0084> Tags { get; set; }
 
-        public Blog0084 Blog00 { get; set; }
-        public Blog0084 Blog01 { get; set; }
-        public Blog0084 Blog02 { get; set; }
-        public Blog0084 Blog03 { get; set; }
+    public Blog0084 Blog00 { get; set; }
+    public Blog0084 Blog01 { get; set; }
+    public Blog0084 Blog02 { get; set; }
+    public Blog0084 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0085
-    {
-        public int Id { get; set; }
+public class Post0085
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0085> Tags { get; set; }
+    public ICollection<Tag0085> Tags { get; set; }
 
-        public Blog0085 Blog00 { get; set; }
-        public Blog0085 Blog01 { get; set; }
-        public Blog0085 Blog02 { get; set; }
-        public Blog0085 Blog03 { get; set; }
+    public Blog0085 Blog00 { get; set; }
+    public Blog0085 Blog01 { get; set; }
+    public Blog0085 Blog02 { get; set; }
+    public Blog0085 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0086
-    {
-        public int Id { get; set; }
+public class Post0086
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0086> Tags { get; set; }
+    public ICollection<Tag0086> Tags { get; set; }
 
-        public Blog0086 Blog00 { get; set; }
-        public Blog0086 Blog01 { get; set; }
-        public Blog0086 Blog02 { get; set; }
-        public Blog0086 Blog03 { get; set; }
+    public Blog0086 Blog00 { get; set; }
+    public Blog0086 Blog01 { get; set; }
+    public Blog0086 Blog02 { get; set; }
+    public Blog0086 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0087
-    {
-        public int Id { get; set; }
+public class Post0087
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0087> Tags { get; set; }
+    public ICollection<Tag0087> Tags { get; set; }
 
-        public Blog0087 Blog00 { get; set; }
-        public Blog0087 Blog01 { get; set; }
-        public Blog0087 Blog02 { get; set; }
-        public Blog0087 Blog03 { get; set; }
+    public Blog0087 Blog00 { get; set; }
+    public Blog0087 Blog01 { get; set; }
+    public Blog0087 Blog02 { get; set; }
+    public Blog0087 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0088
-    {
-        public int Id { get; set; }
+public class Post0088
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0088> Tags { get; set; }
+    public ICollection<Tag0088> Tags { get; set; }
 
-        public Blog0088 Blog00 { get; set; }
-        public Blog0088 Blog01 { get; set; }
-        public Blog0088 Blog02 { get; set; }
-        public Blog0088 Blog03 { get; set; }
+    public Blog0088 Blog00 { get; set; }
+    public Blog0088 Blog01 { get; set; }
+    public Blog0088 Blog02 { get; set; }
+    public Blog0088 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
 
-    public class Post0089
-    {
-        public int Id { get; set; }
+public class Post0089
+{
+    public int Id { get; set; }
 
-        public ICollection<Tag0089> Tags { get; set; }
+    public ICollection<Tag0089> Tags { get; set; }
 
-        public Blog0089 Blog00 { get; set; }
-        public Blog0089 Blog01 { get; set; }
-        public Blog0089 Blog02 { get; set; }
-        public Blog0089 Blog03 { get; set; }
+    public Blog0089 Blog00 { get; set; }
+    public Blog0089 Blog01 { get; set; }
+    public Blog0089 Blog02 { get; set; }
+    public Blog0089 Blog03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
 }

--- a/samples/core/Miscellaneous/CompiledModels/SingleRuntimeModel.cs
+++ b/samples/core/Miscellaneous/CompiledModels/SingleRuntimeModel.cs
@@ -5,31 +5,30 @@ using Microsoft.EntityFrameworkCore.Metadata;
 #pragma warning disable 219, 612, 618
 #nullable disable
 
-namespace SingleRuntimeModel
+namespace SingleRuntimeModel;
+
+#region RuntimeModel
+[DbContext(typeof(BlogsContext))]
+partial class BlogsContextModel : RuntimeModel
 {
-    #region RuntimeModel
-    [DbContext(typeof(BlogsContext))]
-    partial class BlogsContextModel : RuntimeModel
+    private static BlogsContextModel _instance;
+    public static IModel Instance
     {
-        private static BlogsContextModel _instance;
-        public static IModel Instance
+        get
         {
-            get
+            if (_instance == null)
             {
-                if (_instance == null)
-                {
-                    _instance = new BlogsContextModel();
-                    _instance.Initialize();
-                    _instance.Customize();
-                }
-
-                return _instance;
+                _instance = new BlogsContextModel();
+                _instance.Initialize();
+                _instance.Customize();
             }
+
+            return _instance;
         }
-
-        partial void Initialize();
-
-        partial void Customize();
     }
-    #endregion
+
+    partial void Initialize();
+
+    partial void Customize();
 }
+#endregion

--- a/samples/core/Miscellaneous/CompiledModels/Tag0000.cs
+++ b/samples/core/Miscellaneous/CompiledModels/Tag0000.cs
@@ -1,4326 +1,4324 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
-namespace CompiledModelTest
+namespace CompiledModelTest;
+
+public class Tag0000
 {
-    public class Tag0000
-    {
-        public int Id { get; set; }
+    public int Id { get; set; }
         
-        public ICollection<Post0000> Posts { get; set; }
-        public ICollection<Blog0000> Blogs { get; set; }
+    public ICollection<Post0000> Posts { get; set; }
+    public ICollection<Blog0000> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0001
-    {
-        public int Id { get; set; }
+public class Tag0001
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0001> Posts { get; set; }
-        public ICollection<Blog0001> Blogs { get; set; }
+    public ICollection<Post0001> Posts { get; set; }
+    public ICollection<Blog0001> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0002
-    {
-        public int Id { get; set; }
+public class Tag0002
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0002> Posts { get; set; }
-        public ICollection<Blog0002> Blogs { get; set; }
+    public ICollection<Post0002> Posts { get; set; }
+    public ICollection<Blog0002> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0003
-    {
-        public int Id { get; set; }
+public class Tag0003
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0003> Posts { get; set; }
-        public ICollection<Blog0003> Blogs { get; set; }
+    public ICollection<Post0003> Posts { get; set; }
+    public ICollection<Blog0003> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0004
-    {
-        public int Id { get; set; }
+public class Tag0004
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0004> Posts { get; set; }
-        public ICollection<Blog0004> Blogs { get; set; }
+    public ICollection<Post0004> Posts { get; set; }
+    public ICollection<Blog0004> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0005
-    {
-        public int Id { get; set; }
+public class Tag0005
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0005> Posts { get; set; }
-        public ICollection<Blog0005> Blogs { get; set; }
+    public ICollection<Post0005> Posts { get; set; }
+    public ICollection<Blog0005> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0006
-    {
-        public int Id { get; set; }
+public class Tag0006
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0006> Posts { get; set; }
-        public ICollection<Blog0006> Blogs { get; set; }
+    public ICollection<Post0006> Posts { get; set; }
+    public ICollection<Blog0006> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0007
-    {
-        public int Id { get; set; }
+public class Tag0007
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0007> Posts { get; set; }
-        public ICollection<Blog0007> Blogs { get; set; }
+    public ICollection<Post0007> Posts { get; set; }
+    public ICollection<Blog0007> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0008
-    {
-        public int Id { get; set; }
+public class Tag0008
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0008> Posts { get; set; }
-        public ICollection<Blog0008> Blogs { get; set; }
+    public ICollection<Post0008> Posts { get; set; }
+    public ICollection<Blog0008> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0009
-    {
-        public int Id { get; set; }
+public class Tag0009
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0009> Posts { get; set; }
-        public ICollection<Blog0009> Blogs { get; set; }
+    public ICollection<Post0009> Posts { get; set; }
+    public ICollection<Blog0009> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0010
-    {
-        public int Id { get; set; }
+public class Tag0010
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0010> Posts { get; set; }
-        public ICollection<Blog0010> Blogs { get; set; }
+    public ICollection<Post0010> Posts { get; set; }
+    public ICollection<Blog0010> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0011
-    {
-        public int Id { get; set; }
+public class Tag0011
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0011> Posts { get; set; }
-        public ICollection<Blog0011> Blogs { get; set; }
+    public ICollection<Post0011> Posts { get; set; }
+    public ICollection<Blog0011> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0012
-    {
-        public int Id { get; set; }
+public class Tag0012
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0012> Posts { get; set; }
-        public ICollection<Blog0012> Blogs { get; set; }
+    public ICollection<Post0012> Posts { get; set; }
+    public ICollection<Blog0012> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0013
-    {
-        public int Id { get; set; }
+public class Tag0013
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0013> Posts { get; set; }
-        public ICollection<Blog0013> Blogs { get; set; }
+    public ICollection<Post0013> Posts { get; set; }
+    public ICollection<Blog0013> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0014
-    {
-        public int Id { get; set; }
+public class Tag0014
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0014> Posts { get; set; }
-        public ICollection<Blog0014> Blogs { get; set; }
+    public ICollection<Post0014> Posts { get; set; }
+    public ICollection<Blog0014> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0015
-    {
-        public int Id { get; set; }
+public class Tag0015
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0015> Posts { get; set; }
-        public ICollection<Blog0015> Blogs { get; set; }
+    public ICollection<Post0015> Posts { get; set; }
+    public ICollection<Blog0015> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0016
-    {
-        public int Id { get; set; }
+public class Tag0016
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0016> Posts { get; set; }
-        public ICollection<Blog0016> Blogs { get; set; }
+    public ICollection<Post0016> Posts { get; set; }
+    public ICollection<Blog0016> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0017
-    {
-        public int Id { get; set; }
+public class Tag0017
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0017> Posts { get; set; }
-        public ICollection<Blog0017> Blogs { get; set; }
+    public ICollection<Post0017> Posts { get; set; }
+    public ICollection<Blog0017> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0018
-    {
-        public int Id { get; set; }
+public class Tag0018
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0018> Posts { get; set; }
-        public ICollection<Blog0018> Blogs { get; set; }
+    public ICollection<Post0018> Posts { get; set; }
+    public ICollection<Blog0018> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0019
-    {
-        public int Id { get; set; }
+public class Tag0019
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0019> Posts { get; set; }
-        public ICollection<Blog0019> Blogs { get; set; }
+    public ICollection<Post0019> Posts { get; set; }
+    public ICollection<Blog0019> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0020
-    {
-        public int Id { get; set; }
+public class Tag0020
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0020> Posts { get; set; }
-        public ICollection<Blog0020> Blogs { get; set; }
+    public ICollection<Post0020> Posts { get; set; }
+    public ICollection<Blog0020> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0021
-    {
-        public int Id { get; set; }
+public class Tag0021
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0021> Posts { get; set; }
-        public ICollection<Blog0021> Blogs { get; set; }
+    public ICollection<Post0021> Posts { get; set; }
+    public ICollection<Blog0021> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0022
-    {
-        public int Id { get; set; }
+public class Tag0022
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0022> Posts { get; set; }
-        public ICollection<Blog0022> Blogs { get; set; }
+    public ICollection<Post0022> Posts { get; set; }
+    public ICollection<Blog0022> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0023
-    {
-        public int Id { get; set; }
+public class Tag0023
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0023> Posts { get; set; }
-        public ICollection<Blog0023> Blogs { get; set; }
+    public ICollection<Post0023> Posts { get; set; }
+    public ICollection<Blog0023> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0024
-    {
-        public int Id { get; set; }
+public class Tag0024
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0024> Posts { get; set; }
-        public ICollection<Blog0024> Blogs { get; set; }
+    public ICollection<Post0024> Posts { get; set; }
+    public ICollection<Blog0024> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0025
-    {
-        public int Id { get; set; }
+public class Tag0025
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0025> Posts { get; set; }
-        public ICollection<Blog0025> Blogs { get; set; }
+    public ICollection<Post0025> Posts { get; set; }
+    public ICollection<Blog0025> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0026
-    {
-        public int Id { get; set; }
+public class Tag0026
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0026> Posts { get; set; }
-        public ICollection<Blog0026> Blogs { get; set; }
+    public ICollection<Post0026> Posts { get; set; }
+    public ICollection<Blog0026> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0027
-    {
-        public int Id { get; set; }
+public class Tag0027
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0027> Posts { get; set; }
-        public ICollection<Blog0027> Blogs { get; set; }
+    public ICollection<Post0027> Posts { get; set; }
+    public ICollection<Blog0027> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0028
-    {
-        public int Id { get; set; }
+public class Tag0028
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0028> Posts { get; set; }
-        public ICollection<Blog0028> Blogs { get; set; }
+    public ICollection<Post0028> Posts { get; set; }
+    public ICollection<Blog0028> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0029
-    {
-        public int Id { get; set; }
+public class Tag0029
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0029> Posts { get; set; }
-        public ICollection<Blog0029> Blogs { get; set; }
+    public ICollection<Post0029> Posts { get; set; }
+    public ICollection<Blog0029> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0030
-    {
-        public int Id { get; set; }
+public class Tag0030
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0030> Posts { get; set; }
-        public ICollection<Blog0030> Blogs { get; set; }
+    public ICollection<Post0030> Posts { get; set; }
+    public ICollection<Blog0030> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0031
-    {
-        public int Id { get; set; }
+public class Tag0031
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0031> Posts { get; set; }
-        public ICollection<Blog0031> Blogs { get; set; }
+    public ICollection<Post0031> Posts { get; set; }
+    public ICollection<Blog0031> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0032
-    {
-        public int Id { get; set; }
+public class Tag0032
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0032> Posts { get; set; }
-        public ICollection<Blog0032> Blogs { get; set; }
+    public ICollection<Post0032> Posts { get; set; }
+    public ICollection<Blog0032> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0033
-    {
-        public int Id { get; set; }
+public class Tag0033
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0033> Posts { get; set; }
-        public ICollection<Blog0033> Blogs { get; set; }
+    public ICollection<Post0033> Posts { get; set; }
+    public ICollection<Blog0033> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0034
-    {
-        public int Id { get; set; }
+public class Tag0034
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0034> Posts { get; set; }
-        public ICollection<Blog0034> Blogs { get; set; }
+    public ICollection<Post0034> Posts { get; set; }
+    public ICollection<Blog0034> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0035
-    {
-        public int Id { get; set; }
+public class Tag0035
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0035> Posts { get; set; }
-        public ICollection<Blog0035> Blogs { get; set; }
+    public ICollection<Post0035> Posts { get; set; }
+    public ICollection<Blog0035> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0036
-    {
-        public int Id { get; set; }
+public class Tag0036
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0036> Posts { get; set; }
-        public ICollection<Blog0036> Blogs { get; set; }
+    public ICollection<Post0036> Posts { get; set; }
+    public ICollection<Blog0036> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0037
-    {
-        public int Id { get; set; }
+public class Tag0037
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0037> Posts { get; set; }
-        public ICollection<Blog0037> Blogs { get; set; }
+    public ICollection<Post0037> Posts { get; set; }
+    public ICollection<Blog0037> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0038
-    {
-        public int Id { get; set; }
+public class Tag0038
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0038> Posts { get; set; }
-        public ICollection<Blog0038> Blogs { get; set; }
+    public ICollection<Post0038> Posts { get; set; }
+    public ICollection<Blog0038> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0039
-    {
-        public int Id { get; set; }
+public class Tag0039
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0039> Posts { get; set; }
-        public ICollection<Blog0039> Blogs { get; set; }
+    public ICollection<Post0039> Posts { get; set; }
+    public ICollection<Blog0039> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0040
-    {
-        public int Id { get; set; }
+public class Tag0040
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0040> Posts { get; set; }
-        public ICollection<Blog0040> Blogs { get; set; }
+    public ICollection<Post0040> Posts { get; set; }
+    public ICollection<Blog0040> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0041
-    {
-        public int Id { get; set; }
+public class Tag0041
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0041> Posts { get; set; }
-        public ICollection<Blog0041> Blogs { get; set; }
+    public ICollection<Post0041> Posts { get; set; }
+    public ICollection<Blog0041> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0042
-    {
-        public int Id { get; set; }
+public class Tag0042
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0042> Posts { get; set; }
-        public ICollection<Blog0042> Blogs { get; set; }
+    public ICollection<Post0042> Posts { get; set; }
+    public ICollection<Blog0042> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0043
-    {
-        public int Id { get; set; }
+public class Tag0043
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0043> Posts { get; set; }
-        public ICollection<Blog0043> Blogs { get; set; }
+    public ICollection<Post0043> Posts { get; set; }
+    public ICollection<Blog0043> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0044
-    {
-        public int Id { get; set; }
+public class Tag0044
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0044> Posts { get; set; }
-        public ICollection<Blog0044> Blogs { get; set; }
+    public ICollection<Post0044> Posts { get; set; }
+    public ICollection<Blog0044> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0045
-    {
-        public int Id { get; set; }
+public class Tag0045
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0045> Posts { get; set; }
-        public ICollection<Blog0045> Blogs { get; set; }
+    public ICollection<Post0045> Posts { get; set; }
+    public ICollection<Blog0045> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0046
-    {
-        public int Id { get; set; }
+public class Tag0046
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0046> Posts { get; set; }
-        public ICollection<Blog0046> Blogs { get; set; }
+    public ICollection<Post0046> Posts { get; set; }
+    public ICollection<Blog0046> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0047
-    {
-        public int Id { get; set; }
+public class Tag0047
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0047> Posts { get; set; }
-        public ICollection<Blog0047> Blogs { get; set; }
+    public ICollection<Post0047> Posts { get; set; }
+    public ICollection<Blog0047> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0048
-    {
-        public int Id { get; set; }
+public class Tag0048
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0048> Posts { get; set; }
-        public ICollection<Blog0048> Blogs { get; set; }
+    public ICollection<Post0048> Posts { get; set; }
+    public ICollection<Blog0048> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0049
-    {
-        public int Id { get; set; }
+public class Tag0049
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0049> Posts { get; set; }
-        public ICollection<Blog0039> Blogs { get; set; }
+    public ICollection<Post0049> Posts { get; set; }
+    public ICollection<Blog0039> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0050
-    {
-        public int Id { get; set; }
+public class Tag0050
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0050> Posts { get; set; }
-        public ICollection<Blog0050> Blogs { get; set; }
+    public ICollection<Post0050> Posts { get; set; }
+    public ICollection<Blog0050> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0051
-    {
-        public int Id { get; set; }
+public class Tag0051
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0051> Posts { get; set; }
-        public ICollection<Blog0051> Blogs { get; set; }
+    public ICollection<Post0051> Posts { get; set; }
+    public ICollection<Blog0051> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0052
-    {
-        public int Id { get; set; }
+public class Tag0052
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0052> Posts { get; set; }
-        public ICollection<Blog0052> Blogs { get; set; }
+    public ICollection<Post0052> Posts { get; set; }
+    public ICollection<Blog0052> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0053
-    {
-        public int Id { get; set; }
+public class Tag0053
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0053> Posts { get; set; }
-        public ICollection<Blog0053> Blogs { get; set; }
+    public ICollection<Post0053> Posts { get; set; }
+    public ICollection<Blog0053> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0054
-    {
-        public int Id { get; set; }
+public class Tag0054
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0054> Posts { get; set; }
-        public ICollection<Blog0054> Blogs { get; set; }
+    public ICollection<Post0054> Posts { get; set; }
+    public ICollection<Blog0054> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0055
-    {
-        public int Id { get; set; }
+public class Tag0055
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0055> Posts { get; set; }
-        public ICollection<Blog0055> Blogs { get; set; }
+    public ICollection<Post0055> Posts { get; set; }
+    public ICollection<Blog0055> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0056
-    {
-        public int Id { get; set; }
+public class Tag0056
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0056> Posts { get; set; }
-        public ICollection<Blog0056> Blogs { get; set; }
+    public ICollection<Post0056> Posts { get; set; }
+    public ICollection<Blog0056> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0057
-    {
-        public int Id { get; set; }
+public class Tag0057
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0057> Posts { get; set; }
-        public ICollection<Blog0057> Blogs { get; set; }
+    public ICollection<Post0057> Posts { get; set; }
+    public ICollection<Blog0057> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0058
-    {
-        public int Id { get; set; }
+public class Tag0058
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0058> Posts { get; set; }
-        public ICollection<Blog0058> Blogs { get; set; }
+    public ICollection<Post0058> Posts { get; set; }
+    public ICollection<Blog0058> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0059
-    {
-        public int Id { get; set; }
+public class Tag0059
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0059> Posts { get; set; }
-        public ICollection<Blog0059> Blogs { get; set; }
+    public ICollection<Post0059> Posts { get; set; }
+    public ICollection<Blog0059> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0060
-    {
-        public int Id { get; set; }
+public class Tag0060
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0060> Posts { get; set; }
-        public ICollection<Blog0060> Blogs { get; set; }
+    public ICollection<Post0060> Posts { get; set; }
+    public ICollection<Blog0060> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0061
-    {
-        public int Id { get; set; }
+public class Tag0061
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0061> Posts { get; set; }
-        public ICollection<Blog0061> Blogs { get; set; }
+    public ICollection<Post0061> Posts { get; set; }
+    public ICollection<Blog0061> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0062
-    {
-        public int Id { get; set; }
+public class Tag0062
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0062> Posts { get; set; }
-        public ICollection<Blog0062> Blogs { get; set; }
+    public ICollection<Post0062> Posts { get; set; }
+    public ICollection<Blog0062> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0063
-    {
-        public int Id { get; set; }
+public class Tag0063
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0063> Posts { get; set; }
-        public ICollection<Blog0063> Blogs { get; set; }
+    public ICollection<Post0063> Posts { get; set; }
+    public ICollection<Blog0063> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0064
-    {
-        public int Id { get; set; }
+public class Tag0064
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0064> Posts { get; set; }
-        public ICollection<Blog0064> Blogs { get; set; }
+    public ICollection<Post0064> Posts { get; set; }
+    public ICollection<Blog0064> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0065
-    {
-        public int Id { get; set; }
+public class Tag0065
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0065> Posts { get; set; }
-        public ICollection<Blog0065> Blogs { get; set; }
+    public ICollection<Post0065> Posts { get; set; }
+    public ICollection<Blog0065> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0066
-    {
-        public int Id { get; set; }
+public class Tag0066
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0066> Posts { get; set; }
-        public ICollection<Blog0066> Blogs { get; set; }
+    public ICollection<Post0066> Posts { get; set; }
+    public ICollection<Blog0066> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0067
-    {
-        public int Id { get; set; }
+public class Tag0067
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0067> Posts { get; set; }
-        public ICollection<Blog0067> Blogs { get; set; }
+    public ICollection<Post0067> Posts { get; set; }
+    public ICollection<Blog0067> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0068
-    {
-        public int Id { get; set; }
+public class Tag0068
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0068> Posts { get; set; }
-        public ICollection<Blog0068> Blogs { get; set; }
+    public ICollection<Post0068> Posts { get; set; }
+    public ICollection<Blog0068> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0069
-    {
-        public int Id { get; set; }
+public class Tag0069
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0069> Posts { get; set; }
-        public ICollection<Blog0069> Blogs { get; set; }
+    public ICollection<Post0069> Posts { get; set; }
+    public ICollection<Blog0069> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0070
-    {
-        public int Id { get; set; }
+public class Tag0070
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0070> Posts { get; set; }
-        public ICollection<Blog0070> Blogs { get; set; }
+    public ICollection<Post0070> Posts { get; set; }
+    public ICollection<Blog0070> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0071
-    {
-        public int Id { get; set; }
+public class Tag0071
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0071> Posts { get; set; }
-        public ICollection<Blog0071> Blogs { get; set; }
+    public ICollection<Post0071> Posts { get; set; }
+    public ICollection<Blog0071> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0072
-    {
-        public int Id { get; set; }
+public class Tag0072
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0072> Posts { get; set; }
-        public ICollection<Blog0072> Blogs { get; set; }
+    public ICollection<Post0072> Posts { get; set; }
+    public ICollection<Blog0072> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0073
-    {
-        public int Id { get; set; }
+public class Tag0073
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0073> Posts { get; set; }
-        public ICollection<Blog0073> Blogs { get; set; }
+    public ICollection<Post0073> Posts { get; set; }
+    public ICollection<Blog0073> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0074
-    {
-        public int Id { get; set; }
+public class Tag0074
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0074> Posts { get; set; }
-        public ICollection<Blog0074> Blogs { get; set; }
+    public ICollection<Post0074> Posts { get; set; }
+    public ICollection<Blog0074> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0075
-    {
-        public int Id { get; set; }
+public class Tag0075
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0075> Posts { get; set; }
-        public ICollection<Blog0075> Blogs { get; set; }
+    public ICollection<Post0075> Posts { get; set; }
+    public ICollection<Blog0075> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0076
-    {
-        public int Id { get; set; }
+public class Tag0076
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0076> Posts { get; set; }
-        public ICollection<Blog0076> Blogs { get; set; }
+    public ICollection<Post0076> Posts { get; set; }
+    public ICollection<Blog0076> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0077
-    {
-        public int Id { get; set; }
+public class Tag0077
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0077> Posts { get; set; }
-        public ICollection<Blog0077> Blogs { get; set; }
+    public ICollection<Post0077> Posts { get; set; }
+    public ICollection<Blog0077> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0078
-    {
-        public int Id { get; set; }
+public class Tag0078
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0078> Posts { get; set; }
-        public ICollection<Blog0078> Blogs { get; set; }
+    public ICollection<Post0078> Posts { get; set; }
+    public ICollection<Blog0078> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0079
-    {
-        public int Id { get; set; }
+public class Tag0079
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0079> Posts { get; set; }
-        public ICollection<Blog0079> Blogs { get; set; }
+    public ICollection<Post0079> Posts { get; set; }
+    public ICollection<Blog0079> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0080
-    {
-        public int Id { get; set; }
+public class Tag0080
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0080> Posts { get; set; }
-        public ICollection<Blog0080> Blogs { get; set; }
+    public ICollection<Post0080> Posts { get; set; }
+    public ICollection<Blog0080> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0081
-    {
-        public int Id { get; set; }
+public class Tag0081
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0081> Posts { get; set; }
-        public ICollection<Blog0081> Blogs { get; set; }
+    public ICollection<Post0081> Posts { get; set; }
+    public ICollection<Blog0081> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0082
-    {
-        public int Id { get; set; }
+public class Tag0082
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0082> Posts { get; set; }
-        public ICollection<Blog0082> Blogs { get; set; }
+    public ICollection<Post0082> Posts { get; set; }
+    public ICollection<Blog0082> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0083
-    {
-        public int Id { get; set; }
+public class Tag0083
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0083> Posts { get; set; }
-        public ICollection<Blog0083> Blogs { get; set; }
+    public ICollection<Post0083> Posts { get; set; }
+    public ICollection<Blog0083> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0084
-    {
-        public int Id { get; set; }
+public class Tag0084
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0084> Posts { get; set; }
-        public ICollection<Blog0084> Blogs { get; set; }
+    public ICollection<Post0084> Posts { get; set; }
+    public ICollection<Blog0084> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0085
-    {
-        public int Id { get; set; }
+public class Tag0085
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0085> Posts { get; set; }
-        public ICollection<Blog0085> Blogs { get; set; }
+    public ICollection<Post0085> Posts { get; set; }
+    public ICollection<Blog0085> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0086
-    {
-        public int Id { get; set; }
+public class Tag0086
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0086> Posts { get; set; }
-        public ICollection<Blog0086> Blogs { get; set; }
+    public ICollection<Post0086> Posts { get; set; }
+    public ICollection<Blog0086> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0087
-    {
-        public int Id { get; set; }
+public class Tag0087
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0087> Posts { get; set; }
-        public ICollection<Blog0087> Blogs { get; set; }
+    public ICollection<Post0087> Posts { get; set; }
+    public ICollection<Blog0087> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0088
-    {
-        public int Id { get; set; }
+public class Tag0088
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0088> Posts { get; set; }
-        public ICollection<Blog0088> Blogs { get; set; }
+    public ICollection<Post0088> Posts { get; set; }
+    public ICollection<Blog0088> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
+    [Required] [StringLength(64)] public string Property19 { get; set; }
+}
     
-    public class Tag0089
-    {
-        public int Id { get; set; }
+public class Tag0089
+{
+    public int Id { get; set; }
         
-        public ICollection<Post0089> Posts { get; set; }
-        public ICollection<Blog0089> Blogs { get; set; }
+    public ICollection<Post0089> Posts { get; set; }
+    public ICollection<Blog0089> Blogs { get; set; }
         
-        [Required] [StringLength(64)] public string Property00 { get; set; }
+    [Required] [StringLength(64)] public string Property00 { get; set; }
 
-        [Required] [StringLength(64)] public string Property01 { get; set; }
+    [Required] [StringLength(64)] public string Property01 { get; set; }
 
-        [Required] [StringLength(64)] public string Property02 { get; set; }
+    [Required] [StringLength(64)] public string Property02 { get; set; }
 
-        [Required] [StringLength(64)] public string Property03 { get; set; }
+    [Required] [StringLength(64)] public string Property03 { get; set; }
 
-        [Required] [StringLength(64)] public string Property04 { get; set; }
+    [Required] [StringLength(64)] public string Property04 { get; set; }
 
-        [Required] [StringLength(64)] public string Property05 { get; set; }
+    [Required] [StringLength(64)] public string Property05 { get; set; }
 
-        [Required] [StringLength(64)] public string Property06 { get; set; }
+    [Required] [StringLength(64)] public string Property06 { get; set; }
 
-        [Required] [StringLength(64)] public string Property07 { get; set; }
+    [Required] [StringLength(64)] public string Property07 { get; set; }
 
-        [Required] [StringLength(64)] public string Property08 { get; set; }
+    [Required] [StringLength(64)] public string Property08 { get; set; }
 
-        [Required] [StringLength(64)] public string Property09 { get; set; }
+    [Required] [StringLength(64)] public string Property09 { get; set; }
 
-        [Required] [StringLength(64)] public string Property10 { get; set; }
+    [Required] [StringLength(64)] public string Property10 { get; set; }
 
-        [Required] [StringLength(64)] public string Property11 { get; set; }
+    [Required] [StringLength(64)] public string Property11 { get; set; }
 
-        [Required] [StringLength(64)] public string Property12 { get; set; }
+    [Required] [StringLength(64)] public string Property12 { get; set; }
 
-        [Required] [StringLength(64)] public string Property13 { get; set; }
+    [Required] [StringLength(64)] public string Property13 { get; set; }
 
-        [Required] [StringLength(64)] public string Property14 { get; set; }
+    [Required] [StringLength(64)] public string Property14 { get; set; }
 
-        [Required] [StringLength(64)] public string Property15 { get; set; }
+    [Required] [StringLength(64)] public string Property15 { get; set; }
 
-        [Required] [StringLength(64)] public string Property16 { get; set; }
+    [Required] [StringLength(64)] public string Property16 { get; set; }
 
-        [Required] [StringLength(64)] public string Property17 { get; set; }
+    [Required] [StringLength(64)] public string Property17 { get; set; }
 
-        [Required] [StringLength(64)] public string Property18 { get; set; }
+    [Required] [StringLength(64)] public string Property18 { get; set; }
 
-        [Required] [StringLength(64)] public string Property19 { get; set; }
-    }
-    
+    [Required] [StringLength(64)] public string Property19 { get; set; }
 }

--- a/samples/core/Miscellaneous/ConfiguringDbContext/AdditionalConfiguration/ApplicationDbContext.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/AdditionalConfiguration/ApplicationDbContext.cs
@@ -1,16 +1,15 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace AdditionalConfiguration
+namespace AdditionalConfiguration;
+
+#region ApplicationDbContext
+public class ApplicationDbContext : DbContext
 {
-    #region ApplicationDbContext
-    public class ApplicationDbContext : DbContext
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .EnableSensitiveDataLogging()
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Test");
-        }
+        optionsBuilder
+            .EnableSensitiveDataLogging()
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Test");
     }
-    #endregion
 }
+#endregion

--- a/samples/core/Miscellaneous/ConfiguringDbContext/AdditionalProviderConfiguration/ApplicationDbContext.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/AdditionalProviderConfiguration/ApplicationDbContext.cs
@@ -1,17 +1,16 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace AdditionalProviderConfiguration
+namespace AdditionalProviderConfiguration;
+
+#region ApplicationDbContext
+public class ApplicationDbContext : DbContext
 {
-    #region ApplicationDbContext
-    public class ApplicationDbContext : DbContext
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=Test",
-                    providerOptions => { providerOptions.EnableRetryOnFailure(); });
-        }
+        optionsBuilder
+            .UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=Test",
+                providerOptions => { providerOptions.EnableRetryOnFailure(); });
     }
-    #endregion
 }
+#endregion

--- a/samples/core/Miscellaneous/ConfiguringDbContext/InheritDbContext/ApplicationDbContext.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/InheritDbContext/ApplicationDbContext.cs
@@ -1,57 +1,56 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace InheritDbContext
+namespace InheritDbContext;
+
+#region SealedApplicationDbContext
+public sealed class SealedApplicationDbContext : DbContext
 {
-    #region SealedApplicationDbContext
-    public sealed class SealedApplicationDbContext : DbContext
+    public SealedApplicationDbContext(DbContextOptions<SealedApplicationDbContext> contextOptions)
+        : base(contextOptions)
     {
-        public SealedApplicationDbContext(DbContextOptions<SealedApplicationDbContext> contextOptions)
-            : base(contextOptions)
-        {
-        }
     }
-    #endregion
-
-    #region ApplicationDbContextBase
-    public abstract class ApplicationDbContextBase : DbContext
-    {
-        protected ApplicationDbContextBase(DbContextOptions contextOptions)
-            : base(contextOptions)
-        {
-        }
-    }
-    #endregion
-
-    #region ApplicationDbContext12
-    public sealed class ApplicationDbContext1 : ApplicationDbContextBase
-    {
-        public ApplicationDbContext1(DbContextOptions<ApplicationDbContext1> contextOptions)
-            : base(contextOptions)
-        {
-        }
-    }
-
-    public sealed class ApplicationDbContext2 : ApplicationDbContextBase
-    {
-        public ApplicationDbContext2(DbContextOptions<ApplicationDbContext2> contextOptions)
-            : base(contextOptions)
-        {
-        }
-    }
-    #endregion
-
-    #region ApplicationDbContext
-    public class ApplicationDbContext : DbContext
-    {
-        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> contextOptions)
-            : base(contextOptions)
-        {
-        }
-
-        protected ApplicationDbContext(DbContextOptions contextOptions)
-            : base(contextOptions)
-        {
-        }
-    }
-    #endregion
 }
+#endregion
+
+#region ApplicationDbContextBase
+public abstract class ApplicationDbContextBase : DbContext
+{
+    protected ApplicationDbContextBase(DbContextOptions contextOptions)
+        : base(contextOptions)
+    {
+    }
+}
+#endregion
+
+#region ApplicationDbContext12
+public sealed class ApplicationDbContext1 : ApplicationDbContextBase
+{
+    public ApplicationDbContext1(DbContextOptions<ApplicationDbContext1> contextOptions)
+        : base(contextOptions)
+    {
+    }
+}
+
+public sealed class ApplicationDbContext2 : ApplicationDbContextBase
+{
+    public ApplicationDbContext2(DbContextOptions<ApplicationDbContext2> contextOptions)
+        : base(contextOptions)
+    {
+    }
+}
+#endregion
+
+#region ApplicationDbContext
+public class ApplicationDbContext : DbContext
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> contextOptions)
+        : base(contextOptions)
+    {
+    }
+
+    protected ApplicationDbContext(DbContextOptions contextOptions)
+        : base(contextOptions)
+    {
+    }
+}
+#endregion

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/ApplicationDbContext.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/ApplicationDbContext.cs
@@ -1,14 +1,13 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace WebApp
+namespace WebApp;
+
+#region ApplicationDbContext
+public class ApplicationDbContext : DbContext
 {
-    #region ApplicationDbContext
-    public class ApplicationDbContext : DbContext
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
     {
-        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
-            : base(options)
-        {
-        }
     }
-    #endregion
 }
+#endregion

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/Controllers/MyController.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/Controllers/MyController.cs
@@ -1,14 +1,13 @@
-﻿namespace WebApp.Controllers
-{
-    #region MyController
-    public class MyController
-    {
-        private readonly ApplicationDbContext _context;
+﻿namespace WebApp.Controllers;
 
-        public MyController(ApplicationDbContext context)
-        {
-            _context = context;
-        }
+#region MyController
+public class MyController
+{
+    private readonly ApplicationDbContext _context;
+
+    public MyController(ApplicationDbContext context)
+    {
+        _context = context;
     }
-    #endregion
 }
+#endregion

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/Startup.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/Startup.cs
@@ -5,43 +5,42 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace WebApp
+namespace WebApp;
+
+public class Startup
 {
-    public class Startup
+    public Startup(IConfiguration configuration)
     {
-        public Startup(IConfiguration configuration)
+        Configuration = configuration;
+    }
+
+    public IConfiguration Configuration { get; }
+
+    // This method gets called by the runtime. Use this method to add services to the container.
+    #region ConfigureServices
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddControllers();
+
+        services.AddDbContext<ApplicationDbContext>(
+            options => options.UseSqlServer("name=ConnectionStrings:DefaultConnection"));
+    }
+    #endregion
+
+    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        if (env.IsDevelopment())
         {
-            Configuration = configuration;
+            app.UseDeveloperExceptionPage();
         }
 
-        public IConfiguration Configuration { get; }
+        app.UseHttpsRedirection();
 
-        // This method gets called by the runtime. Use this method to add services to the container.
-        #region ConfigureServices
-        public void ConfigureServices(IServiceCollection services)
-        {
-            services.AddControllers();
+        app.UseRouting();
 
-            services.AddDbContext<ApplicationDbContext>(
-                options => options.UseSqlServer("name=ConnectionStrings:DefaultConnection"));
-        }
-        #endregion
+        app.UseAuthorization();
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-        {
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
-
-            app.UseHttpsRedirection();
-
-            app.UseRouting();
-
-            app.UseAuthorization();
-
-            app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
-        }
+        app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
     }
 }

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/UseNewForWebApp.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WebApp/UseNewForWebApp.cs
@@ -1,18 +1,17 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace WebApp
-{
-    public static class UseNewForWebApp
-    {
-        public static void Example()
-        {
-            #region UseNewForWebApp
-            var contextOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Test")
-                .Options;
+namespace WebApp;
 
-            using var context = new ApplicationDbContext(contextOptions);
-            #endregion
-        }
+public static class UseNewForWebApp
+{
+    public static void Example()
+    {
+        #region UseNewForWebApp
+        var contextOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Test")
+            .Options;
+
+        using var context = new ApplicationDbContext(contextOptions);
+        #endregion
     }
 }

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WithContextFactory/FactoryServicesExample.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WithContextFactory/FactoryServicesExample.cs
@@ -2,17 +2,16 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using WebApp;
 
-namespace WithContextFactory
+namespace WithContextFactory;
+
+public class FactoryServicesExample
 {
-    public class FactoryServicesExample
+    #region ConfigureServices
+    public void ConfigureServices(IServiceCollection services)
     {
-        #region ConfigureServices
-        public void ConfigureServices(IServiceCollection services)
-        {
-            services.AddDbContextFactory<ApplicationDbContext>(
-                options =>
-                    options.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Test"));
-        }
-        #endregion
+        services.AddDbContextFactory<ApplicationDbContext>(
+            options =>
+                options.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Test"));
     }
+    #endregion
 }

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WithContextFactory/MyController.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WithContextFactory/MyController.cs
@@ -1,27 +1,26 @@
 using Microsoft.EntityFrameworkCore;
 using WebApp;
 
-namespace WithContextFactory
+namespace WithContextFactory;
+
+public class MyController
 {
-    public class MyController
+    #region Construct
+    private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
+
+    public MyController(IDbContextFactory<ApplicationDbContext> contextFactory)
     {
-        #region Construct
-        private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
-
-        public MyController(IDbContextFactory<ApplicationDbContext> contextFactory)
-        {
-            _contextFactory = contextFactory;
-        }
-        #endregion
-
-        #region DoSomething
-        public void DoSomething()
-        {
-            using (var context = _contextFactory.CreateDbContext())
-            {
-                // ...
-            }
-        }
-        #endregion
+        _contextFactory = contextFactory;
     }
+    #endregion
+
+    #region DoSomething
+    public void DoSomething()
+    {
+        using (var context = _contextFactory.CreateDbContext())
+        {
+            // ...
+        }
+    }
+    #endregion
 }

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WithNew/ApplicationDbContext.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WithNew/ApplicationDbContext.cs
@@ -1,14 +1,13 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace WithNew
+namespace WithNew;
+
+#region ApplicationDbContext
+public class ApplicationDbContext : DbContext
 {
-    #region ApplicationDbContext
-    public class ApplicationDbContext : DbContext
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Test");
-        }
+        optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Test");
     }
-    #endregion
 }
+#endregion

--- a/samples/core/Miscellaneous/ConfiguringDbContext/WithNewAndArgs/ApplicationDbContext.cs
+++ b/samples/core/Miscellaneous/ConfiguringDbContext/WithNewAndArgs/ApplicationDbContext.cs
@@ -1,21 +1,20 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace WithNewAndArgs
+namespace WithNewAndArgs;
+
+#region ApplicationDbContext
+public class ApplicationDbContext : DbContext
 {
-    #region ApplicationDbContext
-    public class ApplicationDbContext : DbContext
+    private readonly string _connectionString;
+
+    public ApplicationDbContext(string connectionString)
     {
-        private readonly string _connectionString;
-
-        public ApplicationDbContext(string connectionString)
-        {
-            _connectionString = connectionString;
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(_connectionString);
-        }
+        _connectionString = connectionString;
     }
-    #endregion
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseSqlServer(_connectionString);
+    }
 }
+#endregion

--- a/samples/core/Miscellaneous/ConnectionResiliency/Program.cs
+++ b/samples/core/Miscellaneous/ConnectionResiliency/Program.cs
@@ -3,158 +3,157 @@ using System.Linq;
 using System.Transactions;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFConnectionResiliency
+namespace EFConnectionResiliency;
+
+public class Program
 {
-    public class Program
+    public static void Main(string[] args)
     {
-        public static void Main(string[] args)
+        using (var db = new BloggingContext())
         {
-            using (var db = new BloggingContext())
-            {
-                db.Database.EnsureDeleted();
-                db.Database.EnsureCreated();
-            }
-
-            ExecuteWithManualTransaction();
-
-            ExecuteWithManualAmbientTransaction();
-
-            ExecuteInTransactionWithVerification();
-
-            ExecuteInTransactionWithTracking();
+            db.Database.EnsureDeleted();
+            db.Database.EnsureCreated();
         }
 
-        private static void ExecuteWithManualTransaction()
-        {
-            #region ManualTransaction
-            using (var db = new BloggingContext())
-            {
-                var strategy = db.Database.CreateExecutionStrategy();
+        ExecuteWithManualTransaction();
 
-                strategy.Execute(
-                    () =>
-                    {
-                        using (var context = new BloggingContext())
-                        {
-                            using (var transaction = context.Database.BeginTransaction())
-                            {
-                                context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
-                                context.SaveChanges();
+        ExecuteWithManualAmbientTransaction();
 
-                                context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/visualstudio" });
-                                context.SaveChanges();
+        ExecuteInTransactionWithVerification();
 
-                                transaction.Commit();
-                            }
-                        }
-                    });
-            }
-            #endregion
-        }
-
-        private static void ExecuteWithManualAmbientTransaction()
-        {
-            #region AmbientTransaction
-            using (var context1 = new BloggingContext())
-            {
-                context1.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/visualstudio" });
-
-                var strategy = context1.Database.CreateExecutionStrategy();
-
-                strategy.Execute(
-                    () =>
-                    {
-                        using (var context2 = new BloggingContext())
-                        {
-                            using (var transaction = new TransactionScope())
-                            {
-                                context2.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
-                                context2.SaveChanges();
-
-                                context1.SaveChanges();
-
-                                transaction.Complete();
-                            }
-                        }
-                    });
-            }
-            #endregion
-        }
-
-        private static void ExecuteInTransactionWithVerification()
-        {
-            #region Verification
-            using (var db = new BloggingContext())
-            {
-                var strategy = db.Database.CreateExecutionStrategy();
-
-                var blogToAdd = new Blog { Url = "http://blogs.msdn.com/dotnet" };
-                db.Blogs.Add(blogToAdd);
-
-                strategy.ExecuteInTransaction(
-                    db,
-                    operation: context => { context.SaveChanges(acceptAllChangesOnSuccess: false); },
-                    verifySucceeded: context => context.Blogs.AsNoTracking().Any(b => b.BlogId == blogToAdd.BlogId));
-
-                db.ChangeTracker.AcceptAllChanges();
-            }
-            #endregion
-        }
-
-        private static void ExecuteInTransactionWithTracking()
-        {
-            #region Tracking
-            using (var db = new BloggingContext())
-            {
-                var strategy = db.Database.CreateExecutionStrategy();
-
-                db.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
-
-                var transaction = new TransactionRow { Id = Guid.NewGuid() };
-                db.Transactions.Add(transaction);
-
-                strategy.ExecuteInTransaction(
-                    db,
-                    operation: context => { context.SaveChanges(acceptAllChangesOnSuccess: false); },
-                    verifySucceeded: context => context.Transactions.AsNoTracking().Any(t => t.Id == transaction.Id));
-
-                db.ChangeTracker.AcceptAllChanges();
-                db.Transactions.Remove(transaction);
-                db.SaveChanges();
-            }
-            #endregion
-        }
+        ExecuteInTransactionWithTracking();
     }
 
-    public class BloggingContext : DbContext
+    private static void ExecuteWithManualTransaction()
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<TransactionRow> Transactions { get; set; }
-
-        #region OnConfiguring
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        #region ManualTransaction
+        using (var db = new BloggingContext())
         {
-            optionsBuilder
-                .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFMiscellanous.ConnectionResiliency;Trusted_Connection=True",
-                    options => options.EnableRetryOnFailure());
+            var strategy = db.Database.CreateExecutionStrategy();
+
+            strategy.Execute(
+                () =>
+                {
+                    using (var context = new BloggingContext())
+                    {
+                        using (var transaction = context.Database.BeginTransaction())
+                        {
+                            context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
+                            context.SaveChanges();
+
+                            context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/visualstudio" });
+                            context.SaveChanges();
+
+                            transaction.Commit();
+                        }
+                    }
+                });
         }
         #endregion
+    }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+    private static void ExecuteWithManualAmbientTransaction()
+    {
+        #region AmbientTransaction
+        using (var context1 = new BloggingContext())
         {
-            modelBuilder.Entity<Blog>().Property(b => b.BlogId).UseHiLo();
+            context1.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/visualstudio" });
+
+            var strategy = context1.Database.CreateExecutionStrategy();
+
+            strategy.Execute(
+                () =>
+                {
+                    using (var context2 = new BloggingContext())
+                    {
+                        using (var transaction = new TransactionScope())
+                        {
+                            context2.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
+                            context2.SaveChanges();
+
+                            context1.SaveChanges();
+
+                            transaction.Complete();
+                        }
+                    }
+                });
         }
+        #endregion
     }
 
-    public class Blog
+    private static void ExecuteInTransactionWithVerification()
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        #region Verification
+        using (var db = new BloggingContext())
+        {
+            var strategy = db.Database.CreateExecutionStrategy();
+
+            var blogToAdd = new Blog { Url = "http://blogs.msdn.com/dotnet" };
+            db.Blogs.Add(blogToAdd);
+
+            strategy.ExecuteInTransaction(
+                db,
+                operation: context => { context.SaveChanges(acceptAllChangesOnSuccess: false); },
+                verifySucceeded: context => context.Blogs.AsNoTracking().Any(b => b.BlogId == blogToAdd.BlogId));
+
+            db.ChangeTracker.AcceptAllChanges();
+        }
+        #endregion
     }
 
-    public class TransactionRow
+    private static void ExecuteInTransactionWithTracking()
     {
-        public Guid Id { get; set; }
+        #region Tracking
+        using (var db = new BloggingContext())
+        {
+            var strategy = db.Database.CreateExecutionStrategy();
+
+            db.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
+
+            var transaction = new TransactionRow { Id = Guid.NewGuid() };
+            db.Transactions.Add(transaction);
+
+            strategy.ExecuteInTransaction(
+                db,
+                operation: context => { context.SaveChanges(acceptAllChangesOnSuccess: false); },
+                verifySucceeded: context => context.Transactions.AsNoTracking().Any(t => t.Id == transaction.Id));
+
+            db.ChangeTracker.AcceptAllChanges();
+            db.Transactions.Remove(transaction);
+            db.SaveChanges();
+        }
+        #endregion
     }
+}
+
+public class BloggingContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<TransactionRow> Transactions { get; set; }
+
+    #region OnConfiguring
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=EFMiscellanous.ConnectionResiliency;Trusted_Connection=True",
+                options => options.EnableRetryOnFailure());
+    }
+    #endregion
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Blog>().Property(b => b.BlogId).UseHiLo();
+    }
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+}
+
+public class TransactionRow
+{
+    public Guid Id { get; set; }
 }

--- a/samples/core/Miscellaneous/Logging/Logging/Blog.cs
+++ b/samples/core/Miscellaneous/Logging/Logging/Blog.cs
@@ -1,8 +1,7 @@
-﻿namespace EFLogging
+﻿namespace EFLogging;
+
+public class Blog
 {
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-    }
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Miscellaneous/Logging/Logging/BloggingContext.cs
+++ b/samples/core/Miscellaneous/Logging/Logging/BloggingContext.cs
@@ -2,68 +2,67 @@
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 
-namespace EFLogging
+namespace EFLogging;
+
+public class BloggingContext : DbContext
 {
-    public class BloggingContext : DbContext
-    {
-        #region DefineLoggerFactory
-        public static readonly ILoggerFactory MyLoggerFactory
-            = LoggerFactory.Create(builder => { builder.AddConsole(); });
-        #endregion
+    #region DefineLoggerFactory
+    public static readonly ILoggerFactory MyLoggerFactory
+        = LoggerFactory.Create(builder => { builder.AddConsole(); });
+    #endregion
 
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region RegisterLoggerFactory
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder
-                .UseLoggerFactory(MyLoggerFactory)
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFLogging;Trusted_Connection=True");
-        #endregion
-    }
+    #region RegisterLoggerFactory
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder
+            .UseLoggerFactory(MyLoggerFactory)
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFLogging;Trusted_Connection=True");
+    #endregion
+}
 
-    public class EnableSensitiveDataLoggingContext : BloggingContext
-    {
-        #region EnableSensitiveDataLogging
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.EnableSensitiveDataLogging();
-        #endregion
-    }
+public class EnableSensitiveDataLoggingContext : BloggingContext
+{
+    #region EnableSensitiveDataLogging
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.EnableSensitiveDataLogging();
+    #endregion
+}
 
-    public class EnableDetailedErrorsContext : BloggingContext
-    {
-        #region EnableDetailedErrors
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.EnableDetailedErrors();
-        #endregion
-    }
+public class EnableDetailedErrorsContext : BloggingContext
+{
+    #region EnableDetailedErrors
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.EnableDetailedErrors();
+    #endregion
+}
 
-    public class ChangeLogLevelContext : BloggingContext
-    {
-        #region ChangeLogLevel
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder
-                .ConfigureWarnings(
-                    b => b.Log(
-                        (RelationalEventId.ConnectionOpened, LogLevel.Information),
-                        (RelationalEventId.ConnectionClosed, LogLevel.Information)));
-        #endregion
-    }
+public class ChangeLogLevelContext : BloggingContext
+{
+    #region ChangeLogLevel
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder
+            .ConfigureWarnings(
+                b => b.Log(
+                    (RelationalEventId.ConnectionOpened, LogLevel.Information),
+                    (RelationalEventId.ConnectionClosed, LogLevel.Information)));
+    #endregion
+}
 
-    public class SuppressMessageContext : BloggingContext
-    {
-        #region SuppressMessage
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder
-                .ConfigureWarnings(b => b.Ignore(CoreEventId.DetachedLazyLoadingWarning));
-        #endregion
-    }
+public class SuppressMessageContext : BloggingContext
+{
+    #region SuppressMessage
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder
+            .ConfigureWarnings(b => b.Ignore(CoreEventId.DetachedLazyLoadingWarning));
+    #endregion
+}
 
-    public class ThrowForEventContext : BloggingContext
-    {
-        #region ThrowForEvent
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder
-                .ConfigureWarnings(b => b.Throw(RelationalEventId.QueryPossibleUnintendedUseOfEqualsWarning));
-        #endregion
-    }
+public class ThrowForEventContext : BloggingContext
+{
+    #region ThrowForEvent
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder
+            .ConfigureWarnings(b => b.Throw(RelationalEventId.QueryPossibleUnintendedUseOfEqualsWarning));
+    #endregion
 }

--- a/samples/core/Miscellaneous/Logging/Logging/BloggingContextWithFiltering.cs
+++ b/samples/core/Miscellaneous/Logging/Logging/BloggingContextWithFiltering.cs
@@ -1,32 +1,31 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace EFLogging
+namespace EFLogging;
+
+public class BloggingContextWithFiltering : DbContext
 {
-    public class BloggingContextWithFiltering : DbContext
-    {
-        #region DefineLoggerFactory
-        public static readonly ILoggerFactory MyLoggerFactory
-            = LoggerFactory.Create(
-                builder =>
-                {
-                    builder
-                        .AddFilter(
-                            (category, level) =>
-                                category == DbLoggerCategory.Database.Command.Name
-                                && level == LogLevel.Information)
-                        .AddConsole();
-                });
-        #endregion
+    #region DefineLoggerFactory
+    public static readonly ILoggerFactory MyLoggerFactory
+        = LoggerFactory.Create(
+            builder =>
+            {
+                builder
+                    .AddFilter(
+                        (category, level) =>
+                            category == DbLoggerCategory.Database.Command.Name
+                            && level == LogLevel.Information)
+                    .AddConsole();
+            });
+    #endregion
 
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region RegisterLoggerFactory
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder
-                .UseLoggerFactory(MyLoggerFactory) // Warning: Do not create a new ILoggerFactory instance each time
-                .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFLogging;Trusted_Connection=True");
-        #endregion
-    }
+    #region RegisterLoggerFactory
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder
+            .UseLoggerFactory(MyLoggerFactory) // Warning: Do not create a new ILoggerFactory instance each time
+            .UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=EFLogging;Trusted_Connection=True");
+    #endregion
 }

--- a/samples/core/Miscellaneous/Logging/Logging/Program.cs
+++ b/samples/core/Miscellaneous/Logging/Logging/Program.cs
@@ -1,39 +1,38 @@
 ﻿using System;
 
-namespace EFLogging
+namespace EFLogging;
+
+public class Program
 {
-    public class Program
+    public static void Main()
     {
-        public static void Main()
+        using (var db = new BloggingContext())
         {
-            using (var db = new BloggingContext())
-            {
-                db.Database.EnsureCreated();
-                db.Blogs.Add(new Blog { Url = "http://sample.com" });
-                db.SaveChanges();
-            }
+            db.Database.EnsureCreated();
+            db.Blogs.Add(new Blog { Url = "http://sample.com" });
+            db.SaveChanges();
+        }
 
-            using (var db = new BloggingContext())
+        using (var db = new BloggingContext())
+        {
+            foreach (var blog in db.Blogs)
             {
-                foreach (var blog in db.Blogs)
-                {
-                    Console.WriteLine(blog.Url);
-                }
+                Console.WriteLine(blog.Url);
             }
+        }
 
-            using (var db = new BloggingContextWithFiltering())
-            {
-                db.Database.EnsureCreated();
-                db.Blogs.Add(new Blog { Url = "http://sample.com" });
-                db.SaveChanges();
-            }
+        using (var db = new BloggingContextWithFiltering())
+        {
+            db.Database.EnsureCreated();
+            db.Blogs.Add(new Blog { Url = "http://sample.com" });
+            db.SaveChanges();
+        }
 
-            using (var db = new BloggingContextWithFiltering())
+        using (var db = new BloggingContextWithFiltering())
+        {
+            foreach (var blog in db.Blogs)
             {
-                foreach (var blog in db.Blogs)
-                {
-                    Console.WriteLine(blog.Url);
-                }
+                Console.WriteLine(blog.Url);
             }
         }
     }

--- a/samples/core/Modeling/BackingFields/BackingField.cs
+++ b/samples/core/Modeling/BackingFields/BackingField.cs
@@ -1,24 +1,23 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.BackingFields.BackingField
+namespace EFModeling.BackingFields.BackingField;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
-
-    #region Sample
-    public class Blog
-    {
-        private string _url;
-
-        public int BlogId { get; set; }
-
-        public string Url
-        {
-            get { return _url; }
-            set { _url = value; }
-        }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region Sample
+public class Blog
+{
+    private string _url;
+
+    public int BlogId { get; set; }
+
+    public string Url
+    {
+        get { return _url; }
+        set { _url = value; }
+    }
+}
+#endregion

--- a/samples/core/Modeling/BackingFields/DataAnnotations/BackingField.cs
+++ b/samples/core/Modeling/BackingFields/DataAnnotations/BackingField.cs
@@ -1,31 +1,30 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.BackingFields.DataAnnotations.BackingField
+namespace EFModeling.BackingFields.DataAnnotations.BackingField;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
-
-    #region BackingField
-    public class Blog
-    {
-        private string _validatedUrl;
-
-        public int BlogId { get; set; }
-
-        [BackingField(nameof(_validatedUrl))]
-        public string Url
-        {
-            get { return _validatedUrl; }
-        }
-
-        public void SetUrl(string url)
-        {
-            // put your validation code here
-
-            _validatedUrl = url;
-        }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region BackingField
+public class Blog
+{
+    private string _validatedUrl;
+
+    public int BlogId { get; set; }
+
+    [BackingField(nameof(_validatedUrl))]
+    public string Url
+    {
+        get { return _validatedUrl; }
+    }
+
+    public void SetUrl(string url)
+    {
+        // put your validation code here
+
+        _validatedUrl = url;
+    }
+}
+#endregion

--- a/samples/core/Modeling/BackingFields/FluentAPI/BackingField.cs
+++ b/samples/core/Modeling/BackingFields/FluentAPI/BackingField.cs
@@ -1,37 +1,36 @@
 ﻿using System.Net.Http;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.BackingFields.FluentAPI.BackingField
+namespace EFModeling.BackingFields.FluentAPI.BackingField;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region BackingField
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property(b => b.Url)
-                .HasField("_validatedUrl");
-        }
-        #endregion
+    #region BackingField
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Blog>()
+            .Property(b => b.Url)
+            .HasField("_validatedUrl");
     }
+    #endregion
+}
 
-    public class Blog
+public class Blog
+{
+    public int BlogId { get; set; }
+
+    public string Url { get; private set; }
+
+    public void SetUrl(string url)
     {
-        public int BlogId { get; set; }
-
-        public string Url { get; private set; }
-
-        public void SetUrl(string url)
+        using (var client = new HttpClient())
         {
-            using (var client = new HttpClient())
-            {
-                var response = client.GetAsync(url).Result;
-                response.EnsureSuccessStatusCode();
-            }
-
-            Url = url;
+            var response = client.GetAsync(url).Result;
+            response.EnsureSuccessStatusCode();
         }
+
+        Url = url;
     }
 }

--- a/samples/core/Modeling/BackingFields/FluentAPI/BackingFieldAccessMode.cs
+++ b/samples/core/Modeling/BackingFields/FluentAPI/BackingFieldAccessMode.cs
@@ -1,38 +1,37 @@
 ﻿using System.Net.Http;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.BackingFields.FluentAPI.BackingFieldAccessMode
+namespace EFModeling.BackingFields.FluentAPI.BackingFieldAccessMode;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region BackingFieldAccessMode
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property(b => b.Url)
-                .HasField("_validatedUrl")
-                .UsePropertyAccessMode(PropertyAccessMode.PreferFieldDuringConstruction);
-        }
-        #endregion
+    #region BackingFieldAccessMode
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Blog>()
+            .Property(b => b.Url)
+            .HasField("_validatedUrl")
+            .UsePropertyAccessMode(PropertyAccessMode.PreferFieldDuringConstruction);
     }
+    #endregion
+}
 
-    public class Blog
+public class Blog
+{
+    public int BlogId { get; set; }
+
+    public string Url { get; private set; }
+
+    public void SetUrl(string url)
     {
-        public int BlogId { get; set; }
-
-        public string Url { get; private set; }
-
-        public void SetUrl(string url)
+        using (var client = new HttpClient())
         {
-            using (var client = new HttpClient())
-            {
-                var response = client.GetAsync(url).Result;
-                response.EnsureSuccessStatusCode();
-            }
-
-            Url = url;
+            var response = client.GetAsync(url).Result;
+            response.EnsureSuccessStatusCode();
         }
+
+        Url = url;
     }
 }

--- a/samples/core/Modeling/BackingFields/FluentAPI/BackingFieldNoProperty.cs
+++ b/samples/core/Modeling/BackingFields/FluentAPI/BackingFieldNoProperty.cs
@@ -1,41 +1,40 @@
 ﻿using System.Net.Http;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.BackingFields.FluentAPI.BackingFieldNoProperty
+namespace EFModeling.BackingFields.FluentAPI.BackingFieldNoProperty;
+
+#region Sample
+internal class MyContext : DbContext
 {
-    #region Sample
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property("_validatedUrl");
-        }
+        modelBuilder.Entity<Blog>()
+            .Property("_validatedUrl");
     }
-
-    public class Blog
-    {
-        private string _validatedUrl;
-
-        public int BlogId { get; set; }
-
-        public string GetUrl()
-        {
-            return _validatedUrl;
-        }
-
-        public void SetUrl(string url)
-        {
-            using (var client = new HttpClient())
-            {
-                var response = client.GetAsync(url).Result;
-                response.EnsureSuccessStatusCode();
-            }
-
-            _validatedUrl = url;
-        }
-    }
-    #endregion
 }
+
+public class Blog
+{
+    private string _validatedUrl;
+
+    public int BlogId { get; set; }
+
+    public string GetUrl()
+    {
+        return _validatedUrl;
+    }
+
+    public void SetUrl(string url)
+    {
+        using (var client = new HttpClient())
+        {
+            var response = client.GetAsync(url).Result;
+            response.EnsureSuccessStatusCode();
+        }
+
+        _validatedUrl = url;
+    }
+}
+#endregion

--- a/samples/core/Modeling/BackingFields/Program.cs
+++ b/samples/core/Modeling/BackingFields/Program.cs
@@ -1,9 +1,8 @@
-namespace EFModeling.BackingFields
+namespace EFModeling.BackingFields;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
-        {
-        }
     }
 }

--- a/samples/core/Modeling/BulkConfiguration/Currency.cs
+++ b/samples/core/Modeling/BulkConfiguration/Currency.cs
@@ -1,15 +1,14 @@
-﻿namespace EFModeling.BulkConfiguration
+﻿namespace EFModeling.BulkConfiguration;
+
+#region Currency
+public readonly struct Currency
 {
-    #region Currency
-    public readonly struct Currency
-    {
-        public Currency(decimal amount)
-            => Amount = amount;
+    public Currency(decimal amount)
+        => Amount = amount;
 
-        public decimal Amount { get; }
+    public decimal Amount { get; }
 
-        public override string ToString()
-            => $"${Amount}";
-    }
-    #endregion
+    public override string ToString()
+        => $"${Amount}";
 }
+#endregion

--- a/samples/core/Modeling/BulkConfiguration/CurrencyContext.cs
+++ b/samples/core/Modeling/BulkConfiguration/CurrencyContext.cs
@@ -2,25 +2,24 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.BulkConfiguration
+namespace EFModeling.BulkConfiguration;
+
+public class CurrencyContext : DbContext
 {
-    public class CurrencyContext : DbContext
+    public DbSet<Product> Products { get; set; }
+
+    #region ConfigureConventions
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
-        public DbSet<Product> Products { get; set; }
-
-        #region ConfigureConventions
-        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
-        {
-            configurationBuilder
-                .Properties<Currency>()
-                .HaveConversion<CurrencyConverter>();
-        }
-        #endregion
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFModeling.BulkConfiguration.Currency;Trusted_Connection=True")
-                .LogTo(Console.WriteLine, minimumLevel: Microsoft.Extensions.Logging.LogLevel.Information)
-                .EnableSensitiveDataLogging();
+        configurationBuilder
+            .Properties<Currency>()
+            .HaveConversion<CurrencyConverter>();
     }
+    #endregion
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=EFModeling.BulkConfiguration.Currency;Trusted_Connection=True")
+            .LogTo(Console.WriteLine, minimumLevel: Microsoft.Extensions.Logging.LogLevel.Information)
+            .EnableSensitiveDataLogging();
 }

--- a/samples/core/Modeling/BulkConfiguration/CurrencyConverter.cs
+++ b/samples/core/Modeling/BulkConfiguration/CurrencyConverter.cs
@@ -1,16 +1,15 @@
 ﻿using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace EFModeling.BulkConfiguration
+namespace EFModeling.BulkConfiguration;
+
+#region CurrencyConverter
+public class CurrencyConverter : ValueConverter<Currency, decimal>
 {
-    #region CurrencyConverter
-    public class CurrencyConverter : ValueConverter<Currency, decimal>
+    public CurrencyConverter()
+        : base(
+            v => v.Amount,
+            v => new Currency(v))
     {
-        public CurrencyConverter()
-            : base(
-                v => v.Amount,
-                v => new Currency(v))
-        {
-        }
     }
-    #endregion
 }
+#endregion

--- a/samples/core/Modeling/BulkConfiguration/MetadataAPIContext.cs
+++ b/samples/core/Modeling/BulkConfiguration/MetadataAPIContext.cs
@@ -1,33 +1,32 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.BulkConfiguration
-{
-    public class MetadataAPIContext : DbContext
-    {
-        public DbSet<Product> Products { get; set; }
+namespace EFModeling.BulkConfiguration;
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+public class MetadataAPIContext : DbContext
+{
+    public DbSet<Product> Products { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        #region MetadataAPI
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
         {
-            #region MetadataAPI
-            foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+            foreach (var propertyInfo in entityType.ClrType.GetProperties())
             {
-                foreach (var propertyInfo in entityType.ClrType.GetProperties())
+                if (propertyInfo.PropertyType == typeof(Currency))
                 {
-                    if (propertyInfo.PropertyType == typeof(Currency))
-                    {
-                        entityType.AddProperty(propertyInfo)
-                            .SetValueConverter(typeof(CurrencyConverter));
-                    }
+                    entityType.AddProperty(propertyInfo)
+                        .SetValueConverter(typeof(CurrencyConverter));
                 }
             }
-            #endregion
         }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFModeling.BulkConfiguration;Trusted_Connection=True")
-                .LogTo(Console.WriteLine, minimumLevel: Microsoft.Extensions.Logging.LogLevel.Information)
-                .EnableSensitiveDataLogging();
+        #endregion
     }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=EFModeling.BulkConfiguration;Trusted_Connection=True")
+            .LogTo(Console.WriteLine, minimumLevel: Microsoft.Extensions.Logging.LogLevel.Information)
+            .EnableSensitiveDataLogging();
 }

--- a/samples/core/Modeling/BulkConfiguration/PreConventionContext.cs
+++ b/samples/core/Modeling/BulkConfiguration/PreConventionContext.cs
@@ -2,43 +2,42 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.BulkConfiguration
+namespace EFModeling.BulkConfiguration;
+
+public class PreConventionContext : DbContext
 {
-    public class PreConventionContext : DbContext
+    public DbSet<Product> Products { get; set; }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
-        public DbSet<Product> Products { get; set; }
+        #region CurrencyConversion
+        configurationBuilder
+            .Properties<Currency>()
+            .HaveConversion<CurrencyConverter>();
+        #endregion
 
-        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
-        {
-            #region CurrencyConversion
-            configurationBuilder
-                .Properties<Currency>()
-                .HaveConversion<CurrencyConverter>();
-            #endregion
+        #region StringFacets
+        configurationBuilder
+            .Properties<string>()
+            .AreUnicode(false)
+            .HaveMaxLength(1024);
+        #endregion
 
-            #region StringFacets
-            configurationBuilder
-                .Properties<string>()
-                .AreUnicode(false)
-                .HaveMaxLength(1024);
-            #endregion
+        #region IgnoreInterface
+        configurationBuilder
+            .IgnoreAny(typeof(IList<>));
+        #endregion
 
-            #region IgnoreInterface
-            configurationBuilder
-                .IgnoreAny(typeof(IList<>));
-            #endregion
-
-            #region DefaultTypeMapping
-            configurationBuilder
-                .DefaultTypeMapping<Currency>()
-                .HasConversion<CurrencyConverter>();
-            #endregion
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFModeling.BulkConfiguration;Trusted_Connection=True")
-                .LogTo(Console.WriteLine, minimumLevel: Microsoft.Extensions.Logging.LogLevel.Information)
-                .EnableSensitiveDataLogging();
+        #region DefaultTypeMapping
+        configurationBuilder
+            .DefaultTypeMapping<Currency>()
+            .HasConversion<CurrencyConverter>();
+        #endregion
     }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=EFModeling.BulkConfiguration;Trusted_Connection=True")
+            .LogTo(Console.WriteLine, minimumLevel: Microsoft.Extensions.Logging.LogLevel.Information)
+            .EnableSensitiveDataLogging();
 }

--- a/samples/core/Modeling/BulkConfiguration/Product.cs
+++ b/samples/core/Modeling/BulkConfiguration/Product.cs
@@ -1,8 +1,7 @@
-﻿namespace EFModeling.BulkConfiguration
+﻿namespace EFModeling.BulkConfiguration;
+
+public class Product
 {
-    public class Product
-    {
-        public int Id { get; set; }
-        public Currency Price { get; set; }
-    }
+    public int Id { get; set; }
+    public Currency Price { get; set; }
 }

--- a/samples/core/Modeling/BulkConfiguration/Program.cs
+++ b/samples/core/Modeling/BulkConfiguration/Program.cs
@@ -2,50 +2,49 @@
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.BulkConfiguration
+namespace EFModeling.BulkConfiguration;
+
+internal class Program
 {
-    internal class Program
+    private static void Main()
     {
-        private static void Main()
+        Console.WriteLine("Sample showing bulk configuration of value conversion for a simple value object");
+        Console.WriteLine();
+
+        using (var context = new MetadataAPIContext())
         {
-            Console.WriteLine("Sample showing bulk configuration of value conversion for a simple value object");
-            Console.WriteLine();
-
-            using (var context = new MetadataAPIContext())
-            {
-                RoundtripValue(context);
-            }
-
-            using (var context = new PreConventionContext())
-            {
-                RoundtripValue(context);
-            }
-
-            Console.WriteLine();
-            Console.WriteLine("Sample finished.");
+            RoundtripValue(context);
         }
 
-        private static void RoundtripValue(DbContext context)
+        using (var context = new PreConventionContext())
         {
-            Console.WriteLine("Using " + context.GetType().Name);
-            Console.WriteLine("Deleting and re-creating database...");
-            Console.WriteLine();
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-            Console.WriteLine();
-            Console.WriteLine("Done. Database is clean and fresh.");
-
-            var product = new Product { Price = new Currency(3.99m) };
-            context.Add(product);
-
-            Console.WriteLine("Save a new product with price: " + product.Price.Amount);
-            Console.WriteLine();
-
-            context.SaveChanges();
-
-            Console.WriteLine();
-            Console.WriteLine("Read the entity back with price: " + context.Set<Product>().Single().Price.Amount);
-            Console.WriteLine();
+            RoundtripValue(context);
         }
+
+        Console.WriteLine();
+        Console.WriteLine("Sample finished.");
+    }
+
+    private static void RoundtripValue(DbContext context)
+    {
+        Console.WriteLine("Using " + context.GetType().Name);
+        Console.WriteLine("Deleting and re-creating database...");
+        Console.WriteLine();
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+        Console.WriteLine();
+        Console.WriteLine("Done. Database is clean and fresh.");
+
+        var product = new Product { Price = new Currency(3.99m) };
+        context.Add(product);
+
+        Console.WriteLine("Save a new product with price: " + product.Price.Amount);
+        Console.WriteLine();
+
+        context.SaveChanges();
+
+        Console.WriteLine();
+        Console.WriteLine("Read the entity back with price: " + context.Set<Product>().Single().Price.Amount);
+        Console.WriteLine();
     }
 }

--- a/samples/core/Modeling/ConcurrencyTokens/DataAnnotations/Concurrency.cs
+++ b/samples/core/Modeling/ConcurrencyTokens/DataAnnotations/Concurrency.cs
@@ -1,22 +1,21 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.ConcurrencyTokens.DataAnnotations.Concurrency
+namespace EFModeling.ConcurrencyTokens.DataAnnotations.Concurrency;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Person> People { get; set; }
-    }
-
-    #region Concurrency
-    public class Person
-    {
-        public int PersonId { get; set; }
-
-        [ConcurrencyCheck]
-        public string LastName { get; set; }
-
-        public string FirstName { get; set; }
-    }
-    #endregion
+    public DbSet<Person> People { get; set; }
 }
+
+#region Concurrency
+public class Person
+{
+    public int PersonId { get; set; }
+
+    [ConcurrencyCheck]
+    public string LastName { get; set; }
+
+    public string FirstName { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/ConcurrencyTokens/DataAnnotations/Timestamp.cs
+++ b/samples/core/Modeling/ConcurrencyTokens/DataAnnotations/Timestamp.cs
@@ -1,22 +1,21 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.ConcurrencyTokens.DataAnnotations.Timestamp
+namespace EFModeling.ConcurrencyTokens.DataAnnotations.Timestamp;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
-
-    #region Timestamp
-    public class Blog
-    {
-        public int BlogId { get; set; }
-
-        public string Url { get; set; }
-
-        [Timestamp]
-        public byte[] Timestamp { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region Timestamp
+public class Blog
+{
+    public int BlogId { get; set; }
+
+    public string Url { get; set; }
+
+    [Timestamp]
+    public byte[] Timestamp { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/ConcurrencyTokens/FluentAPI/Concurrency.cs
+++ b/samples/core/Modeling/ConcurrencyTokens/FluentAPI/Concurrency.cs
@@ -1,25 +1,24 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.ConcurrencyTokens.FluentAPI.Concurrency
+namespace EFModeling.ConcurrencyTokens.FluentAPI.Concurrency;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Person> People { get; set; }
+    public DbSet<Person> People { get; set; }
 
-        #region Concurrency
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Person>()
-                .Property(p => p.LastName)
-                .IsConcurrencyToken();
-        }
-        #endregion
-    }
-
-    public class Person
+    #region Concurrency
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int PersonId { get; set; }
-        public string LastName { get; set; }
-        public string FirstName { get; set; }
+        modelBuilder.Entity<Person>()
+            .Property(p => p.LastName)
+            .IsConcurrencyToken();
     }
+    #endregion
+}
+
+public class Person
+{
+    public int PersonId { get; set; }
+    public string LastName { get; set; }
+    public string FirstName { get; set; }
 }

--- a/samples/core/Modeling/ConcurrencyTokens/FluentAPI/Timestamp.cs
+++ b/samples/core/Modeling/ConcurrencyTokens/FluentAPI/Timestamp.cs
@@ -1,25 +1,24 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.ConcurrencyTokens.FluentAPI.Timestamp
+namespace EFModeling.ConcurrencyTokens.FluentAPI.Timestamp;
+
+#region Timestamp
+internal class MyContext : DbContext
 {
-    #region Timestamp
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property(p => p.Timestamp)
-                .IsRowVersion();
-        }
-    }
-
-    public class Blog
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public byte[] Timestamp { get; set; }
+        modelBuilder.Entity<Blog>()
+            .Property(p => p.Timestamp)
+            .IsRowVersion();
     }
-    #endregion
 }
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public byte[] Timestamp { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/ConcurrencyTokens/Program.cs
+++ b/samples/core/Modeling/ConcurrencyTokens/Program.cs
@@ -1,9 +1,8 @@
-namespace EFModeling.ConcurrencyTokens
+namespace EFModeling.ConcurrencyTokens;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
-        {
-        }
     }
 }

--- a/samples/core/Modeling/DataSeeding/Blog.cs
+++ b/samples/core/Modeling/DataSeeding/Blog.cs
@@ -1,12 +1,11 @@
 using System.Collections.Generic;
 
-namespace EFModeling.DataSeeding
-{
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+namespace EFModeling.DataSeeding;
 
-        public virtual ICollection<Post> Posts { get; set; }
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public virtual ICollection<Post> Posts { get; set; }
 }

--- a/samples/core/Modeling/DataSeeding/DataSeedingContext.cs
+++ b/samples/core/Modeling/DataSeeding/DataSeedingContext.cs
@@ -1,47 +1,46 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.DataSeeding
+namespace EFModeling.DataSeeding;
+
+public class DataSeedingContext : DbContext
 {
-    public class DataSeedingContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFDataSeeding;Trusted_Connection=True");
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+        modelBuilder.Entity<Blog>(entity => { entity.Property(e => e.Url).IsRequired(); });
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFDataSeeding;Trusted_Connection=True");
+        #region BlogSeed
+        modelBuilder.Entity<Blog>().HasData(new Blog { BlogId = 1, Url = "http://sample.com" });
+        #endregion
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>(entity => { entity.Property(e => e.Url).IsRequired(); });
+        modelBuilder.Entity<Post>(
+            entity =>
+            {
+                entity.HasOne(d => d.Blog)
+                    .WithMany(p => p.Posts)
+                    .HasForeignKey("BlogId");
+            });
 
-            #region BlogSeed
-            modelBuilder.Entity<Blog>().HasData(new Blog { BlogId = 1, Url = "http://sample.com" });
-            #endregion
+        #region PostSeed
+        modelBuilder.Entity<Post>().HasData(
+            new Post { BlogId = 1, PostId = 1, Title = "First post", Content = "Test 1" });
+        #endregion
 
-            modelBuilder.Entity<Post>(
-                entity =>
-                {
-                    entity.HasOne(d => d.Blog)
-                        .WithMany(p => p.Posts)
-                        .HasForeignKey("BlogId");
-                });
+        #region AnonymousPostSeed
+        modelBuilder.Entity<Post>().HasData(
+            new { BlogId = 1, PostId = 2, Title = "Second post", Content = "Test 2" });
+        #endregion
 
-            #region PostSeed
-            modelBuilder.Entity<Post>().HasData(
-                new Post { BlogId = 1, PostId = 1, Title = "First post", Content = "Test 1" });
-            #endregion
-
-            #region AnonymousPostSeed
-            modelBuilder.Entity<Post>().HasData(
-                new { BlogId = 1, PostId = 2, Title = "Second post", Content = "Test 2" });
-            #endregion
-
-            #region OwnedTypeSeed
-            modelBuilder.Entity<Post>().OwnsOne(p => p.AuthorName).HasData(
-                new { PostId = 1, First = "Andriy", Last = "Svyryd" },
-                new { PostId = 2, First = "Diego", Last = "Vega" });
-            #endregion
-        }
+        #region OwnedTypeSeed
+        modelBuilder.Entity<Post>().OwnsOne(p => p.AuthorName).HasData(
+            new { PostId = 1, First = "Andriy", Last = "Svyryd" },
+            new { PostId = 2, First = "Diego", Last = "Vega" });
+        #endregion
     }
 }

--- a/samples/core/Modeling/DataSeeding/Migrations/DataSeedingContextModelSnapshot.cs
+++ b/samples/core/Modeling/DataSeeding/Migrations/DataSeedingContextModelSnapshot.cs
@@ -2,96 +2,95 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 
-namespace EFModeling.DataSeeding.Migrations
+namespace EFModeling.DataSeeding.Migrations;
+
+[DbContext(typeof(DataSeedingContext))]
+internal class DataSeedingContextModelSnapshot : ModelSnapshot
 {
-    [DbContext(typeof(DataSeedingContext))]
-    internal class DataSeedingContextModelSnapshot : ModelSnapshot
+    protected override void BuildModel(ModelBuilder modelBuilder)
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
-        {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation("ProductVersion", "2.1.0-rtm-30799")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128)
-                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+        modelBuilder
+            .HasAnnotation("ProductVersion", "2.1.0-rtm-30799")
+            .HasAnnotation("Relational:MaxIdentifierLength", 128)
+            .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
-            modelBuilder.Entity(
-                "EFModeling.DataSeeding.Blog", b =>
-                {
-                    b.Property<int>("BlogId")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+        modelBuilder.Entity(
+            "EFModeling.DataSeeding.Blog", b =>
+            {
+                b.Property<int>("BlogId")
+                    .ValueGeneratedOnAdd()
+                    .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
-                    b.Property<string>("Url")
-                        .IsRequired();
+                b.Property<string>("Url")
+                    .IsRequired();
 
-                    b.HasKey("BlogId");
+                b.HasKey("BlogId");
 
-                    b.ToTable("Blogs");
+                b.ToTable("Blogs");
 
-                    b.HasData(
-                        new { BlogId = 1, Url = "http://sample.com" }
-                    );
-                });
+                b.HasData(
+                    new { BlogId = 1, Url = "http://sample.com" }
+                );
+            });
 
-            modelBuilder.Entity(
-                "EFModeling.DataSeeding.Post", b =>
-                {
-                    b.Property<int>("PostId")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+        modelBuilder.Entity(
+            "EFModeling.DataSeeding.Post", b =>
+            {
+                b.Property<int>("PostId")
+                    .ValueGeneratedOnAdd()
+                    .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
-                    b.Property<int>("BlogId");
+                b.Property<int>("BlogId");
 
-                    b.Property<string>("Content");
+                b.Property<string>("Content");
 
-                    b.Property<string>("Title");
+                b.Property<string>("Title");
 
-                    b.HasKey("PostId");
+                b.HasKey("PostId");
 
-                    b.HasIndex("BlogId");
+                b.HasIndex("BlogId");
 
-                    b.ToTable("Posts");
+                b.ToTable("Posts");
 
-                    b.HasData(
-                        new { PostId = 1, BlogId = 1, Content = "Test 1", Title = "First post" },
-                        new { PostId = 2, BlogId = 1, Content = "Test 2", Title = "Second post" }
-                    );
-                });
+                b.HasData(
+                    new { PostId = 1, BlogId = 1, Content = "Test 1", Title = "First post" },
+                    new { PostId = 2, BlogId = 1, Content = "Test 2", Title = "Second post" }
+                );
+            });
 
-            modelBuilder.Entity(
-                "EFModeling.DataSeeding.Post", b =>
-                {
-                    b.HasOne("EFModeling.DataSeeding.Blog", "Blog")
-                        .WithMany("Posts")
-                        .HasForeignKey("BlogId")
-                        .OnDelete(DeleteBehavior.Cascade);
+        modelBuilder.Entity(
+            "EFModeling.DataSeeding.Post", b =>
+            {
+                b.HasOne("EFModeling.DataSeeding.Blog", "Blog")
+                    .WithMany("Posts")
+                    .HasForeignKey("BlogId")
+                    .OnDelete(DeleteBehavior.Cascade);
 
-                    b.OwnsOne(
-                        "EFModeling.DataSeeding.Name", "AuthorName", b1 =>
-                        {
-                            b1.Property<int?>("PostId")
-                                .ValueGeneratedOnAdd()
-                                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                b.OwnsOne(
+                    "EFModeling.DataSeeding.Name", "AuthorName", b1 =>
+                    {
+                        b1.Property<int?>("PostId")
+                            .ValueGeneratedOnAdd()
+                            .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
-                            b1.Property<string>("First");
+                        b1.Property<string>("First");
 
-                            b1.Property<string>("Last");
+                        b1.Property<string>("Last");
 
-                            b1.ToTable("Posts");
+                        b1.ToTable("Posts");
 
-                            b1.HasOne("EFModeling.DataSeeding.Post")
-                                .WithOne("AuthorName")
-                                .HasForeignKey("EFModeling.DataSeeding.Name", "PostId")
-                                .OnDelete(DeleteBehavior.Cascade);
+                        b1.HasOne("EFModeling.DataSeeding.Post")
+                            .WithOne("AuthorName")
+                            .HasForeignKey("EFModeling.DataSeeding.Name", "PostId")
+                            .OnDelete(DeleteBehavior.Cascade);
 
-                            b1.HasData(
-                                new { PostId = 1, First = "Andriy", Last = "Svyryd" },
-                                new { PostId = 2, First = "Diego", Last = "Vega" }
-                            );
-                        });
-                });
+                        b1.HasData(
+                            new { PostId = 1, First = "Andriy", Last = "Svyryd" },
+                            new { PostId = 2, First = "Diego", Last = "Vega" }
+                        );
+                    });
+            });
 #pragma warning restore 612, 618
-        }
     }
 }

--- a/samples/core/Modeling/DataSeeding/Name.cs
+++ b/samples/core/Modeling/DataSeeding/Name.cs
@@ -1,8 +1,7 @@
-﻿namespace EFModeling.DataSeeding
+﻿namespace EFModeling.DataSeeding;
+
+public class Name
 {
-    public class Name
-    {
-        public virtual string First { get; set; }
-        public virtual string Last { get; set; }
-    }
+    public virtual string First { get; set; }
+    public virtual string Last { get; set; }
 }

--- a/samples/core/Modeling/DataSeeding/Post.cs
+++ b/samples/core/Modeling/DataSeeding/Post.cs
@@ -1,12 +1,11 @@
-namespace EFModeling.DataSeeding
+namespace EFModeling.DataSeeding;
+
+public class Post
 {
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Content { get; set; }
-        public string Title { get; set; }
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-        public Name AuthorName { get; set; }
-    }
+    public int PostId { get; set; }
+    public string Content { get; set; }
+    public string Title { get; set; }
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
+    public Name AuthorName { get; set; }
 }

--- a/samples/core/Modeling/DataSeeding/Program.cs
+++ b/samples/core/Modeling/DataSeeding/Program.cs
@@ -2,37 +2,36 @@ using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.DataSeeding
+namespace EFModeling.DataSeeding;
+
+internal static class Program
 {
-    internal static class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
+        #region CustomSeeding
+        using (var context = new DataSeedingContext())
         {
-            #region CustomSeeding
-            using (var context = new DataSeedingContext())
+            context.Database.EnsureCreated();
+
+            var testBlog = context.Blogs.FirstOrDefault(b => b.Url == "http://test.com");
+            if (testBlog == null)
             {
-                context.Database.EnsureCreated();
-
-                var testBlog = context.Blogs.FirstOrDefault(b => b.Url == "http://test.com");
-                if (testBlog == null)
-                {
-                    context.Blogs.Add(new Blog { Url = "http://test.com" });
-                }
-
-                context.SaveChanges();
+                context.Blogs.Add(new Blog { Url = "http://test.com" });
             }
-            #endregion
 
-            using (var context = new DataSeedingContext())
+            context.SaveChanges();
+        }
+        #endregion
+
+        using (var context = new DataSeedingContext())
+        {
+            foreach (var blog in context.Blogs.Include(b => b.Posts))
             {
-                foreach (var blog in context.Blogs.Include(b => b.Posts))
-                {
-                    Console.WriteLine($"Blog {blog.Url}");
+                Console.WriteLine($"Blog {blog.Url}");
 
-                    foreach (var post in blog.Posts)
-                    {
-                        Console.WriteLine($"\t{post.Title}: {post.Content} by {post.AuthorName.First} {post.AuthorName.Last}");
-                    }
+                foreach (var post in blog.Posts)
+                {
+                    Console.WriteLine($"\t{post.Title}: {post.Content} by {post.AuthorName.First} {post.AuthorName.Last}");
                 }
             }
         }

--- a/samples/core/Modeling/DynamicModel/ConfigurableEntity.cs
+++ b/samples/core/Modeling/DynamicModel/ConfigurableEntity.cs
@@ -1,9 +1,8 @@
-namespace EFModeling.DynamicModel
+namespace EFModeling.DynamicModel;
+
+public class ConfigurableEntity
 {
-    public class ConfigurableEntity
-    {
-        public int Id { get; set; }
-        public int IntProperty { get; set; }
-        public string StringProperty { get; set; }
-    }
+    public int Id { get; set; }
+    public int IntProperty { get; set; }
+    public string StringProperty { get; set; }
 }

--- a/samples/core/Modeling/DynamicModel/DynamicContext.cs
+++ b/samples/core/Modeling/DynamicModel/DynamicContext.cs
@@ -1,33 +1,32 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-namespace EFModeling.DynamicModel
+namespace EFModeling.DynamicModel;
+
+public class DynamicContext : DbContext
 {
-    public class DynamicContext : DbContext
+    public bool UseIntProperty { get; set; }
+
+    public DbSet<ConfigurableEntity> Entities { get; set; }
+
+    #region OnConfiguring
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder
+            .UseInMemoryDatabase("DynamicContext")
+            .ReplaceService<IModelCacheKeyFactory, DynamicModelCacheKeyFactory>();
+    #endregion
+
+    #region OnModelCreating
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public bool UseIntProperty { get; set; }
-
-        public DbSet<ConfigurableEntity> Entities { get; set; }
-
-        #region OnConfiguring
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder
-                .UseInMemoryDatabase("DynamicContext")
-                .ReplaceService<IModelCacheKeyFactory, DynamicModelCacheKeyFactory>();
-        #endregion
-
-        #region OnModelCreating
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        if (UseIntProperty)
         {
-            if (UseIntProperty)
-            {
-                modelBuilder.Entity<ConfigurableEntity>().Ignore(e => e.StringProperty);
-            }
-            else
-            {
-                modelBuilder.Entity<ConfigurableEntity>().Ignore(e => e.IntProperty);
-            }
+            modelBuilder.Entity<ConfigurableEntity>().Ignore(e => e.StringProperty);
         }
-        #endregion
+        else
+        {
+            modelBuilder.Entity<ConfigurableEntity>().Ignore(e => e.IntProperty);
+        }
     }
+    #endregion
 }

--- a/samples/core/Modeling/DynamicModel/DynamicModelCacheKeyFactory.cs
+++ b/samples/core/Modeling/DynamicModel/DynamicModelCacheKeyFactory.cs
@@ -1,15 +1,14 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-namespace EFModeling.DynamicModel
+namespace EFModeling.DynamicModel;
+
+#region DynamicModel
+public class DynamicModelCacheKeyFactory : IModelCacheKeyFactory
 {
-    #region DynamicModel
-    public class DynamicModelCacheKeyFactory : IModelCacheKeyFactory
-    {
-        public object Create(DbContext context)
-            => context is DynamicContext dynamicContext
-                ? (context.GetType(), dynamicContext.UseIntProperty)
-                : (object)context.GetType();
-    }
-    #endregion
+    public object Create(DbContext context)
+        => context is DynamicContext dynamicContext
+            ? (context.GetType(), dynamicContext.UseIntProperty)
+            : (object)context.GetType();
 }
+#endregion

--- a/samples/core/Modeling/DynamicModel/DynamicModelCacheKeyFactoryDesignTimeSupport.cs
+++ b/samples/core/Modeling/DynamicModel/DynamicModelCacheKeyFactoryDesignTimeSupport.cs
@@ -1,18 +1,17 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-namespace EFModeling.DynamicModel
-{
-    #region DynamicModelDesignTimeSupport
-    public class DynamicModelCacheKeyFactoryDesignTimeSupport : IModelCacheKeyFactory
-    {
-        public object Create(DbContext context, bool designTime)
-            => context is DynamicContext dynamicContext
-                ? (context.GetType(), dynamicContext.UseIntProperty, designTime)
-                : (object)context.GetType();
+namespace EFModeling.DynamicModel;
 
-        public object Create(DbContext context)
-            => Create(context, false);
-    }
-    #endregion
+#region DynamicModelDesignTimeSupport
+public class DynamicModelCacheKeyFactoryDesignTimeSupport : IModelCacheKeyFactory
+{
+    public object Create(DbContext context, bool designTime)
+        => context is DynamicContext dynamicContext
+            ? (context.GetType(), dynamicContext.UseIntProperty, designTime)
+            : (object)context.GetType();
+
+    public object Create(DbContext context)
+        => Create(context, false);
 }
+#endregion

--- a/samples/core/Modeling/DynamicModel/Program.cs
+++ b/samples/core/Modeling/DynamicModel/Program.cs
@@ -1,41 +1,40 @@
 using System;
 using System.Linq;
 
-namespace EFModeling.DynamicModel
+namespace EFModeling.DynamicModel;
+
+public class Program
 {
-    public class Program
+    private static void Main()
     {
-        private static void Main()
+        // Note that because this sample uses InMemory as its provider, each model gets it's own separate store.
+
+        using (var context = new DynamicContext { UseIntProperty = true })
         {
-            // Note that because this sample uses InMemory as its provider, each model gets it's own separate store.
+            context.Entities.Add(new ConfigurableEntity { IntProperty = 44, StringProperty = "Aloha" });
+            context.SaveChanges();
+        }
 
-            using (var context = new DynamicContext { UseIntProperty = true })
-            {
-                context.Entities.Add(new ConfigurableEntity { IntProperty = 44, StringProperty = "Aloha" });
-                context.SaveChanges();
-            }
+        using (var context = new DynamicContext { UseIntProperty = false })
+        {
+            context.Entities.Add(new ConfigurableEntity { IntProperty = 43, StringProperty = "Hola" });
+            context.SaveChanges();
+        }
 
-            using (var context = new DynamicContext { UseIntProperty = false })
-            {
-                context.Entities.Add(new ConfigurableEntity { IntProperty = 43, StringProperty = "Hola" });
-                context.SaveChanges();
-            }
+        using (var context = new DynamicContext { UseIntProperty = true })
+        {
+            var entity = context.Entities.Single();
 
-            using (var context = new DynamicContext { UseIntProperty = true })
-            {
-                var entity = context.Entities.Single();
+            // Writes 44 and an empty string
+            Console.WriteLine($"{entity.IntProperty} {entity.StringProperty}");
+        }
 
-                // Writes 44 and an empty string
-                Console.WriteLine($"{entity.IntProperty} {entity.StringProperty}");
-            }
+        using (var context = new DynamicContext { UseIntProperty = false })
+        {
+            var entity = context.Entities.Single();
 
-            using (var context = new DynamicContext { UseIntProperty = false })
-            {
-                var entity = context.Entities.Single();
-
-                // Writes 0 and an "Hola"
-                Console.WriteLine($"{entity.IntProperty} {entity.StringProperty}");
-            }
+            // Writes 0 and an "Hola"
+            Console.WriteLine($"{entity.IntProperty} {entity.StringProperty}");
         }
     }
 }

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/Annotations.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/Annotations.cs
@@ -2,19 +2,18 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.DataAnnotations.Annotations
+namespace EFModeling.EntityProperties.DataAnnotations.Annotations;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
+    public DbSet<Blog> Blogs { get; set; }
+}
 
-    [Table("Blogs")]
-    public class Blog
-    {
-        public int BlogId { get; set; }
+[Table("Blogs")]
+public class Blog
+{
+    public int BlogId { get; set; }
 
-        [Required]
-        public string Url { get; set; }
-    }
+    [Required]
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/ColumnComment.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/ColumnComment.cs
@@ -1,19 +1,18 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.DataAnnotations.ColumnComment
+namespace EFModeling.EntityProperties.DataAnnotations.ColumnComment;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
-
-    #region ColumnComment
-    public class Blog
-    {
-        public int BlogId { get; set; }
-
-        [Comment("The URL of the blog")]
-        public string Url { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region ColumnComment
+public class Blog
+{
+    public int BlogId { get; set; }
+
+    [Comment("The URL of the blog")]
+    public string Url { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/ColumnDataType.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/ColumnDataType.cs
@@ -1,23 +1,22 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.DataAnnotations.ColumnDataType
+namespace EFModeling.EntityProperties.DataAnnotations.ColumnDataType;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
-
-    #region ColumnDataType
-    public class Blog
-    {
-        public int BlogId { get; set; }
-
-        [Column(TypeName = "varchar(200)")]
-        public string Url { get; set; }
-
-        [Column(TypeName = "decimal(5, 2)")]
-        public decimal Rating { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region ColumnDataType
+public class Blog
+{
+    public int BlogId { get; set; }
+
+    [Column(TypeName = "varchar(200)")]
+    public string Url { get; set; }
+
+    [Column(TypeName = "decimal(5, 2)")]
+    public decimal Rating { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/ColumnName.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/ColumnName.cs
@@ -1,20 +1,19 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.DataAnnotations.ColumnName
+namespace EFModeling.EntityProperties.DataAnnotations.ColumnName;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
-
-    #region ColumnName
-    public class Blog
-    {
-        [Column("blog_id")]
-        public int BlogId { get; set; }
-
-        public string Url { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region ColumnName
+public class Blog
+{
+    [Column("blog_id")]
+    public int BlogId { get; set; }
+
+    public string Url { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/ColumnOrder.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/ColumnOrder.cs
@@ -1,33 +1,32 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.DataAnnotations.ColumnOrder
+namespace EFModeling.EntityProperties.DataAnnotations.ColumnOrder;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Employee> Employees { get; set; }
-    }
-
-    #region snippet_ColumnAttribute
-    public class EntityBase
-    {
-        [Column(Order = 0)]
-        public int Id { get; set; }
-    }
-
-    public class PersonBase : EntityBase
-    {
-        [Column(Order = 1)]
-        public string FirstName { get; set; }
-
-        [Column(Order = 2)]
-        public string LastName { get; set; }
-    }
-
-    public class Employee : PersonBase
-    {
-        public string Department { get; set; }
-        public decimal AnnualSalary { get; set; }
-    }
-    #endregion
+    public DbSet<Employee> Employees { get; set; }
 }
+
+#region snippet_ColumnAttribute
+public class EntityBase
+{
+    [Column(Order = 0)]
+    public int Id { get; set; }
+}
+
+public class PersonBase : EntityBase
+{
+    [Column(Order = 1)]
+    public string FirstName { get; set; }
+
+    [Column(Order = 2)]
+    public string LastName { get; set; }
+}
+
+public class Employee : PersonBase
+{
+    public string Department { get; set; }
+    public decimal AnnualSalary { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/IgnoreProperty.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/IgnoreProperty.cs
@@ -2,21 +2,20 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.DataAnnotations.IgnoreProperty
+namespace EFModeling.EntityProperties.DataAnnotations.IgnoreProperty;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
-
-    #region IgnoreProperty
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        [NotMapped]
-        public DateTime LoadedFromDatabase { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region IgnoreProperty
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    [NotMapped]
+    public DateTime LoadedFromDatabase { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/MaxLength.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/MaxLength.cs
@@ -1,20 +1,19 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.DataAnnotations.MaxLength
+namespace EFModeling.EntityProperties.DataAnnotations.MaxLength;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
-
-    #region MaxLength
-    public class Blog
-    {
-        public int BlogId { get; set; }
-
-        [MaxLength(500)]
-        public string Url { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region MaxLength
+public class Blog
+{
+    public int BlogId { get; set; }
+
+    [MaxLength(500)]
+    public string Url { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/PrecisionAndScale.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/PrecisionAndScale.cs
@@ -1,21 +1,20 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.DataAnnotations.PrecisionAndScale
-{
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
+namespace EFModeling.EntityProperties.DataAnnotations.PrecisionAndScale;
 
-    #region PrecisionAndScale
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        [Precision(14, 2)]
-        public decimal Score { get; set; }
-        [Precision(3)]
-        public DateTime LastUpdated { get; set; }
-    }
-    #endregion
+internal class MyContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region PrecisionAndScale
+public class Blog
+{
+    public int BlogId { get; set; }
+    [Precision(14, 2)]
+    public decimal Score { get; set; }
+    [Precision(3)]
+    public DateTime LastUpdated { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/Required.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/Required.cs
@@ -1,20 +1,19 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.DataAnnotations.Required
+namespace EFModeling.EntityProperties.DataAnnotations.Required;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
-
-    #region Required
-    public class Blog
-    {
-        public int BlogId { get; set; }
-
-        [Required]
-        public string Url { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region Required
+public class Blog
+{
+    public int BlogId { get; set; }
+
+    [Required]
+    public string Url { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/EntityProperties/DataAnnotations/Unicode.cs
+++ b/samples/core/Modeling/EntityProperties/DataAnnotations/Unicode.cs
@@ -1,22 +1,21 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.DataAnnotations.Unicode
+namespace EFModeling.EntityProperties.DataAnnotations.Unicode;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Book> Books { get; set; }
-    }
-
-    #region Unicode
-    public class Book
-    {
-        public int Id { get; set; }
-        public string Title { get; set; }
-
-        [Unicode(false)]
-        [MaxLength(22)]
-        public string Isbn { get; set; }
-    }
-    #endregion
+    public DbSet<Book> Books { get; set; }
 }
+
+#region Unicode
+public class Book
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+
+    [Unicode(false)]
+    [MaxLength(22)]
+    public string Isbn { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/EntityProperties/FluentAPI/ColumnComment.cs
+++ b/samples/core/Modeling/EntityProperties/FluentAPI/ColumnComment.cs
@@ -1,24 +1,23 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.FluentAPI.ColumnComment
+namespace EFModeling.EntityProperties.FluentAPI.ColumnComment;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region ColumnComment
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property(b => b.Url)
-                .HasComment("The URL of the blog");
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region ColumnComment
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .Property(b => b.Url)
+            .HasComment("The URL of the blog");
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/EntityProperties/FluentAPI/ColumnDataType.cs
+++ b/samples/core/Modeling/EntityProperties/FluentAPI/ColumnDataType.cs
@@ -1,28 +1,27 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.FluentAPI.DataType
+namespace EFModeling.EntityProperties.FluentAPI.DataType;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region ColumnDataType
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>(
-                eb =>
-                {
-                    eb.Property(b => b.Url).HasColumnType("varchar(200)");
-                    eb.Property(b => b.Rating).HasColumnType("decimal(5, 2)");
-                });
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region ColumnDataType
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public decimal Rating { get; set; }
+        modelBuilder.Entity<Blog>(
+            eb =>
+            {
+                eb.Property(b => b.Url).HasColumnType("varchar(200)");
+                eb.Property(b => b.Rating).HasColumnType("decimal(5, 2)");
+            });
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public decimal Rating { get; set; }
 }

--- a/samples/core/Modeling/EntityProperties/FluentAPI/ColumnName.cs
+++ b/samples/core/Modeling/EntityProperties/FluentAPI/ColumnName.cs
@@ -1,24 +1,23 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.FluentAPI.ColumnName
+namespace EFModeling.EntityProperties.FluentAPI.ColumnName;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region ColumnName
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property(b => b.BlogId)
-                .HasColumnName("blog_id");
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region ColumnName
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .Property(b => b.BlogId)
+            .HasColumnName("blog_id");
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/EntityProperties/FluentAPI/ColumnOrder.cs
+++ b/samples/core/Modeling/EntityProperties/FluentAPI/ColumnOrder.cs
@@ -1,43 +1,42 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.FluentAPI.ColumnOrder
+namespace EFModeling.EntityProperties.FluentAPI.ColumnOrder;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Employee> Employees { get; set; }
+    public DbSet<Employee> Employees { get; set; }
 
-        #region snippet_HasColumnOrder
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+    #region snippet_HasColumnOrder
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Employee>(x =>
         {
-            modelBuilder.Entity<Employee>(x =>
-            {
-                x.Property(b => b.Id)
-                    .HasColumnOrder(0);
+            x.Property(b => b.Id)
+                .HasColumnOrder(0);
 
-                x.Property(b => b.FirstName)
-                    .HasColumnOrder(1);
+            x.Property(b => b.FirstName)
+                .HasColumnOrder(1);
 
-                x.Property(b => b.LastName)
-                    .HasColumnOrder(2);
-            });
-        }
-        #endregion
+            x.Property(b => b.LastName)
+                .HasColumnOrder(2);
+        });
     }
+    #endregion
+}
 
-    public class EntityBase
-    {
-        public int Id { get; set; }
-    }
+public class EntityBase
+{
+    public int Id { get; set; }
+}
 
-    public class PersonBase : EntityBase
-    {
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-    }
+public class PersonBase : EntityBase
+{
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+}
 
-    public class Employee : PersonBase
-    {
-        public string Department { get; set; }
-        public decimal AnnualSalary { get; set; }
-    }
+public class Employee : PersonBase
+{
+    public string Department { get; set; }
+    public decimal AnnualSalary { get; set; }
 }

--- a/samples/core/Modeling/EntityProperties/FluentAPI/IgnoreProperty.cs
+++ b/samples/core/Modeling/EntityProperties/FluentAPI/IgnoreProperty.cs
@@ -1,26 +1,25 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.FluentAPI.IgnoreProperty
+namespace EFModeling.EntityProperties.FluentAPI.IgnoreProperty;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+
+    #region IgnoreProperty
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-
-        #region IgnoreProperty
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Ignore(b => b.LoadedFromDatabase);
-        }
-        #endregion
+        modelBuilder.Entity<Blog>()
+            .Ignore(b => b.LoadedFromDatabase);
     }
+    #endregion
+}
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 
-        public DateTime LoadedFromDatabase { get; set; }
-    }
+    public DateTime LoadedFromDatabase { get; set; }
 }

--- a/samples/core/Modeling/EntityProperties/FluentAPI/MaxLength.cs
+++ b/samples/core/Modeling/EntityProperties/FluentAPI/MaxLength.cs
@@ -1,24 +1,23 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.FluentAPI.MaxLength
+namespace EFModeling.EntityProperties.FluentAPI.MaxLength;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region MaxLength
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property(b => b.Url)
-                .HasMaxLength(500);
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region MaxLength
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .Property(b => b.Url)
+            .HasMaxLength(500);
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/EntityProperties/FluentAPI/PrecisionAndScale.cs
+++ b/samples/core/Modeling/EntityProperties/FluentAPI/PrecisionAndScale.cs
@@ -1,30 +1,29 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.FluentAPI.PrecisionAndScale
+namespace EFModeling.EntityProperties.FluentAPI.PrecisionAndScale;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+
+    #region PrecisionAndScale
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
+        modelBuilder.Entity<Blog>()
+            .Property(b => b.Score)
+            .HasPrecision(14, 2);
 
-        #region PrecisionAndScale
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property(b => b.Score)
-                .HasPrecision(14, 2);
-
-            modelBuilder.Entity<Blog>()
-                .Property(b => b.LastUpdated)
-                .HasPrecision(3);
-        }
-        #endregion
+        modelBuilder.Entity<Blog>()
+            .Property(b => b.LastUpdated)
+            .HasPrecision(3);
     }
+    #endregion
+}
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public decimal Score { get; set; }
-        public DateTime LastUpdated { get; set; }
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public decimal Score { get; set; }
+    public DateTime LastUpdated { get; set; }
 }

--- a/samples/core/Modeling/EntityProperties/FluentAPI/Required.cs
+++ b/samples/core/Modeling/EntityProperties/FluentAPI/Required.cs
@@ -1,24 +1,23 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.FluentAPI.Required
+namespace EFModeling.EntityProperties.FluentAPI.Required;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region Required
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property(b => b.Url)
-                .IsRequired();
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region Required
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .Property(b => b.Url)
+            .IsRequired();
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/EntityProperties/FluentAPI/Unicode.cs
+++ b/samples/core/Modeling/EntityProperties/FluentAPI/Unicode.cs
@@ -1,26 +1,25 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityProperties.FluentAPI.Unicode
+namespace EFModeling.EntityProperties.FluentAPI.Unicode;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Book> Books { get; set; }
+    public DbSet<Book> Books { get; set; }
 
-        #region Unicode
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Book>()
-                .Property(b => b.Isbn)
-                .IsUnicode(false);
-        }
-        #endregion
-    }
-
-    public class Book
+    #region Unicode
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int Id { get; set; }
-        public string Title { get; set; }
-        public string Isbn { get; set; }
+        modelBuilder.Entity<Book>()
+            .Property(b => b.Isbn)
+            .IsUnicode(false);
     }
+    #endregion
+}
+
+public class Book
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+    public string Isbn { get; set; }
 }

--- a/samples/core/Modeling/EntityProperties/Program.cs
+++ b/samples/core/Modeling/EntityProperties/Program.cs
@@ -1,9 +1,8 @@
-namespace EFModeling.EntityProperties
+namespace EFModeling.EntityProperties;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
-        {
-        }
     }
 }

--- a/samples/core/Modeling/EntityTypes/DataAnnotations/IgnoreType.cs
+++ b/samples/core/Modeling/EntityTypes/DataAnnotations/IgnoreType.cs
@@ -2,26 +2,25 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityTypes.DataAnnotations.IgnoreType
+namespace EFModeling.EntityTypes.DataAnnotations.IgnoreType;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
-
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        public BlogMetadata Metadata { get; set; }
-    }
-
-    #region IgnoreType
-    [NotMapped]
-    public class BlogMetadata
-    {
-        public DateTime LoadedFromDatabase { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public BlogMetadata Metadata { get; set; }
+}
+
+#region IgnoreType
+[NotMapped]
+public class BlogMetadata
+{
+    public DateTime LoadedFromDatabase { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/EntityTypes/DataAnnotations/TableComment.cs
+++ b/samples/core/Modeling/EntityTypes/DataAnnotations/TableComment.cs
@@ -1,18 +1,17 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityTypes.DataAnnotations.TableComment
-{
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
+namespace EFModeling.EntityTypes.DataAnnotations.TableComment;
 
-    #region TableComment
-    [Comment("Blogs managed on the website")]
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-    }
-    #endregion
+internal class MyContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region TableComment
+[Comment("Blogs managed on the website")]
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/EntityTypes/DataAnnotations/TableName.cs
+++ b/samples/core/Modeling/EntityTypes/DataAnnotations/TableName.cs
@@ -1,19 +1,18 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityTypes.DataAnnotations.TableName
-{
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
+namespace EFModeling.EntityTypes.DataAnnotations.TableName;
 
-    #region TableName
-    [Table("blogs")]
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-    }
-    #endregion
+internal class MyContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region TableName
+[Table("blogs")]
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/EntityTypes/DataAnnotations/TableNameAndSchema.cs
+++ b/samples/core/Modeling/EntityTypes/DataAnnotations/TableNameAndSchema.cs
@@ -1,19 +1,18 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityTypes.DataAnnotations.TableNameAndSchema
-{
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
+namespace EFModeling.EntityTypes.DataAnnotations.TableNameAndSchema;
 
-    #region TableNameAndSchema
-    [Table("blogs", Schema = "blogging")]
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-    }
-    #endregion
+internal class MyContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region TableNameAndSchema
+[Table("blogs", Schema = "blogging")]
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/EntityTypes/EntityTypes.cs
+++ b/samples/core/Modeling/EntityTypes/EntityTypes.cs
@@ -1,68 +1,67 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityTypes
+namespace EFModeling.EntityTypes;
+
+#region EntityTypes
+internal class MyContext : DbContext
 {
-    #region EntityTypes
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<AuditEntry>();
-        }
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<AuditEntry>();
+    }
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public List<Post> Posts { get; set; }
+}
+
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public Blog Blog { get; set; }
+}
+
+public class AuditEntry
+{
+    public int AuditEntryId { get; set; }
+    public string Username { get; set; }
+    public string Action { get; set; }
+}
+#endregion
+
+#region BlogWithMultiplePostsEntity
+public class BlogWithMultiplePosts
+{
+    public string Url { get; set; }
+    public int PostCount { get; set; }
+}
+#endregion
+
+public class MyContextWithFunctionMapping : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        #region QueryableFunctionConfigurationToFunction
+        modelBuilder.Entity<BlogWithMultiplePosts>().HasNoKey().ToFunction("BlogsWithMultiplePosts");
+        #endregion
     }
 
-    public class Blog
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        public List<Post> Posts { get; set; }
-    }
-
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public Blog Blog { get; set; }
-    }
-
-    public class AuditEntry
-    {
-        public int AuditEntryId { get; set; }
-        public string Username { get; set; }
-        public string Action { get; set; }
-    }
-    #endregion
-
-    #region BlogWithMultiplePostsEntity
-    public class BlogWithMultiplePosts
-    {
-        public string Url { get; set; }
-        public int PostCount { get; set; }
-    }
-    #endregion
-
-    public class MyContextWithFunctionMapping : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            #region QueryableFunctionConfigurationToFunction
-            modelBuilder.Entity<BlogWithMultiplePosts>().HasNoKey().ToFunction("BlogsWithMultiplePosts");
-            #endregion
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFModeling.EntityTypeToFunctionMapping;Trusted_Connection=True");
-        }
+        optionsBuilder.UseSqlServer(
+            @"Server=(localdb)\mssqllocaldb;Database=EFModeling.EntityTypeToFunctionMapping;Trusted_Connection=True");
     }
 }

--- a/samples/core/Modeling/EntityTypes/FluentAPI/DefaultSchema.cs
+++ b/samples/core/Modeling/EntityTypes/FluentAPI/DefaultSchema.cs
@@ -1,22 +1,21 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityTypes.FluentAPI.DefaultSchema
+namespace EFModeling.EntityTypes.FluentAPI.DefaultSchema;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region DefaultSchema
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.HasDefaultSchema("blogging");
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region DefaultSchema
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.HasDefaultSchema("blogging");
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/EntityTypes/FluentAPI/IgnoreType.cs
+++ b/samples/core/Modeling/EntityTypes/FluentAPI/IgnoreType.cs
@@ -1,30 +1,29 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityTypes.FluentAPI.IgnoreType
+namespace EFModeling.EntityTypes.FluentAPI.IgnoreType;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+
+    #region IgnoreType
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-
-        #region IgnoreType
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Ignore<BlogMetadata>();
-        }
-        #endregion
+        modelBuilder.Ignore<BlogMetadata>();
     }
+    #endregion
+}
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 
-        public BlogMetadata Metadata { get; set; }
-    }
+    public BlogMetadata Metadata { get; set; }
+}
 
-    public class BlogMetadata
-    {
-        public DateTime LoadedFromDatabase { get; set; }
-    }
+public class BlogMetadata
+{
+    public DateTime LoadedFromDatabase { get; set; }
 }

--- a/samples/core/Modeling/EntityTypes/FluentAPI/TableComment.cs
+++ b/samples/core/Modeling/EntityTypes/FluentAPI/TableComment.cs
@@ -1,23 +1,22 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityTypes.FluentAPI.TableComment
+namespace EFModeling.EntityTypes.FluentAPI.TableComment;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region TableComment
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasComment("Blogs managed on the website");
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region TableComment
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasComment("Blogs managed on the website");
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/EntityTypes/FluentAPI/TableExcludeFromMigrations.cs
+++ b/samples/core/Modeling/EntityTypes/FluentAPI/TableExcludeFromMigrations.cs
@@ -1,23 +1,22 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityTypes.FluentAPI.TableExcludeFromMigrations
+namespace EFModeling.EntityTypes.FluentAPI.TableExcludeFromMigrations;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<IdentityUser> Users { get; set; }
+    public DbSet<IdentityUser> Users { get; set; }
 
-        #region TableExcludeFromMigrations
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<IdentityUser>()
-                .ToTable("AspNetUsers", t => t.ExcludeFromMigrations());
-        }
-        #endregion
-    }
-
-    public class IdentityUser
+    #region TableExcludeFromMigrations
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public string Id { get; set; }
-        public string UserName { get; set; }
+        modelBuilder.Entity<IdentityUser>()
+            .ToTable("AspNetUsers", t => t.ExcludeFromMigrations());
     }
+    #endregion
+}
+
+public class IdentityUser
+{
+    public string Id { get; set; }
+    public string UserName { get; set; }
 }

--- a/samples/core/Modeling/EntityTypes/FluentAPI/TableName.cs
+++ b/samples/core/Modeling/EntityTypes/FluentAPI/TableName.cs
@@ -1,23 +1,22 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityTypes.FluentAPI.TableName
+namespace EFModeling.EntityTypes.FluentAPI.TableName;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region TableName
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .ToTable("blogs");
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region TableName
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .ToTable("blogs");
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/EntityTypes/FluentAPI/TableNameAndSchema.cs
+++ b/samples/core/Modeling/EntityTypes/FluentAPI/TableNameAndSchema.cs
@@ -1,23 +1,22 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityTypes.FluentAPI.TableNameAndSchema
+namespace EFModeling.EntityTypes.FluentAPI.TableNameAndSchema;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region TableNameAndSchema
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .ToTable("blogs", schema: "blogging");
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region TableNameAndSchema
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .ToTable("blogs", schema: "blogging");
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/EntityTypes/FluentAPI/ViewNameAndSchema.cs
+++ b/samples/core/Modeling/EntityTypes/FluentAPI/ViewNameAndSchema.cs
@@ -1,23 +1,22 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityTypes.FluentAPI.ViewNameAndSchema
+namespace EFModeling.EntityTypes.FluentAPI.ViewNameAndSchema;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            #region ViewNameAndSchema
-            modelBuilder.Entity<Blog>()
-                .ToView("blogsView", schema: "blogging");
-            #endregion
-        }
-    }
-
-    public class Blog
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        #region ViewNameAndSchema
+        modelBuilder.Entity<Blog>()
+            .ToView("blogsView", schema: "blogging");
+        #endregion
     }
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/EntityTypes/Program.cs
+++ b/samples/core/Modeling/EntityTypes/Program.cs
@@ -1,19 +1,19 @@
 ﻿using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.EntityTypes
-{
-    internal class Program
-    {
-        private static void Main(string[] args)
-        {
-            using (var context = new MyContextWithFunctionMapping())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+namespace EFModeling.EntityTypes;
 
-                context.Database.ExecuteSqlRaw(
-                    @"CREATE FUNCTION dbo.BlogsWithMultiplePosts()
+internal class Program
+{
+    private static void Main(string[] args)
+    {
+        using (var context = new MyContextWithFunctionMapping())
+        {
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+
+            context.Database.ExecuteSqlRaw(
+                @"CREATE FUNCTION dbo.BlogsWithMultiplePosts()
                         RETURNS TABLE
                         AS
                         RETURN
@@ -25,13 +25,12 @@ namespace EFModeling.EntityTypes
                             HAVING COUNT(p.BlogId) > 1
                         )");
 
-                #region ToFunctionQuery
-                var query = from b in context.Set<BlogWithMultiplePosts>()
-                            where b.PostCount > 3
-                            select new { b.Url, b.PostCount };
-                #endregion
-                var result = query.ToList();
-            }
+            #region ToFunctionQuery
+            var query = from b in context.Set<BlogWithMultiplePosts>()
+                        where b.PostCount > 3
+                        select new { b.Url, b.PostCount };
+            #endregion
+            var result = query.ToList();
         }
     }
 }

--- a/samples/core/Modeling/GeneratedProperties/DataAnnotations/ValueGeneratedNever.cs
+++ b/samples/core/Modeling/GeneratedProperties/DataAnnotations/ValueGeneratedNever.cs
@@ -1,20 +1,19 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.GeneratedProperties.DataAnnotations.ValueGeneratedNever
+namespace EFModeling.GeneratedProperties.DataAnnotations.ValueGeneratedNever;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
-
-    #region ValueGeneratedNever
-    public class Blog
-    {
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        public int BlogId { get; set; }
-
-        public string Url { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region ValueGeneratedNever
+public class Blog
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public int BlogId { get; set; }
+
+    public string Url { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/GeneratedProperties/DataAnnotations/ValueGeneratedOnAdd.cs
+++ b/samples/core/Modeling/GeneratedProperties/DataAnnotations/ValueGeneratedOnAdd.cs
@@ -2,21 +2,20 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.GeneratedProperties.DataAnnotations.ValueGeneratedOnAdd
+namespace EFModeling.GeneratedProperties.DataAnnotations.ValueGeneratedOnAdd;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
-
-    #region ValueGeneratedOnAdd
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public DateTime Inserted { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region ValueGeneratedOnAdd
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public DateTime Inserted { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/GeneratedProperties/DataAnnotations/ValueGeneratedOnAddOrUpdate.cs
+++ b/samples/core/Modeling/GeneratedProperties/DataAnnotations/ValueGeneratedOnAddOrUpdate.cs
@@ -2,21 +2,20 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.GeneratedProperties.DataAnnotations.ValueGeneratedOnAddOrUpdate
+namespace EFModeling.GeneratedProperties.DataAnnotations.ValueGeneratedOnAddOrUpdate;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
-
-    #region ValueGeneratedOnAddOrUpdate
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
-        public DateTime LastUpdated { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region ValueGeneratedOnAddOrUpdate
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
+    public DateTime LastUpdated { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/GeneratedProperties/FluentAPI/ComputedColumn.cs
+++ b/samples/core/Modeling/GeneratedProperties/FluentAPI/ComputedColumn.cs
@@ -1,33 +1,32 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.GeneratedProperties.FluentAPI.ComputedColumn
+namespace EFModeling.GeneratedProperties.FluentAPI.ComputedColumn;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
+    public DbSet<Person> People { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Person> People { get; set; }
+        #region DefaultComputedColumn
+        modelBuilder.Entity<Person>()
+            .Property(p => p.DisplayName)
+            .HasComputedColumnSql("[LastName] + ', ' + [FirstName]");
+        #endregion
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            #region DefaultComputedColumn
-            modelBuilder.Entity<Person>()
-                .Property(p => p.DisplayName)
-                .HasComputedColumnSql("[LastName] + ', ' + [FirstName]");
-            #endregion
-
-            #region StoredComputedColumn
-            modelBuilder.Entity<Person>()
-                .Property(p => p.NameLength)
-                .HasComputedColumnSql("LEN([LastName]) + LEN([FirstName])", stored: true);
-            #endregion
-        }
+        #region StoredComputedColumn
+        modelBuilder.Entity<Person>()
+            .Property(p => p.NameLength)
+            .HasComputedColumnSql("LEN([LastName]) + LEN([FirstName])", stored: true);
+        #endregion
     }
+}
 
-    public class Person
-    {
-        public int PersonId { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public string DisplayName { get; set; }
-        public int NameLength { get; set; }
-    }
+public class Person
+{
+    public int PersonId { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public string DisplayName { get; set; }
+    public int NameLength { get; set; }
 }

--- a/samples/core/Modeling/GeneratedProperties/FluentAPI/DefaultValue.cs
+++ b/samples/core/Modeling/GeneratedProperties/FluentAPI/DefaultValue.cs
@@ -1,25 +1,24 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.GeneratedProperties.FluentAPI.DefaultValue
+namespace EFModeling.GeneratedProperties.FluentAPI.DefaultValue;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region DefaultValue
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property(b => b.Rating)
-                .HasDefaultValue(3);
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region DefaultValue
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public int Rating { get; set; }
+        modelBuilder.Entity<Blog>()
+            .Property(b => b.Rating)
+            .HasDefaultValue(3);
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public int Rating { get; set; }
 }

--- a/samples/core/Modeling/GeneratedProperties/FluentAPI/DefaultValueSql.cs
+++ b/samples/core/Modeling/GeneratedProperties/FluentAPI/DefaultValueSql.cs
@@ -1,26 +1,25 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.GeneratedProperties.FluentAPI.DefaultValueSql
+namespace EFModeling.GeneratedProperties.FluentAPI.DefaultValueSql;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region DefaultValueSql
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property(b => b.Created)
-                .HasDefaultValueSql("getdate()");
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region DefaultValueSql
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public DateTime Created { get; set; }
+        modelBuilder.Entity<Blog>()
+            .Property(b => b.Created)
+            .HasDefaultValueSql("getdate()");
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public DateTime Created { get; set; }
 }

--- a/samples/core/Modeling/GeneratedProperties/FluentAPI/ValueGeneratedNever.cs
+++ b/samples/core/Modeling/GeneratedProperties/FluentAPI/ValueGeneratedNever.cs
@@ -1,24 +1,23 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.GeneratedProperties.FluentAPI.ValueGeneratedNever
+namespace EFModeling.GeneratedProperties.FluentAPI.ValueGeneratedNever;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region ValueGeneratedNever
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property(b => b.BlogId)
-                .ValueGeneratedNever();
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region ValueGeneratedNever
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .Property(b => b.BlogId)
+            .ValueGeneratedNever();
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/GeneratedProperties/FluentAPI/ValueGeneratedOnAdd.cs
+++ b/samples/core/Modeling/GeneratedProperties/FluentAPI/ValueGeneratedOnAdd.cs
@@ -1,26 +1,25 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.GeneratedProperties.FluentAPI.ValueGeneratedOnAdd
+namespace EFModeling.GeneratedProperties.FluentAPI.ValueGeneratedOnAdd;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region ValueGeneratedOnAdd
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property(b => b.Inserted)
-                .ValueGeneratedOnAdd();
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region ValueGeneratedOnAdd
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public DateTime Inserted { get; set; }
+        modelBuilder.Entity<Blog>()
+            .Property(b => b.Inserted)
+            .ValueGeneratedOnAdd();
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public DateTime Inserted { get; set; }
 }

--- a/samples/core/Modeling/GeneratedProperties/FluentAPI/ValueGeneratedOnAddOrUpdate.cs
+++ b/samples/core/Modeling/GeneratedProperties/FluentAPI/ValueGeneratedOnAddOrUpdate.cs
@@ -1,26 +1,25 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.GeneratedProperties.FluentAPI.ValueGeneratedOnAddOrUpdate
+namespace EFModeling.GeneratedProperties.FluentAPI.ValueGeneratedOnAddOrUpdate;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region ValueGeneratedOnAddOrUpdate
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property(b => b.LastUpdated)
-                .ValueGeneratedOnAddOrUpdate();
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region ValueGeneratedOnAddOrUpdate
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public DateTime LastUpdated { get; set; }
+        modelBuilder.Entity<Blog>()
+            .Property(b => b.LastUpdated)
+            .ValueGeneratedOnAddOrUpdate();
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public DateTime LastUpdated { get; set; }
 }

--- a/samples/core/Modeling/GeneratedProperties/FluentAPI/ValueGeneratedOnAddOrUpdateWithPropertySaveBehavior.cs
+++ b/samples/core/Modeling/GeneratedProperties/FluentAPI/ValueGeneratedOnAddOrUpdateWithPropertySaveBehavior.cs
@@ -2,26 +2,25 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 
-namespace EFModeling.GeneratedProperties.FluentAPI.ValueGeneratedOnAddOrUpdateWithPropertySaveBehavior
+namespace EFModeling.GeneratedProperties.FluentAPI.ValueGeneratedOnAddOrUpdateWithPropertySaveBehavior;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region ValueGeneratedOnAddOrUpdateWithPropertySaveBehavior
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>().Property(b => b.LastUpdated)
-                .ValueGeneratedOnAddOrUpdate()
-                .Metadata.SetAfterSaveBehavior(PropertySaveBehavior.Save);
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region ValueGeneratedOnAddOrUpdateWithPropertySaveBehavior
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public DateTime LastUpdated { get; set; }
+        modelBuilder.Entity<Blog>().Property(b => b.LastUpdated)
+            .ValueGeneratedOnAddOrUpdate()
+            .Metadata.SetAfterSaveBehavior(PropertySaveBehavior.Save);
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public DateTime LastUpdated { get; set; }
 }

--- a/samples/core/Modeling/GeneratedProperties/Program.cs
+++ b/samples/core/Modeling/GeneratedProperties/Program.cs
@@ -1,9 +1,8 @@
-namespace EFModeling.GeneratedProperties
+namespace EFModeling.GeneratedProperties;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
-        {
-        }
     }
 }

--- a/samples/core/Modeling/IndexesAndConstraints/DataAnnotations/Index.cs
+++ b/samples/core/Modeling/IndexesAndConstraints/DataAnnotations/Index.cs
@@ -1,18 +1,17 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.IndexesAndConstraints.DataAnnotations.Index
-{
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
+namespace EFModeling.IndexesAndConstraints.DataAnnotations.Index;
 
-    #region Index
-    [Index(nameof(Url))]
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-    }
-    #endregion
+internal class MyContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region Index
+[Index(nameof(Url))]
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/IndexesAndConstraints/DataAnnotations/IndexComposite.cs
+++ b/samples/core/Modeling/IndexesAndConstraints/DataAnnotations/IndexComposite.cs
@@ -1,19 +1,18 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.IndexesAndConstraints.DataAnnotations.IndexComposite
-{
-    internal class MyContext : DbContext
-    {
-        public DbSet<Person> People { get; set; }
-    }
+namespace EFModeling.IndexesAndConstraints.DataAnnotations.IndexComposite;
 
-    #region Composite
-    [Index(nameof(FirstName), nameof(LastName))]
-    public class Person
-    {
-        public int PersonId { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-    }
-    #endregion
+internal class MyContext : DbContext
+{
+    public DbSet<Person> People { get; set; }
 }
+
+#region Composite
+[Index(nameof(FirstName), nameof(LastName))]
+public class Person
+{
+    public int PersonId { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/IndexesAndConstraints/DataAnnotations/IndexName.cs
+++ b/samples/core/Modeling/IndexesAndConstraints/DataAnnotations/IndexName.cs
@@ -1,18 +1,17 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.IndexesAndConstraints.DataAnnotations.IndexName
-{
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
+namespace EFModeling.IndexesAndConstraints.DataAnnotations.IndexName;
 
-    #region IndexName
-    [Index(nameof(Url), Name = "Index_Url")]
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-    }
-    #endregion
+internal class MyContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region IndexName
+[Index(nameof(Url), Name = "Index_Url")]
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/IndexesAndConstraints/DataAnnotations/IndexUnique.cs
+++ b/samples/core/Modeling/IndexesAndConstraints/DataAnnotations/IndexUnique.cs
@@ -1,18 +1,17 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.IndexesAndConstraints.DataAnnotations.IndexUnique
-{
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-    }
+namespace EFModeling.IndexesAndConstraints.DataAnnotations.IndexUnique;
 
-    #region IndexUnique
-    [Index(nameof(Url), IsUnique = true)]
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-    }
-    #endregion
+internal class MyContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
 }
+
+#region IndexUnique
+[Index(nameof(Url), IsUnique = true)]
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/IndexesAndConstraints/FluentAPI/CheckConstraint.cs
+++ b/samples/core/Modeling/IndexesAndConstraints/FluentAPI/CheckConstraint.cs
@@ -1,24 +1,23 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.IndexesAndConstraints.FluentAPI.CheckConstraint
+namespace EFModeling.IndexesAndConstraints.FluentAPI.CheckConstraint;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Product> Products { get; set; }
+    public DbSet<Product> Products { get; set; }
 
-        #region CheckConstraint
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Product>()
-                .HasCheckConstraint("CK_Prices", "[Price] > [DiscountedPrice]", c => c.HasName("CK_Product_Prices"));
-        }
-        #endregion
-    }
-
-    public class Product
+    #region CheckConstraint
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int Id { get; set; }
-        public decimal Price { get; set; }
-        public decimal DiscountedPrice { get; set; }
+        modelBuilder.Entity<Product>()
+            .HasCheckConstraint("CK_Prices", "[Price] > [DiscountedPrice]", c => c.HasName("CK_Product_Prices"));
     }
+    #endregion
+}
+
+public class Product
+{
+    public int Id { get; set; }
+    public decimal Price { get; set; }
+    public decimal DiscountedPrice { get; set; }
 }

--- a/samples/core/Modeling/IndexesAndConstraints/FluentAPI/Index.cs
+++ b/samples/core/Modeling/IndexesAndConstraints/FluentAPI/Index.cs
@@ -1,23 +1,22 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.IndexesAndConstraints.FluentAPI.Index
+namespace EFModeling.IndexesAndConstraints.FluentAPI.Index;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region Index
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasIndex(b => b.Url);
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region Index
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasIndex(b => b.Url);
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/IndexesAndConstraints/FluentAPI/IndexComposite.cs
+++ b/samples/core/Modeling/IndexesAndConstraints/FluentAPI/IndexComposite.cs
@@ -1,24 +1,23 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.IndexesAndConstraints.FluentAPI.IndexComposite
+namespace EFModeling.IndexesAndConstraints.FluentAPI.IndexComposite;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Person> People { get; set; }
+    public DbSet<Person> People { get; set; }
 
-        #region Composite
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Person>()
-                .HasIndex(p => new { p.FirstName, p.LastName });
-        }
-        #endregion
-    }
-
-    public class Person
+    #region Composite
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int PersonId { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
+        modelBuilder.Entity<Person>()
+            .HasIndex(p => new { p.FirstName, p.LastName });
     }
+    #endregion
+}
+
+public class Person
+{
+    public int PersonId { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
 }

--- a/samples/core/Modeling/IndexesAndConstraints/FluentAPI/IndexFilter.cs
+++ b/samples/core/Modeling/IndexesAndConstraints/FluentAPI/IndexFilter.cs
@@ -1,24 +1,23 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.IndexesAndConstraints.FluentAPI.IndexFilter
+namespace EFModeling.IndexesAndConstraints.FluentAPI.IndexFilter;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region IndexFilter
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasIndex(b => b.Url)
-                .HasFilter("[Url] IS NOT NULL");
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region IndexFilter
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasIndex(b => b.Url)
+            .HasFilter("[Url] IS NOT NULL");
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/IndexesAndConstraints/FluentAPI/IndexInclude.cs
+++ b/samples/core/Modeling/IndexesAndConstraints/FluentAPI/IndexInclude.cs
@@ -1,28 +1,27 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.IndexesAndConstraints.FluentAPI.IndexInclude
+namespace EFModeling.IndexesAndConstraints.FluentAPI.IndexInclude;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Post> Posts { get; set; }
+    public DbSet<Post> Posts { get; set; }
 
-        #region IndexInclude
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Post>()
-                .HasIndex(p => p.Url)
-                .IncludeProperties(
-                    p => new { p.Title, p.PublishedOn });
-        }
-        #endregion
-    }
-
-    public class Post
+    #region IndexInclude
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int PostId { get; set; }
-        public string Url { get; set; }
-        public string Title { get; set; }
-        public DateTime PublishedOn { get; set; }
+        modelBuilder.Entity<Post>()
+            .HasIndex(p => p.Url)
+            .IncludeProperties(
+                p => new { p.Title, p.PublishedOn });
     }
+    #endregion
+}
+
+public class Post
+{
+    public int PostId { get; set; }
+    public string Url { get; set; }
+    public string Title { get; set; }
+    public DateTime PublishedOn { get; set; }
 }

--- a/samples/core/Modeling/IndexesAndConstraints/FluentAPI/IndexName.cs
+++ b/samples/core/Modeling/IndexesAndConstraints/FluentAPI/IndexName.cs
@@ -1,24 +1,23 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.IndexesAndConstraints.FluentAPI.IndexName
+namespace EFModeling.IndexesAndConstraints.FluentAPI.IndexName;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region IndexName
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasIndex(b => b.Url)
-                .HasDatabaseName("Index_Url");
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region IndexName
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasIndex(b => b.Url)
+            .HasDatabaseName("Index_Url");
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/IndexesAndConstraints/FluentAPI/IndexNoFilter.cs
+++ b/samples/core/Modeling/IndexesAndConstraints/FluentAPI/IndexNoFilter.cs
@@ -1,25 +1,24 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.IndexesAndConstraints.FluentAPI.IndexNoFilter
+namespace EFModeling.IndexesAndConstraints.FluentAPI.IndexNoFilter;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region IndexNoFilter
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasIndex(b => b.Url)
-                .IsUnique()
-                .HasFilter(null);
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region IndexNoFilter
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasIndex(b => b.Url)
+            .IsUnique()
+            .HasFilter(null);
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/IndexesAndConstraints/FluentAPI/IndexUnique.cs
+++ b/samples/core/Modeling/IndexesAndConstraints/FluentAPI/IndexUnique.cs
@@ -1,24 +1,23 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.IndexesAndConstraints.FluentAPI.IndexUnique
+namespace EFModeling.IndexesAndConstraints.FluentAPI.IndexUnique;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region IndexUnique
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasIndex(b => b.Url)
-                .IsUnique();
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region IndexUnique
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasIndex(b => b.Url)
+            .IsUnique();
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/IndexesAndConstraints/Program.cs
+++ b/samples/core/Modeling/IndexesAndConstraints/Program.cs
@@ -1,9 +1,8 @@
-namespace EFModeling.IndexesAndConstraints
+namespace EFModeling.IndexesAndConstraints;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
-        {
-        }
     }
 }

--- a/samples/core/Modeling/Inheritance/FluentAPI/DiscriminatorConfiguration.cs
+++ b/samples/core/Modeling/Inheritance/FluentAPI/DiscriminatorConfiguration.cs
@@ -1,30 +1,29 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Inheritance.FluentAPI.DiscriminatorConfiguration
+namespace EFModeling.Inheritance.FluentAPI.DiscriminatorConfiguration;
+
+public class MyContext : DbContext
 {
-    public class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region DiscriminatorConfiguration
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasDiscriminator<string>("blog_type")
-                .HasValue<Blog>("blog_base")
-                .HasValue<RssBlog>("blog_rss");
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region DiscriminatorConfiguration
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasDiscriminator<string>("blog_type")
+            .HasValue<Blog>("blog_base")
+            .HasValue<RssBlog>("blog_rss");
     }
+    #endregion
+}
 
-    public class RssBlog : Blog
-    {
-        public string RssUrl { get; set; }
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+}
+
+public class RssBlog : Blog
+{
+    public string RssUrl { get; set; }
 }

--- a/samples/core/Modeling/Inheritance/FluentAPI/DiscriminatorMappingIncomplete.cs
+++ b/samples/core/Modeling/Inheritance/FluentAPI/DiscriminatorMappingIncomplete.cs
@@ -1,29 +1,28 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Inheritance.FluentAPI.DiscriminatorMappingIncomplete
+namespace EFModeling.Inheritance.FluentAPI.DiscriminatorMappingIncomplete;
+
+public class MyContext : DbContext
 {
-    public class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region DiscriminatorMappingIncomplete
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasDiscriminator()
-                .IsComplete(false);
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region DiscriminatorMappingIncomplete
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasDiscriminator()
+            .IsComplete(false);
     }
+    #endregion
+}
 
-    public class RssBlog : Blog
-    {
-        public string RssUrl { get; set; }
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+}
+
+public class RssBlog : Blog
+{
+    public string RssUrl { get; set; }
 }

--- a/samples/core/Modeling/Inheritance/FluentAPI/DiscriminatorPropertyConfiguration.cs
+++ b/samples/core/Modeling/Inheritance/FluentAPI/DiscriminatorPropertyConfiguration.cs
@@ -1,29 +1,28 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Inheritance.FluentAPI.DiscriminatorPropertyConfiguration
+namespace EFModeling.Inheritance.FluentAPI.DiscriminatorPropertyConfiguration;
+
+public class MyContext : DbContext
 {
-    public class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region DiscriminatorPropertyConfiguration
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property("Discriminator")
-                .HasMaxLength(200);
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region DiscriminatorPropertyConfiguration
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .Property("Discriminator")
+            .HasMaxLength(200);
     }
+    #endregion
+}
 
-    public class RssBlog : Blog
-    {
-        public string RssUrl { get; set; }
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+}
+
+public class RssBlog : Blog
+{
+    public string RssUrl { get; set; }
 }

--- a/samples/core/Modeling/Inheritance/FluentAPI/NonShadowDiscriminator.cs
+++ b/samples/core/Modeling/Inheritance/FluentAPI/NonShadowDiscriminator.cs
@@ -1,34 +1,33 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Inheritance.FluentAPI.NonShadowDiscriminator
+namespace EFModeling.Inheritance.FluentAPI.NonShadowDiscriminator;
+
+public class MyContext : DbContext
 {
-    public class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+
+    #region NonShadowDiscriminator
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasDiscriminator(b => b.BlogType);
 
-        #region NonShadowDiscriminator
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasDiscriminator(b => b.BlogType);
-
-            modelBuilder.Entity<Blog>()
-                .Property(e => e.BlogType)
-                .HasMaxLength(200)
-                .HasColumnName("blog_type");
-        }
-        #endregion
+        modelBuilder.Entity<Blog>()
+            .Property(e => e.BlogType)
+            .HasMaxLength(200)
+            .HasColumnName("blog_type");
     }
+    #endregion
+}
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public string BlogType { get; set; }
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public string BlogType { get; set; }
+}
 
-    public class RssBlog : Blog
-    {
-        public string RssUrl { get; set; }
-    }
+public class RssBlog : Blog
+{
+    public string RssUrl { get; set; }
 }

--- a/samples/core/Modeling/Inheritance/FluentAPI/SharedTPHColumns.cs
+++ b/samples/core/Modeling/Inheritance/FluentAPI/SharedTPHColumns.cs
@@ -1,37 +1,36 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Inheritance.FluentAPI.SharedTPHColumns
+namespace EFModeling.Inheritance.FluentAPI.SharedTPHColumns;
+
+#region SharedTPHColumns
+public class MyContext : DbContext
 {
-    #region SharedTPHColumns
-    public class MyContext : DbContext
+    public DbSet<BlogBase> Blogs { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<BlogBase> Blogs { get; set; }
+        modelBuilder.Entity<Blog>()
+            .Property(b => b.Url)
+            .HasColumnName("Url");
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property(b => b.Url)
-                .HasColumnName("Url");
-
-            modelBuilder.Entity<RssBlog>()
-                .Property(b => b.Url)
-                .HasColumnName("Url");
-        }
+        modelBuilder.Entity<RssBlog>()
+            .Property(b => b.Url)
+            .HasColumnName("Url");
     }
-
-    public abstract class BlogBase
-    {
-        public int BlogId { get; set; }
-    }
-
-    public class Blog : BlogBase
-    {
-        public string Url { get; set; }
-    }
-
-    public class RssBlog : BlogBase
-    {
-        public string Url { get; set; }
-    }
-    #endregion
 }
+
+public abstract class BlogBase
+{
+    public int BlogId { get; set; }
+}
+
+public class Blog : BlogBase
+{
+    public string Url { get; set; }
+}
+
+public class RssBlog : BlogBase
+{
+    public string Url { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Inheritance/FluentAPI/TPTConfiguration.cs
+++ b/samples/core/Modeling/Inheritance/FluentAPI/TPTConfiguration.cs
@@ -2,52 +2,51 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 
-namespace EFModeling.Inheritance.FluentAPI.TPTConfiguration
+namespace EFModeling.Inheritance.FluentAPI.TPTConfiguration;
+
+public class MyContext : DbContext
 {
-    public class MyContext : DbContext
+    public MyContext(DbContextOptions<MyContext> options)
+        : base(options)
     {
-        public MyContext(DbContextOptions<MyContext> options)
-            : base(options)
+    }
+
+    public DbSet<Blog> Blogs { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        #region TPTConfiguration
+        modelBuilder.Entity<Blog>().ToTable("Blogs");
+        modelBuilder.Entity<RssBlog>().ToTable("RssBlogs");
+        #endregion
+
+        #region Metadata
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
         {
-        }
+            var tableIdentifier = StoreObjectIdentifier.Create(entityType, StoreObjectType.Table);
 
-        public DbSet<Blog> Blogs { get; set; }
+            Console.WriteLine($"{entityType.DisplayName()}\t\t{tableIdentifier}");
+            Console.WriteLine(" Property\tColumn");
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            #region TPTConfiguration
-            modelBuilder.Entity<Blog>().ToTable("Blogs");
-            modelBuilder.Entity<RssBlog>().ToTable("RssBlogs");
-            #endregion
-
-            #region Metadata
-            foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+            foreach (var property in entityType.GetProperties())
             {
-                var tableIdentifier = StoreObjectIdentifier.Create(entityType, StoreObjectType.Table);
-
-                Console.WriteLine($"{entityType.DisplayName()}\t\t{tableIdentifier}");
-                Console.WriteLine(" Property\tColumn");
-
-                foreach (var property in entityType.GetProperties())
-                {
-                    var columnName = property.GetColumnName(tableIdentifier.Value);
-                    Console.WriteLine($" {property.Name,-10}\t{columnName}");
-                }
-
-                Console.WriteLine();
+                var columnName = property.GetColumnName(tableIdentifier.Value);
+                Console.WriteLine($" {property.Name,-10}\t{columnName}");
             }
-            #endregion
+
+            Console.WriteLine();
         }
+        #endregion
     }
+}
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+}
 
-    public class RssBlog : Blog
-    {
-        public string RssUrl { get; set; }
-    }
+public class RssBlog : Blog
+{
+    public string RssUrl { get; set; }
 }

--- a/samples/core/Modeling/Inheritance/InheritanceDbSets.cs
+++ b/samples/core/Modeling/Inheritance/InheritanceDbSets.cs
@@ -1,23 +1,22 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Inheritance.InheritanceDbSets
+namespace EFModeling.Inheritance.InheritanceDbSets;
+
+#region InheritanceDbSets
+internal class MyContext : DbContext
 {
-    #region InheritanceDbSets
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<RssBlog> RssBlogs { get; set; }
-    }
-
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-    }
-
-    public class RssBlog : Blog
-    {
-        public string RssUrl { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<RssBlog> RssBlogs { get; set; }
 }
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+}
+
+public class RssBlog : Blog
+{
+    public string RssUrl { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Inheritance/Program.cs
+++ b/samples/core/Modeling/Inheritance/Program.cs
@@ -1,9 +1,8 @@
-namespace EFModeling.Inheritance
+namespace EFModeling.Inheritance;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
-        {
-        }
     }
 }

--- a/samples/core/Modeling/KeylessEntityTypes/DataAnnotations/Keyless.cs
+++ b/samples/core/Modeling/KeylessEntityTypes/DataAnnotations/Keyless.cs
@@ -1,18 +1,17 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.KeylessEntityTypes.DataAnnotations.Keyless
-{
-    internal class BlogsContext : DbContext
-    {
-        public DbSet<BlogPostsCount> BlogPostCounts { get; set; }
-    }
+namespace EFModeling.KeylessEntityTypes.DataAnnotations.Keyless;
 
-    #region Keyless
-    [Keyless]
-    public class BlogPostsCount
-    {
-        public string BlogName { get; set; }
-        public int PostCount { get; set; }
-    }
-    #endregion
+internal class BlogsContext : DbContext
+{
+    public DbSet<BlogPostsCount> BlogPostCounts { get; set; }
 }
+
+#region Keyless
+[Keyless]
+public class BlogPostsCount
+{
+    public string BlogName { get; set; }
+    public int PostCount { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/KeylessEntityTypes/FluentAPI/Keyless.cs
+++ b/samples/core/Modeling/KeylessEntityTypes/FluentAPI/Keyless.cs
@@ -1,23 +1,22 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.KeylessEntityTypes.FluentAPI.Keyless
+namespace EFModeling.KeylessEntityTypes.FluentAPI.Keyless;
+
+internal class BlogsContext : DbContext
 {
-    internal class BlogsContext : DbContext
-    {
-        public DbSet<BlogPostsCount> BlogPostCounts { get; set; }
+    public DbSet<BlogPostsCount> BlogPostCounts { get; set; }
 
-        #region Keyless
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<BlogPostsCount>()
-                .HasNoKey();
-        }
-        #endregion
-    }
-
-    public class BlogPostsCount
+    #region Keyless
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public string BlogName { get; set; }
-        public int PostCount { get; set; }
+        modelBuilder.Entity<BlogPostsCount>()
+            .HasNoKey();
     }
+    #endregion
+}
+
+public class BlogPostsCount
+{
+    public string BlogName { get; set; }
+    public int PostCount { get; set; }
 }

--- a/samples/core/Modeling/Keys/AlternateKey.cs
+++ b/samples/core/Modeling/Keys/AlternateKey.cs
@@ -1,40 +1,39 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Keys.AlternateKey
+namespace EFModeling.Keys.AlternateKey;
+
+#region AlternateKey
+internal class MyContext : DbContext
 {
-    #region AlternateKey
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Post>()
-                .HasOne(p => p.Blog)
-                .WithMany(b => b.Posts)
-                .HasForeignKey(p => p.BlogUrl)
-                .HasPrincipalKey(b => b.Url);
-        }
+        modelBuilder.Entity<Post>()
+            .HasOne(p => p.Blog)
+            .WithMany(b => b.Posts)
+            .HasForeignKey(p => p.BlogUrl)
+            .HasPrincipalKey(b => b.Url);
     }
-
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        public List<Post> Posts { get; set; }
-    }
-
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public string BlogUrl { get; set; }
-        public Blog Blog { get; set; }
-    }
-    #endregion
 }
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public List<Post> Posts { get; set; }
+}
+
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public string BlogUrl { get; set; }
+    public Blog Blog { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Keys/DataAnnotations/KeySingle.cs
+++ b/samples/core/Modeling/Keys/DataAnnotations/KeySingle.cs
@@ -1,21 +1,20 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Keys.DataAnnotations.KeySingle
+namespace EFModeling.Keys.DataAnnotations.KeySingle;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Car> Cars { get; set; }
-    }
-
-    #region KeySingle
-    internal class Car
-    {
-        [Key]
-        public string LicensePlate { get; set; }
-
-        public string Make { get; set; }
-        public string Model { get; set; }
-    }
-    #endregion
+    public DbSet<Car> Cars { get; set; }
 }
+
+#region KeySingle
+internal class Car
+{
+    [Key]
+    public string LicensePlate { get; set; }
+
+    public string Make { get; set; }
+    public string Model { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Keys/FluentAPI/AlternateKeyComposite.cs
+++ b/samples/core/Modeling/Keys/FluentAPI/AlternateKeyComposite.cs
@@ -1,26 +1,25 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Keys.FluentAPI.AlternateKeyComposite
+namespace EFModeling.Keys.FluentAPI.AlternateKeyComposite;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Car> Cars { get; set; }
+    public DbSet<Car> Cars { get; set; }
 
-        #region AlternateKeyComposite
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Car>()
-                .HasAlternateKey(c => new { c.State, c.LicensePlate });
-        }
-        #endregion
-    }
-
-    internal class Car
+    #region AlternateKeyComposite
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int CarId { get; set; }
-        public string State { get; set; }
-        public string LicensePlate { get; set; }
-        public string Make { get; set; }
-        public string Model { get; set; }
+        modelBuilder.Entity<Car>()
+            .HasAlternateKey(c => new { c.State, c.LicensePlate });
     }
+    #endregion
+}
+
+internal class Car
+{
+    public int CarId { get; set; }
+    public string State { get; set; }
+    public string LicensePlate { get; set; }
+    public string Make { get; set; }
+    public string Model { get; set; }
 }

--- a/samples/core/Modeling/Keys/FluentAPI/AlternateKeyName.cs
+++ b/samples/core/Modeling/Keys/FluentAPI/AlternateKeyName.cs
@@ -1,26 +1,25 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Keys.FluentAPI.AlternateKeyName
+namespace EFModeling.Keys.FluentAPI.AlternateKeyName;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Car> Cars { get; set; }
+    public DbSet<Car> Cars { get; set; }
 
-        #region AlternateKeyName
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Car>()
-                .HasAlternateKey(c => c.LicensePlate)
-                .HasName("AlternateKey_LicensePlate");
-        }
-        #endregion
-    }
-
-    internal class Car
+    #region AlternateKeyName
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int CarId { get; set; }
-        public string LicensePlate { get; set; }
-        public string Make { get; set; }
-        public string Model { get; set; }
+        modelBuilder.Entity<Car>()
+            .HasAlternateKey(c => c.LicensePlate)
+            .HasName("AlternateKey_LicensePlate");
     }
+    #endregion
+}
+
+internal class Car
+{
+    public int CarId { get; set; }
+    public string LicensePlate { get; set; }
+    public string Make { get; set; }
+    public string Model { get; set; }
 }

--- a/samples/core/Modeling/Keys/FluentAPI/AlternateKeySingle.cs
+++ b/samples/core/Modeling/Keys/FluentAPI/AlternateKeySingle.cs
@@ -1,25 +1,24 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Keys.FluentAPI.AlternateKeySingle
+namespace EFModeling.Keys.FluentAPI.AlternateKeySingle;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Car> Cars { get; set; }
+    public DbSet<Car> Cars { get; set; }
 
-        #region AlternateKeySingle
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Car>()
-                .HasAlternateKey(c => c.LicensePlate);
-        }
-        #endregion
-    }
-
-    internal class Car
+    #region AlternateKeySingle
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int CarId { get; set; }
-        public string LicensePlate { get; set; }
-        public string Make { get; set; }
-        public string Model { get; set; }
+        modelBuilder.Entity<Car>()
+            .HasAlternateKey(c => c.LicensePlate);
     }
+    #endregion
+}
+
+internal class Car
+{
+    public int CarId { get; set; }
+    public string LicensePlate { get; set; }
+    public string Make { get; set; }
+    public string Model { get; set; }
 }

--- a/samples/core/Modeling/Keys/FluentAPI/KeyComposite.cs
+++ b/samples/core/Modeling/Keys/FluentAPI/KeyComposite.cs
@@ -1,26 +1,25 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Keys.FluentAPI.KeyComposite
+namespace EFModeling.Keys.FluentAPI.KeyComposite;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
+    public DbSet<Car> Cars { get; set; }
+
+    #region KeyComposite
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Car> Cars { get; set; }
-
-        #region KeyComposite
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Car>()
-                .HasKey(c => new { c.State, c.LicensePlate });
-        }
-        #endregion
+        modelBuilder.Entity<Car>()
+            .HasKey(c => new { c.State, c.LicensePlate });
     }
+    #endregion
+}
 
-    internal class Car
-    {
-        public string State { get; set; }
-        public string LicensePlate { get; set; }
+internal class Car
+{
+    public string State { get; set; }
+    public string LicensePlate { get; set; }
 
-        public string Make { get; set; }
-        public string Model { get; set; }
-    }
+    public string Make { get; set; }
+    public string Model { get; set; }
 }

--- a/samples/core/Modeling/Keys/FluentAPI/KeyName.cs
+++ b/samples/core/Modeling/Keys/FluentAPI/KeyName.cs
@@ -1,24 +1,23 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Keys.FluentAPI.KeyName
+namespace EFModeling.Keys.FluentAPI.KeyName;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        #region KeyName
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasKey(b => b.BlogId)
-                .HasName("PrimaryKey_BlogId");
-        }
-        #endregion
-    }
-
-    public class Blog
+    #region KeyName
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasKey(b => b.BlogId)
+            .HasName("PrimaryKey_BlogId");
     }
+    #endregion
+}
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/Keys/FluentAPI/KeySingle.cs
+++ b/samples/core/Modeling/Keys/FluentAPI/KeySingle.cs
@@ -1,25 +1,24 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Keys.FluentAPI.KeySingle
+namespace EFModeling.Keys.FluentAPI.KeySingle;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
+    public DbSet<Car> Cars { get; set; }
+
+    #region KeySingle
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Car> Cars { get; set; }
-
-        #region KeySingle
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Car>()
-                .HasKey(c => c.LicensePlate);
-        }
-        #endregion
+        modelBuilder.Entity<Car>()
+            .HasKey(c => c.LicensePlate);
     }
+    #endregion
+}
 
-    internal class Car
-    {
-        public string LicensePlate { get; set; }
+internal class Car
+{
+    public string LicensePlate { get; set; }
 
-        public string Make { get; set; }
-        public string Model { get; set; }
-    }
+    public string Make { get; set; }
+    public string Model { get; set; }
 }

--- a/samples/core/Modeling/Keys/KeyId.cs
+++ b/samples/core/Modeling/Keys/KeyId.cs
@@ -1,28 +1,27 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Keys.KeyId
+namespace EFModeling.Keys.KeyId;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Car> Cars { get; set; }
-        public DbSet<Truck> Trucks { get; set; }
-    }
-
-    #region KeyId
-    internal class Car
-    {
-        public string Id { get; set; }
-
-        public string Make { get; set; }
-        public string Model { get; set; }
-    }
-
-    internal class Truck
-    {
-        public string TruckId { get; set; }
-
-        public string Make { get; set; }
-        public string Model { get; set; }
-    }
-    #endregion
+    public DbSet<Car> Cars { get; set; }
+    public DbSet<Truck> Trucks { get; set; }
 }
+
+#region KeyId
+internal class Car
+{
+    public string Id { get; set; }
+
+    public string Make { get; set; }
+    public string Model { get; set; }
+}
+
+internal class Truck
+{
+    public string TruckId { get; set; }
+
+    public string Make { get; set; }
+    public string Model { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Keys/Program.cs
+++ b/samples/core/Modeling/Keys/Program.cs
@@ -1,9 +1,8 @@
-namespace EFModeling.Keys
+namespace EFModeling.Keys;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
-        {
-        }
     }
 }

--- a/samples/core/Modeling/Misc/EntityTypeConfiguration.cs
+++ b/samples/core/Modeling/Misc/EntityTypeConfiguration.cs
@@ -1,39 +1,38 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace EFModeling.Misc.EntityTypeConfiguration
+namespace EFModeling.Misc.EntityTypeConfiguration;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
+        #region ApplyIEntityTypeConfiguration
+        new BlogEntityTypeConfiguration().Configure(modelBuilder.Entity<Blog>());
+        #endregion
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            #region ApplyIEntityTypeConfiguration
-            new BlogEntityTypeConfiguration().Configure(modelBuilder.Entity<Blog>());
-            #endregion
-
-            #region ApplyConfigurationsFromAssembly
-            modelBuilder.ApplyConfigurationsFromAssembly(typeof(BlogEntityTypeConfiguration).Assembly);
-            #endregion
-        }
+        #region ApplyConfigurationsFromAssembly
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(BlogEntityTypeConfiguration).Assembly);
+        #endregion
     }
+}
 
-    #region IEntityTypeConfiguration
-    public class BlogEntityTypeConfiguration : IEntityTypeConfiguration<Blog>
+#region IEntityTypeConfiguration
+public class BlogEntityTypeConfiguration : IEntityTypeConfiguration<Blog>
+{
+    public void Configure(EntityTypeBuilder<Blog> builder)
     {
-        public void Configure(EntityTypeBuilder<Blog> builder)
-        {
-            builder
-                .Property(b => b.Url)
-                .IsRequired();
-        }
+        builder
+            .Property(b => b.Url)
+            .IsRequired();
     }
-    #endregion
+}
+#endregion
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/Misc/Program.cs
+++ b/samples/core/Modeling/Misc/Program.cs
@@ -1,9 +1,8 @@
-namespace EFModeling.Misc
+namespace EFModeling.Misc;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
-        {
-        }
     }
 }

--- a/samples/core/Modeling/OwnedEntities/DetailedOrder.cs
+++ b/samples/core/Modeling/OwnedEntities/DetailedOrder.cs
@@ -1,11 +1,10 @@
-﻿namespace EFModeling.OwnedEntities
+﻿namespace EFModeling.OwnedEntities;
+
+#region DetailedOrder
+public class DetailedOrder
 {
-    #region DetailedOrder
-    public class DetailedOrder
-    {
-        public int Id { get; set; }
-        public OrderDetails OrderDetails { get; set; }
-        public OrderStatus Status { get; set; }
-    }
-    #endregion
+    public int Id { get; set; }
+    public OrderDetails OrderDetails { get; set; }
+    public OrderStatus Status { get; set; }
 }
+#endregion

--- a/samples/core/Modeling/OwnedEntities/Distributor.cs
+++ b/samples/core/Modeling/OwnedEntities/Distributor.cs
@@ -1,12 +1,11 @@
 ﻿using System.Collections.Generic;
 
-namespace EFModeling.OwnedEntities
+namespace EFModeling.OwnedEntities;
+
+#region Distributor
+public class Distributor
 {
-    #region Distributor
-    public class Distributor
-    {
-        public int Id { get; set; }
-        public ICollection<StreetAddress> ShippingCenters { get; set; }
-    }
-    #endregion
+    public int Id { get; set; }
+    public ICollection<StreetAddress> ShippingCenters { get; set; }
 }
+#endregion

--- a/samples/core/Modeling/OwnedEntities/Order.cs
+++ b/samples/core/Modeling/OwnedEntities/Order.cs
@@ -1,10 +1,9 @@
-﻿namespace EFModeling.OwnedEntities
+﻿namespace EFModeling.OwnedEntities;
+
+#region Order
+public class Order
 {
-    #region Order
-    public class Order
-    {
-        public int Id { get; set; }
-        public StreetAddress ShippingAddress { get; set; }
-    }
-    #endregion
+    public int Id { get; set; }
+    public StreetAddress ShippingAddress { get; set; }
 }
+#endregion

--- a/samples/core/Modeling/OwnedEntities/OrderDetails.cs
+++ b/samples/core/Modeling/OwnedEntities/OrderDetails.cs
@@ -1,11 +1,10 @@
-﻿namespace EFModeling.OwnedEntities
+﻿namespace EFModeling.OwnedEntities;
+
+#region OrderDetails
+public class OrderDetails
 {
-    #region OrderDetails
-    public class OrderDetails
-    {
-        public DetailedOrder Order { get; set; }
-        public StreetAddress BillingAddress { get; set; }
-        public StreetAddress ShippingAddress { get; set; }
-    }
-    #endregion
+    public DetailedOrder Order { get; set; }
+    public StreetAddress BillingAddress { get; set; }
+    public StreetAddress ShippingAddress { get; set; }
 }
+#endregion

--- a/samples/core/Modeling/OwnedEntities/OrderStatus.cs
+++ b/samples/core/Modeling/OwnedEntities/OrderStatus.cs
@@ -1,10 +1,9 @@
-﻿namespace EFModeling.OwnedEntities
+﻿namespace EFModeling.OwnedEntities;
+
+#region OrderStatus
+public enum OrderStatus
 {
-    #region OrderStatus
-    public enum OrderStatus
-    {
-        Pending,
-        Shipped
-    }
-    #endregion
+    Pending,
+    Shipped
 }
+#endregion

--- a/samples/core/Modeling/OwnedEntities/OwnedEntityContext.cs
+++ b/samples/core/Modeling/OwnedEntities/OwnedEntityContext.cs
@@ -1,77 +1,76 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.OwnedEntities
+namespace EFModeling.OwnedEntities;
+
+public class OwnedEntityContext : DbContext
 {
-    public class OwnedEntityContext : DbContext
+    public DbSet<Order> Orders { get; set; }
+    public DbSet<DetailedOrder> DetailedOrders { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFOwnedEntity;Trusted_Connection=True");
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Order> Orders { get; set; }
-        public DbSet<DetailedOrder> DetailedOrders { get; set; }
+        #region OwnsOne
+        modelBuilder.Entity<Order>().OwnsOne(p => p.ShippingAddress);
+        #endregion
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFOwnedEntity;Trusted_Connection=True");
+        #region OwnsOneString
+        modelBuilder.Entity<Order>().OwnsOne(typeof(StreetAddress), "ShippingAddress");
+        #endregion
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            #region OwnsOne
-            modelBuilder.Entity<Order>().OwnsOne(p => p.ShippingAddress);
-            #endregion
+        #region ColumnNames
+        modelBuilder.Entity<Order>().OwnsOne(
+            o => o.ShippingAddress,
+            sa =>
+            {
+                sa.Property(p => p.Street).HasColumnName("ShipsToStreet");
+                sa.Property(p => p.City).HasColumnName("ShipsToCity");
+            });
+        #endregion
 
-            #region OwnsOneString
-            modelBuilder.Entity<Order>().OwnsOne(typeof(StreetAddress), "ShippingAddress");
-            #endregion
+        #region Required
+        modelBuilder.Entity<Order>(
+            ob =>
+            {
+                ob.OwnsOne(
+                    o => o.ShippingAddress,
+                    sa =>
+                    {
+                        sa.Property(p => p.Street).IsRequired();
+                        sa.Property(p => p.City).IsRequired();
+                    });
 
-            #region ColumnNames
-            modelBuilder.Entity<Order>().OwnsOne(
-                o => o.ShippingAddress,
-                sa =>
-                {
-                    sa.Property(p => p.Street).HasColumnName("ShipsToStreet");
-                    sa.Property(p => p.City).HasColumnName("ShipsToCity");
-                });
-            #endregion
+                ob.Navigation(o => o.ShippingAddress)
+                    .IsRequired();
+            });
+        #endregion
 
-            #region Required
-            modelBuilder.Entity<Order>(
-                ob =>
-                {
-                    ob.OwnsOne(
-                        o => o.ShippingAddress,
-                        sa =>
-                        {
-                            sa.Property(p => p.Street).IsRequired();
-                            sa.Property(p => p.City).IsRequired();
-                        });
+        #region OwnsOneNested
+        modelBuilder.Entity<DetailedOrder>().OwnsOne(
+            p => p.OrderDetails, od =>
+            {
+                od.WithOwner(d => d.Order);
+                od.Navigation(d => d.Order).UsePropertyAccessMode(PropertyAccessMode.Property);
+                od.OwnsOne(c => c.BillingAddress);
+                od.OwnsOne(c => c.ShippingAddress);
+            });
+        #endregion
 
-                    ob.Navigation(o => o.ShippingAddress)
-                        .IsRequired();
-                });
-            #endregion
+        #region OwnsOneTable
+        modelBuilder.Entity<DetailedOrder>().OwnsOne(p => p.OrderDetails, od => { od.ToTable("OrderDetails"); });
+        #endregion
 
-            #region OwnsOneNested
-            modelBuilder.Entity<DetailedOrder>().OwnsOne(
-                p => p.OrderDetails, od =>
-                {
-                    od.WithOwner(d => d.Order);
-                    od.Navigation(d => d.Order).UsePropertyAccessMode(PropertyAccessMode.Property);
-                    od.OwnsOne(c => c.BillingAddress);
-                    od.OwnsOne(c => c.ShippingAddress);
-                });
-            #endregion
-
-            #region OwnsOneTable
-            modelBuilder.Entity<DetailedOrder>().OwnsOne(p => p.OrderDetails, od => { od.ToTable("OrderDetails"); });
-            #endregion
-
-            #region OwnsMany
-            modelBuilder.Entity<Distributor>().OwnsMany(
-                p => p.ShippingCenters, a =>
-                {
-                    a.WithOwner().HasForeignKey("OwnerId");
-                    a.Property<int>("Id");
-                    a.HasKey("Id");
-                });
-            #endregion
-        }
+        #region OwnsMany
+        modelBuilder.Entity<Distributor>().OwnsMany(
+            p => p.ShippingCenters, a =>
+            {
+                a.WithOwner().HasForeignKey("OwnerId");
+                a.Property<int>("Id");
+                a.HasKey("Id");
+            });
+        #endregion
     }
 }

--- a/samples/core/Modeling/OwnedEntities/Program.cs
+++ b/samples/core/Modeling/OwnedEntities/Program.cs
@@ -1,38 +1,37 @@
 ﻿using System;
 using System.Linq;
 
-namespace EFModeling.OwnedEntities
+namespace EFModeling.OwnedEntities;
+
+public static class Program
 {
-    public static class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
+        using (var context = new OwnedEntityContext())
         {
-            using (var context = new OwnedEntityContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
 
-                context.Add(
-                    new DetailedOrder
+            context.Add(
+                new DetailedOrder
+                {
+                    Status = OrderStatus.Pending,
+                    OrderDetails = new OrderDetails
                     {
-                        Status = OrderStatus.Pending,
-                        OrderDetails = new OrderDetails
-                        {
-                            ShippingAddress = new StreetAddress { City = "London", Street = "221 B Baker St" },
-                            BillingAddress = new StreetAddress { City = "New York", Street = "11 Wall Street" }
-                        }
-                    });
+                        ShippingAddress = new StreetAddress { City = "London", Street = "221 B Baker St" },
+                        BillingAddress = new StreetAddress { City = "New York", Street = "11 Wall Street" }
+                    }
+                });
 
-                context.SaveChanges();
-            }
+            context.SaveChanges();
+        }
 
-            using (var context = new OwnedEntityContext())
-            {
-                #region DetailedOrderQuery
-                var order = context.DetailedOrders.First(o => o.Status == OrderStatus.Pending);
-                Console.WriteLine($"First pending order will ship to: {order.OrderDetails.ShippingAddress.City}");
-                #endregion
-            }
+        using (var context = new OwnedEntityContext())
+        {
+            #region DetailedOrderQuery
+            var order = context.DetailedOrders.First(o => o.Status == OrderStatus.Pending);
+            Console.WriteLine($"First pending order will ship to: {order.OrderDetails.ShippingAddress.City}");
+            #endregion
         }
     }
 }

--- a/samples/core/Modeling/OwnedEntities/StreetAddress.cs
+++ b/samples/core/Modeling/OwnedEntities/StreetAddress.cs
@@ -1,13 +1,12 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.OwnedEntities
+namespace EFModeling.OwnedEntities;
+
+#region StreetAddress
+[Owned]
+public class StreetAddress
 {
-    #region StreetAddress
-    [Owned]
-    public class StreetAddress
-    {
-        public string Street { get; set; }
-        public string City { get; set; }
-    }
-    #endregion
+    public string Street { get; set; }
+    public string City { get; set; }
 }
+#endregion

--- a/samples/core/Modeling/Relationships/DataAnnotations/ForeignKey.cs
+++ b/samples/core/Modeling/Relationships/DataAnnotations/ForeignKey.cs
@@ -2,33 +2,32 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.DataAnnotations.ForeignKey
+namespace EFModeling.Relationships.DataAnnotations.ForeignKey;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-    }
-
-    #region ForeignKey
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        public List<Post> Posts { get; set; }
-    }
-
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int BlogForeignKey { get; set; }
-
-        [ForeignKey("BlogForeignKey")]
-        public Blog Blog { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
 }
+
+#region ForeignKey
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public List<Post> Posts { get; set; }
+}
+
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int BlogForeignKey { get; set; }
+
+    [ForeignKey("BlogForeignKey")]
+    public Blog Blog { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/DataAnnotations/InverseProperty.cs
+++ b/samples/core/Modeling/Relationships/DataAnnotations/InverseProperty.cs
@@ -2,39 +2,38 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.DataAnnotations.InverseProperty
+namespace EFModeling.Relationships.DataAnnotations.InverseProperty;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<User> Users { get; set; }
-    }
-
-    #region InverseProperty
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int AuthorUserId { get; set; }
-        public User Author { get; set; }
-
-        public int ContributorUserId { get; set; }
-        public User Contributor { get; set; }
-    }
-
-    public class User
-    {
-        public string UserId { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-
-        [InverseProperty("Author")]
-        public List<Post> AuthoredPosts { get; set; }
-
-        [InverseProperty("Contributor")]
-        public List<Post> ContributedToPosts { get; set; }
-    }
-    #endregion
+    public DbSet<Post> Posts { get; set; }
+    public DbSet<User> Users { get; set; }
 }
+
+#region InverseProperty
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int AuthorUserId { get; set; }
+    public User Author { get; set; }
+
+    public int ContributorUserId { get; set; }
+    public User Contributor { get; set; }
+}
+
+public class User
+{
+    public string UserId { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+
+    [InverseProperty("Author")]
+    public List<Post> AuthoredPosts { get; set; }
+
+    [InverseProperty("Contributor")]
+    public List<Post> ContributedToPosts { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/FluentAPI/CascadeDelete.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/CascadeDelete.cs
@@ -1,39 +1,38 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.CascadeDelete
+namespace EFModeling.Relationships.FluentAPI.CascadeDelete;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    #region CascadeDelete
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        #region CascadeDelete
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Post>()
-                .HasOne(p => p.Blog)
-                .WithMany(b => b.Posts)
-                .OnDelete(DeleteBehavior.Cascade);
-        }
-        #endregion
+        modelBuilder.Entity<Post>()
+            .HasOne(p => p.Blog)
+            .WithMany(b => b.Posts)
+            .OnDelete(DeleteBehavior.Cascade);
     }
+    #endregion
+}
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 
-        public List<Post> Posts { get; set; }
-    }
+    public List<Post> Posts { get; set; }
+}
 
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
 
-        public int? BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
+    public int? BlogId { get; set; }
+    public Blog Blog { get; set; }
 }

--- a/samples/core/Modeling/Relationships/FluentAPI/CompositeForeignKey.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/CompositeForeignKey.cs
@@ -2,44 +2,43 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.CompositeForeignKey
+namespace EFModeling.Relationships.FluentAPI.CompositeForeignKey;
+
+#region CompositeForeignKey
+internal class MyContext : DbContext
 {
-    #region CompositeForeignKey
-    internal class MyContext : DbContext
+    public DbSet<Car> Cars { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Car> Cars { get; set; }
+        modelBuilder.Entity<Car>()
+            .HasKey(c => new { c.State, c.LicensePlate });
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Car>()
-                .HasKey(c => new { c.State, c.LicensePlate });
-
-            modelBuilder.Entity<RecordOfSale>()
-                .HasOne(s => s.Car)
-                .WithMany(c => c.SaleHistory)
-                .HasForeignKey(s => new { s.CarState, s.CarLicensePlate });
-        }
+        modelBuilder.Entity<RecordOfSale>()
+            .HasOne(s => s.Car)
+            .WithMany(c => c.SaleHistory)
+            .HasForeignKey(s => new { s.CarState, s.CarLicensePlate });
     }
-
-    public class Car
-    {
-        public string State { get; set; }
-        public string LicensePlate { get; set; }
-        public string Make { get; set; }
-        public string Model { get; set; }
-
-        public List<RecordOfSale> SaleHistory { get; set; }
-    }
-
-    public class RecordOfSale
-    {
-        public int RecordOfSaleId { get; set; }
-        public DateTime DateSold { get; set; }
-        public decimal Price { get; set; }
-
-        public string CarState { get; set; }
-        public string CarLicensePlate { get; set; }
-        public Car Car { get; set; }
-    }
-    #endregion
 }
+
+public class Car
+{
+    public string State { get; set; }
+    public string LicensePlate { get; set; }
+    public string Make { get; set; }
+    public string Model { get; set; }
+
+    public List<RecordOfSale> SaleHistory { get; set; }
+}
+
+public class RecordOfSale
+{
+    public int RecordOfSaleId { get; set; }
+    public DateTime DateSold { get; set; }
+    public decimal Price { get; set; }
+
+    public string CarState { get; set; }
+    public string CarLicensePlate { get; set; }
+    public Car Car { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/FluentAPI/CompositePrincipalKey.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/CompositePrincipalKey.cs
@@ -2,43 +2,42 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.CompositePrincipalKey
+namespace EFModeling.Relationships.FluentAPI.CompositePrincipalKey;
+
+#region CompositePrincipalKey
+internal class MyContext : DbContext
 {
-    #region CompositePrincipalKey
-    internal class MyContext : DbContext
+    public DbSet<Car> Cars { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Car> Cars { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<RecordOfSale>()
-                .HasOne(s => s.Car)
-                .WithMany(c => c.SaleHistory)
-                .HasForeignKey(s => new { s.CarState, s.CarLicensePlate })
-                .HasPrincipalKey(c => new { c.State, c.LicensePlate });
-        }
+        modelBuilder.Entity<RecordOfSale>()
+            .HasOne(s => s.Car)
+            .WithMany(c => c.SaleHistory)
+            .HasForeignKey(s => new { s.CarState, s.CarLicensePlate })
+            .HasPrincipalKey(c => new { c.State, c.LicensePlate });
     }
-
-    public class Car
-    {
-        public int CarId { get; set; }
-        public string State { get; set; }
-        public string LicensePlate { get; set; }
-        public string Make { get; set; }
-        public string Model { get; set; }
-
-        public List<RecordOfSale> SaleHistory { get; set; }
-    }
-
-    public class RecordOfSale
-    {
-        public int RecordOfSaleId { get; set; }
-        public DateTime DateSold { get; set; }
-        public decimal Price { get; set; }
-
-        public string CarState { get; set; }
-        public string CarLicensePlate { get; set; }
-        public Car Car { get; set; }
-    }
-    #endregion
 }
+
+public class Car
+{
+    public int CarId { get; set; }
+    public string State { get; set; }
+    public string LicensePlate { get; set; }
+    public string Make { get; set; }
+    public string Model { get; set; }
+
+    public List<RecordOfSale> SaleHistory { get; set; }
+}
+
+public class RecordOfSale
+{
+    public int RecordOfSaleId { get; set; }
+    public DateTime DateSold { get; set; }
+    public decimal Price { get; set; }
+
+    public string CarState { get; set; }
+    public string CarLicensePlate { get; set; }
+    public Car Car { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/FluentAPI/ConstraintName.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/ConstraintName.cs
@@ -1,40 +1,39 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.ConstraintName
+namespace EFModeling.Relationships.FluentAPI.ConstraintName;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    #region ConstraintName
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        #region ConstraintName
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Post>()
-                .HasOne(p => p.Blog)
-                .WithMany(b => b.Posts)
-                .HasForeignKey(p => p.BlogId)
-                .HasConstraintName("ForeignKey_Post_Blog");
-        }
-        #endregion
+        modelBuilder.Entity<Post>()
+            .HasOne(p => p.Blog)
+            .WithMany(b => b.Posts)
+            .HasForeignKey(p => p.BlogId)
+            .HasConstraintName("ForeignKey_Post_Blog");
     }
+    #endregion
+}
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 
-        public List<Post> Posts { get; set; }
-    }
+    public List<Post> Posts { get; set; }
+}
 
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
 
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
 }

--- a/samples/core/Modeling/Relationships/FluentAPI/ForeignKey.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/ForeignKey.cs
@@ -1,39 +1,38 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.ForeignKey
+namespace EFModeling.Relationships.FluentAPI.ForeignKey;
+
+#region ForeignKey
+internal class MyContext : DbContext
 {
-    #region ForeignKey
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Post>()
-                .HasOne(p => p.Blog)
-                .WithMany(b => b.Posts)
-                .HasForeignKey(p => p.BlogForeignKey);
-        }
+        modelBuilder.Entity<Post>()
+            .HasOne(p => p.Blog)
+            .WithMany(b => b.Posts)
+            .HasForeignKey(p => p.BlogForeignKey);
     }
-
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        public List<Post> Posts { get; set; }
-    }
-
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int BlogForeignKey { get; set; }
-        public Blog Blog { get; set; }
-    }
-    #endregion
 }
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public List<Post> Posts { get; set; }
+}
+
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int BlogForeignKey { get; set; }
+    public Blog Blog { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/FluentAPI/Full.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/Full.cs
@@ -1,37 +1,36 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.Full
+namespace EFModeling.Relationships.FluentAPI.Full;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Post>()
-                .HasOne(p => p.Blog)
-                .WithMany(b => b.Posts)
-                .HasForeignKey(p => p.BlogId);
-        }
+        modelBuilder.Entity<Post>()
+            .HasOne(p => p.Blog)
+            .WithMany(b => b.Posts)
+            .HasForeignKey(p => p.BlogId);
     }
+}
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 
-        public List<Post> Posts { get; set; }
-    }
+    public List<Post> Posts { get; set; }
+}
 
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
 
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
 }

--- a/samples/core/Modeling/Relationships/FluentAPI/ManyToMany.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/ManyToMany.cs
@@ -2,61 +2,60 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.ManyToMany
+namespace EFModeling.Relationships.FluentAPI.ManyToMany;
+
+#region ManyToMany
+public class MyContext : DbContext
 {
-    #region ManyToMany
-    public class MyContext : DbContext
+    public MyContext(DbContextOptions<MyContext> options)
+        : base(options)
     {
-        public MyContext(DbContextOptions<MyContext> options)
-            : base(options)
-        {
-        }
-
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<Tag> Tags { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<PostTag>()
-                .HasKey(t => new { t.PostId, t.TagId });
-
-            modelBuilder.Entity<PostTag>()
-                .HasOne(pt => pt.Post)
-                .WithMany(p => p.PostTags)
-                .HasForeignKey(pt => pt.PostId);
-
-            modelBuilder.Entity<PostTag>()
-                .HasOne(pt => pt.Tag)
-                .WithMany(t => t.PostTags)
-                .HasForeignKey(pt => pt.TagId);
-        }
     }
 
-    public class Post
+    public DbSet<Post> Posts { get; set; }
+    public DbSet<Tag> Tags { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+        modelBuilder.Entity<PostTag>()
+            .HasKey(t => new { t.PostId, t.TagId });
 
-        public List<PostTag> PostTags { get; set; }
+        modelBuilder.Entity<PostTag>()
+            .HasOne(pt => pt.Post)
+            .WithMany(p => p.PostTags)
+            .HasForeignKey(pt => pt.PostId);
+
+        modelBuilder.Entity<PostTag>()
+            .HasOne(pt => pt.Tag)
+            .WithMany(t => t.PostTags)
+            .HasForeignKey(pt => pt.TagId);
     }
-
-    public class Tag
-    {
-        public string TagId { get; set; }
-
-        public List<PostTag> PostTags { get; set; }
-    }
-
-    public class PostTag
-    {
-        public DateTime PublicationDate { get; set; }
-
-        public int PostId { get; set; }
-        public Post Post { get; set; }
-
-        public string TagId { get; set; }
-        public Tag Tag { get; set; }
-    }
-    #endregion
 }
+
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public List<PostTag> PostTags { get; set; }
+}
+
+public class Tag
+{
+    public string TagId { get; set; }
+
+    public List<PostTag> PostTags { get; set; }
+}
+
+public class PostTag
+{
+    public DateTime PublicationDate { get; set; }
+
+    public int PostId { get; set; }
+    public Post Post { get; set; }
+
+    public string TagId { get; set; }
+    public Tag Tag { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/FluentAPI/ManyToManyPayload.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/ManyToManyPayload.cs
@@ -2,68 +2,67 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.ManyToManyPayload
+namespace EFModeling.Relationships.FluentAPI.ManyToManyPayload;
+
+#region ManyToManyPayload
+internal class MyContext : DbContext
 {
-    #region ManyToManyPayload
-    internal class MyContext : DbContext
+    public MyContext(DbContextOptions<MyContext> options)
+        : base(options)
     {
-        public MyContext(DbContextOptions<MyContext> options)
-            : base(options)
-        {
-        }
-
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<Tag> Tags { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Post>()
-                .HasMany(p => p.Tags)
-                .WithMany(p => p.Posts)
-                .UsingEntity<PostTag>(
-                    j => j
-                        .HasOne(pt => pt.Tag)
-                        .WithMany(t => t.PostTags)
-                        .HasForeignKey(pt => pt.TagId),
-                    j => j
-                        .HasOne(pt => pt.Post)
-                        .WithMany(p => p.PostTags)
-                        .HasForeignKey(pt => pt.PostId),
-                    j =>
-                    {
-                        j.Property(pt => pt.PublicationDate).HasDefaultValueSql("CURRENT_TIMESTAMP");
-                        j.HasKey(t => new { t.PostId, t.TagId });
-                    });
-        }
     }
 
-    public class Post
+    public DbSet<Post> Posts { get; set; }
+    public DbSet<Tag> Tags { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public ICollection<Tag> Tags { get; set; }
-        public List<PostTag> PostTags { get; set; }
+        modelBuilder.Entity<Post>()
+            .HasMany(p => p.Tags)
+            .WithMany(p => p.Posts)
+            .UsingEntity<PostTag>(
+                j => j
+                    .HasOne(pt => pt.Tag)
+                    .WithMany(t => t.PostTags)
+                    .HasForeignKey(pt => pt.TagId),
+                j => j
+                    .HasOne(pt => pt.Post)
+                    .WithMany(p => p.PostTags)
+                    .HasForeignKey(pt => pt.PostId),
+                j =>
+                {
+                    j.Property(pt => pt.PublicationDate).HasDefaultValueSql("CURRENT_TIMESTAMP");
+                    j.HasKey(t => new { t.PostId, t.TagId });
+                });
     }
-
-    public class Tag
-    {
-        public string TagId { get; set; }
-
-        public ICollection<Post> Posts { get; set; }
-        public List<PostTag> PostTags { get; set; }
-    }
-
-    public class PostTag
-    {
-        public DateTime PublicationDate { get; set; }
-
-        public int PostId { get; set; }
-        public Post Post { get; set; }
-
-        public string TagId { get; set; }
-        public Tag Tag { get; set; }
-    }
-    #endregion
 }
+
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public ICollection<Tag> Tags { get; set; }
+    public List<PostTag> PostTags { get; set; }
+}
+
+public class Tag
+{
+    public string TagId { get; set; }
+
+    public ICollection<Post> Posts { get; set; }
+    public List<PostTag> PostTags { get; set; }
+}
+
+public class PostTag
+{
+    public DateTime PublicationDate { get; set; }
+
+    public int PostId { get; set; }
+    public Post Post { get; set; }
+
+    public string TagId { get; set; }
+    public Tag Tag { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/FluentAPI/ManyToManyShared.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/ManyToManyShared.cs
@@ -2,91 +2,90 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.ManyToManyShared
+namespace EFModeling.Relationships.FluentAPI.ManyToManyShared;
+
+public class MyContext : DbContext
 {
-    public class MyContext : DbContext
+    public MyContext(DbContextOptions<MyContext> options)
+        : base(options)
     {
-        public MyContext(DbContextOptions<MyContext> options)
-            : base(options)
+    }
+
+    public DbSet<Post> Posts { get; set; }
+    public DbSet<Tag> Tags { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        #region SharedConfiguration
+        modelBuilder
+            .Entity<Post>()
+            .HasMany(p => p.Tags)
+            .WithMany(p => p.Posts)
+            .UsingEntity(j => j.ToTable("PostTags"));
+        #endregion
+
+        #region Metadata
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
         {
-        }
-
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<Tag> Tags { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            #region SharedConfiguration
-            modelBuilder
-                .Entity<Post>()
-                .HasMany(p => p.Tags)
-                .WithMany(p => p.Posts)
-                .UsingEntity(j => j.ToTable("PostTags"));
-            #endregion
-
-            #region Metadata
-            foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+            foreach (var skipNavigation in entityType.GetSkipNavigations())
             {
-                foreach (var skipNavigation in entityType.GetSkipNavigations())
-                {
-                    Console.WriteLine(entityType.DisplayName() + "." + skipNavigation.Name);
-                }
+                Console.WriteLine(entityType.DisplayName() + "." + skipNavigation.Name);
             }
-            #endregion
-
-            #region Seeding
-            modelBuilder
-                .Entity<Post>()
-                .HasData(new Post { PostId = 1, Title = "First" });
-
-            modelBuilder
-                .Entity<Tag>()
-                .HasData(new Tag { TagId = "ef" });
-
-            modelBuilder
-                .Entity<Post>()
-                .HasMany(p => p.Tags)
-                .WithMany(p => p.Posts)
-                .UsingEntity(j => j.HasData(new { PostsPostId = 1, TagsTagId = "ef" }));
-            #endregion
-
-            #region Components
-            modelBuilder.Entity<Post>()
-                .HasMany(p => p.Tags)
-                .WithMany(p => p.Posts)
-                .UsingEntity<Dictionary<string, object>>(
-                    "PostTag",
-                    j => j
-                        .HasOne<Tag>()
-                        .WithMany()
-                        .HasForeignKey("TagId")
-                        .HasConstraintName("FK_PostTag_Tags_TagId")
-                        .OnDelete(DeleteBehavior.Cascade),
-                    j => j
-                        .HasOne<Post>()
-                        .WithMany()
-                        .HasForeignKey("PostId")
-                        .HasConstraintName("FK_PostTag_Posts_PostId")
-                        .OnDelete(DeleteBehavior.ClientCascade));
-            #endregion
         }
+        #endregion
+
+        #region Seeding
+        modelBuilder
+            .Entity<Post>()
+            .HasData(new Post { PostId = 1, Title = "First" });
+
+        modelBuilder
+            .Entity<Tag>()
+            .HasData(new Tag { TagId = "ef" });
+
+        modelBuilder
+            .Entity<Post>()
+            .HasMany(p => p.Tags)
+            .WithMany(p => p.Posts)
+            .UsingEntity(j => j.HasData(new { PostsPostId = 1, TagsTagId = "ef" }));
+        #endregion
+
+        #region Components
+        modelBuilder.Entity<Post>()
+            .HasMany(p => p.Tags)
+            .WithMany(p => p.Posts)
+            .UsingEntity<Dictionary<string, object>>(
+                "PostTag",
+                j => j
+                    .HasOne<Tag>()
+                    .WithMany()
+                    .HasForeignKey("TagId")
+                    .HasConstraintName("FK_PostTag_Tags_TagId")
+                    .OnDelete(DeleteBehavior.Cascade),
+                j => j
+                    .HasOne<Post>()
+                    .WithMany()
+                    .HasForeignKey("PostId")
+                    .HasConstraintName("FK_PostTag_Posts_PostId")
+                    .OnDelete(DeleteBehavior.ClientCascade));
+        #endregion
     }
-
-    #region ManyToManyShared
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public ICollection<Tag> Tags { get; set; }
-    }
-
-    public class Tag
-    {
-        public string TagId { get; set; }
-
-        public ICollection<Post> Posts { get; set; }
-    }
-    #endregion
 }
+
+#region ManyToManyShared
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public ICollection<Tag> Tags { get; set; }
+}
+
+public class Tag
+{
+    public string TagId { get; set; }
+
+    public ICollection<Post> Posts { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/FluentAPI/NavigationConfiguration.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/NavigationConfiguration.cs
@@ -1,39 +1,38 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.NavigationConfiguration
+namespace EFModeling.Relationships.FluentAPI.NavigationConfiguration;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    #region NavigationConfiguration
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasMany(b => b.Posts)
+            .WithOne();
 
-        #region NavigationConfiguration
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasMany(b => b.Posts)
-                .WithOne();
-
-            modelBuilder.Entity<Blog>()
-                .Navigation(b => b.Posts)
-                .UsePropertyAccessMode(PropertyAccessMode.Property);
-        }
-        #endregion
+        modelBuilder.Entity<Blog>()
+            .Navigation(b => b.Posts)
+            .UsePropertyAccessMode(PropertyAccessMode.Property);
     }
+    #endregion
+}
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 
-        public List<Post> Posts { get; set; }
-    }
+    public List<Post> Posts { get; set; }
+}
 
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-    }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
 }

--- a/samples/core/Modeling/Relationships/FluentAPI/NoForeignKey.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/NoForeignKey.cs
@@ -1,37 +1,36 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.NoForeignKey
+namespace EFModeling.Relationships.FluentAPI.NoForeignKey;
+
+#region NoForeignKey
+internal class MyContext : DbContext
 {
-    #region NoForeignKey
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Post>()
-                .HasOne(p => p.Blog)
-                .WithMany(b => b.Posts);
-        }
+        modelBuilder.Entity<Post>()
+            .HasOne(p => p.Blog)
+            .WithMany(b => b.Posts);
     }
-
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        public List<Post> Posts { get; set; }
-    }
-
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public Blog Blog { get; set; }
-    }
-    #endregion
 }
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public List<Post> Posts { get; set; }
+}
+
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public Blog Blog { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/FluentAPI/NoNavigation.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/NoNavigation.cs
@@ -1,35 +1,34 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.NoNavigation
+namespace EFModeling.Relationships.FluentAPI.NoNavigation;
+
+#region NoNavigation
+internal class MyContext : DbContext
 {
-    #region NoNavigation
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Post>()
-                .HasOne<Blog>()
-                .WithMany()
-                .HasForeignKey(p => p.BlogId);
-        }
+        modelBuilder.Entity<Post>()
+            .HasOne<Blog>()
+            .WithMany()
+            .HasForeignKey(p => p.BlogId);
     }
-
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-    }
-
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int BlogId { get; set; }
-    }
-    #endregion
 }
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+}
+
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int BlogId { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/FluentAPI/OneNavigation.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/OneNavigation.cs
@@ -1,35 +1,34 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.OneNavigation
+namespace EFModeling.Relationships.FluentAPI.OneNavigation;
+
+#region OneNavigation
+internal class MyContext : DbContext
 {
-    #region OneNavigation
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasMany(b => b.Posts)
-                .WithOne();
-        }
+        modelBuilder.Entity<Blog>()
+            .HasMany(b => b.Posts)
+            .WithOne();
     }
-
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        public List<Post> Posts { get; set; }
-    }
-
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-    }
-    #endregion
 }
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public List<Post> Posts { get; set; }
+}
+
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/FluentAPI/OneToOne.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/OneToOne.cs
@@ -1,38 +1,37 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.OneToOne
+namespace EFModeling.Relationships.FluentAPI.OneToOne;
+
+#region OneToOne
+internal class MyContext : DbContext
 {
-    #region OneToOne
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<BlogImage> BlogImages { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<BlogImage> BlogImages { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasOne(b => b.BlogImage)
-                .WithOne(i => i.Blog)
-                .HasForeignKey<BlogImage>(b => b.BlogForeignKey);
-        }
+        modelBuilder.Entity<Blog>()
+            .HasOne(b => b.BlogImage)
+            .WithOne(i => i.Blog)
+            .HasForeignKey<BlogImage>(b => b.BlogForeignKey);
     }
-
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        public BlogImage BlogImage { get; set; }
-    }
-
-    public class BlogImage
-    {
-        public int BlogImageId { get; set; }
-        public byte[] Image { get; set; }
-        public string Caption { get; set; }
-
-        public int BlogForeignKey { get; set; }
-        public Blog Blog { get; set; }
-    }
-    #endregion
 }
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public BlogImage BlogImage { get; set; }
+}
+
+public class BlogImage
+{
+    public int BlogImageId { get; set; }
+    public byte[] Image { get; set; }
+    public string Caption { get; set; }
+
+    public int BlogForeignKey { get; set; }
+    public Blog Blog { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/FluentAPI/PrincipalKey.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/PrincipalKey.cs
@@ -2,41 +2,40 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.PrincipalKey
+namespace EFModeling.Relationships.FluentAPI.PrincipalKey;
+
+#region PrincipalKey
+internal class MyContext : DbContext
 {
-    #region PrincipalKey
-    internal class MyContext : DbContext
+    public DbSet<Car> Cars { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Car> Cars { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<RecordOfSale>()
-                .HasOne(s => s.Car)
-                .WithMany(c => c.SaleHistory)
-                .HasForeignKey(s => s.CarLicensePlate)
-                .HasPrincipalKey(c => c.LicensePlate);
-        }
+        modelBuilder.Entity<RecordOfSale>()
+            .HasOne(s => s.Car)
+            .WithMany(c => c.SaleHistory)
+            .HasForeignKey(s => s.CarLicensePlate)
+            .HasPrincipalKey(c => c.LicensePlate);
     }
-
-    public class Car
-    {
-        public int CarId { get; set; }
-        public string LicensePlate { get; set; }
-        public string Make { get; set; }
-        public string Model { get; set; }
-
-        public List<RecordOfSale> SaleHistory { get; set; }
-    }
-
-    public class RecordOfSale
-    {
-        public int RecordOfSaleId { get; set; }
-        public DateTime DateSold { get; set; }
-        public decimal Price { get; set; }
-
-        public string CarLicensePlate { get; set; }
-        public Car Car { get; set; }
-    }
-    #endregion
 }
+
+public class Car
+{
+    public int CarId { get; set; }
+    public string LicensePlate { get; set; }
+    public string Make { get; set; }
+    public string Model { get; set; }
+
+    public List<RecordOfSale> SaleHistory { get; set; }
+}
+
+public class RecordOfSale
+{
+    public int RecordOfSaleId { get; set; }
+    public DateTime DateSold { get; set; }
+    public decimal Price { get; set; }
+
+    public string CarLicensePlate { get; set; }
+    public Car Car { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/FluentAPI/Required.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/Required.cs
@@ -1,38 +1,37 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.Required
+namespace EFModeling.Relationships.FluentAPI.Required;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    #region Required
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        #region Required
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Post>()
-                .HasOne(p => p.Blog)
-                .WithMany(b => b.Posts)
-                .IsRequired();
-        }
-        #endregion
+        modelBuilder.Entity<Post>()
+            .HasOne(p => p.Blog)
+            .WithMany(b => b.Posts)
+            .IsRequired();
     }
+    #endregion
+}
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 
-        public List<Post> Posts { get; set; }
-    }
+    public List<Post> Posts { get; set; }
+}
 
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
 
-        public Blog Blog { get; set; }
-    }
+    public Blog Blog { get; set; }
 }

--- a/samples/core/Modeling/Relationships/FluentAPI/ShadowForeignKey.cs
+++ b/samples/core/Modeling/Relationships/FluentAPI/ShadowForeignKey.cs
@@ -1,43 +1,42 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.FluentAPI.ShadowForeignKey
+namespace EFModeling.Relationships.FluentAPI.ShadowForeignKey;
+
+#region ShadowForeignKey
+internal class MyContext : DbContext
 {
-    #region ShadowForeignKey
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+        // Add the shadow property to the model
+        modelBuilder.Entity<Post>()
+            .Property<int>("BlogForeignKey");
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            // Add the shadow property to the model
-            modelBuilder.Entity<Post>()
-                .Property<int>("BlogForeignKey");
-
-            // Use the shadow property as a foreign key
-            modelBuilder.Entity<Post>()
-                .HasOne(p => p.Blog)
-                .WithMany(b => b.Posts)
-                .HasForeignKey("BlogForeignKey");
-        }
+        // Use the shadow property as a foreign key
+        modelBuilder.Entity<Post>()
+            .HasOne(p => p.Blog)
+            .WithMany(b => b.Posts)
+            .HasForeignKey("BlogForeignKey");
     }
-
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        public List<Post> Posts { get; set; }
-    }
-
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public Blog Blog { get; set; }
-    }
-    #endregion
 }
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public List<Post> Posts { get; set; }
+}
+
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public Blog Blog { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/Full.cs
+++ b/samples/core/Modeling/Relationships/Full.cs
@@ -1,31 +1,30 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.Full
+namespace EFModeling.Relationships.Full;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-    }
-
-    #region Full
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        public List<Post> Posts { get; set; }
-    }
-
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
 }
+
+#region Full
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public List<Post> Posts { get; set; }
+}
+
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/NoForeignKey.cs
+++ b/samples/core/Modeling/Relationships/NoForeignKey.cs
@@ -1,30 +1,29 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.NoForeignKey
+namespace EFModeling.Relationships.NoForeignKey;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-    }
-
-    #region NoForeignKey
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        public List<Post> Posts { get; set; }
-    }
-
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public Blog Blog { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
 }
+
+#region NoForeignKey
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public List<Post> Posts { get; set; }
+}
+
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public Blog Blog { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/OneNavigation.cs
+++ b/samples/core/Modeling/Relationships/OneNavigation.cs
@@ -1,28 +1,27 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.OneNavigation
+namespace EFModeling.Relationships.OneNavigation;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-    }
-
-    #region OneNavigation
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        public List<Post> Posts { get; set; }
-    }
-
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
 }
+
+#region OneNavigation
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public List<Post> Posts { get; set; }
+}
+
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/OneToOne.cs
+++ b/samples/core/Modeling/Relationships/OneToOne.cs
@@ -1,30 +1,29 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Relationships.OneToOne
+namespace EFModeling.Relationships.OneToOne;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<BlogImage> BlogImages { get; set; }
-    }
-
-    #region OneToOne
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        public BlogImage BlogImage { get; set; }
-    }
-
-    public class BlogImage
-    {
-        public int BlogImageId { get; set; }
-        public byte[] Image { get; set; }
-        public string Caption { get; set; }
-
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<BlogImage> BlogImages { get; set; }
 }
+
+#region OneToOne
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public BlogImage BlogImage { get; set; }
+}
+
+public class BlogImage
+{
+    public int BlogImageId { get; set; }
+    public byte[] Image { get; set; }
+    public string Caption { get; set; }
+
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/Relationships/Program.cs
+++ b/samples/core/Modeling/Relationships/Program.cs
@@ -1,9 +1,8 @@
-namespace EFModeling.Relationships
+namespace EFModeling.Relationships;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
-        {
-        }
     }
 }

--- a/samples/core/Modeling/Sequences/Program.cs
+++ b/samples/core/Modeling/Sequences/Program.cs
@@ -1,9 +1,8 @@
-namespace EFModeling.Sequences
+namespace EFModeling.Sequences;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
-        {
-        }
     }
 }

--- a/samples/core/Modeling/Sequences/Sequence.cs
+++ b/samples/core/Modeling/Sequences/Sequence.cs
@@ -1,27 +1,26 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Sequences.Sequence
+namespace EFModeling.Sequences.Sequence;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
+    public DbSet<Order> Orders { get; set; }
+
+    #region Sequence
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Order> Orders { get; set; }
+        modelBuilder.HasSequence<int>("OrderNumbers");
 
-        #region Sequence
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.HasSequence<int>("OrderNumbers");
-
-            modelBuilder.Entity<Order>()
-                .Property(o => o.OrderNo)
-                .HasDefaultValueSql("NEXT VALUE FOR OrderNumbers");
-        }
-        #endregion
+        modelBuilder.Entity<Order>()
+            .Property(o => o.OrderNo)
+            .HasDefaultValueSql("NEXT VALUE FOR OrderNumbers");
     }
+    #endregion
+}
 
-    public class Order
-    {
-        public int OrderId { get; set; }
-        public int OrderNo { get; set; }
-        public string Url { get; set; }
-    }
+public class Order
+{
+    public int OrderId { get; set; }
+    public int OrderNo { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/Sequences/SequenceConfiguration.cs
+++ b/samples/core/Modeling/Sequences/SequenceConfiguration.cs
@@ -1,25 +1,24 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.Seqiemces.SequenceConfiguration
+namespace EFModeling.Seqiemces.SequenceConfiguration;
+
+internal class MyContext : DbContext
 {
-    internal class MyContext : DbContext
-    {
-        public DbSet<Order> Orders { get; set; }
+    public DbSet<Order> Orders { get; set; }
 
-        #region SequenceConfiguration
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.HasSequence<int>("OrderNumbers", schema: "shared")
-                .StartsAt(1000)
-                .IncrementsBy(5);
-        }
-        #endregion
-    }
-
-    public class Order
+    #region SequenceConfiguration
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int OrderId { get; set; }
-        public int OrderNo { get; set; }
-        public string Url { get; set; }
+        modelBuilder.HasSequence<int>("OrderNumbers", schema: "shared")
+            .StartsAt(1000)
+            .IncrementsBy(5);
     }
+    #endregion
+}
+
+public class Order
+{
+    public int OrderId { get; set; }
+    public int OrderNo { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Modeling/ShadowAndIndexerProperties/IndexerProperty.cs
+++ b/samples/core/Modeling/ShadowAndIndexerProperties/IndexerProperty.cs
@@ -2,29 +2,28 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.ShadowAndIndexerProperties.IndexerProperty
+namespace EFModeling.ShadowAndIndexerProperties.IndexerProperty;
+
+#region IndexerProperty
+internal class MyContext : DbContext
 {
-    #region IndexerProperty
-    internal class MyContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>().IndexerProperty<DateTime>("LastUpdated");
-        }
+        modelBuilder.Entity<Blog>().IndexerProperty<DateTime>("LastUpdated");
     }
-
-    public class Blog
-    {
-        private readonly Dictionary<string, object> _data = new Dictionary<string, object>();
-        public int BlogId { get; set; }
-
-        public object this[string key]
-        {
-            get => _data[key];
-            set => _data[key] = value;
-        }
-    }
-    #endregion
 }
+
+public class Blog
+{
+    private readonly Dictionary<string, object> _data = new Dictionary<string, object>();
+    public int BlogId { get; set; }
+
+    public object this[string key]
+    {
+        get => _data[key];
+        set => _data[key] = value;
+    }
+}
+#endregion

--- a/samples/core/Modeling/ShadowAndIndexerProperties/Program.cs
+++ b/samples/core/Modeling/ShadowAndIndexerProperties/Program.cs
@@ -1,9 +1,8 @@
-namespace EFModeling.ShadowAndIndexerProperties
+namespace EFModeling.ShadowAndIndexerProperties;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
-        {
-        }
     }
 }

--- a/samples/core/Modeling/ShadowAndIndexerProperties/ShadowForeignKey.cs
+++ b/samples/core/Modeling/ShadowAndIndexerProperties/ShadowForeignKey.cs
@@ -1,32 +1,31 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.ShadowAndIndexerProperties.ShadowForeignKey
+namespace EFModeling.ShadowAndIndexerProperties.ShadowForeignKey;
+
+#region Conventions
+internal class MyContext : DbContext
 {
-    #region Conventions
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-    }
-
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-
-        public List<Post> Posts { get; set; }
-    }
-
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        // Since there is no CLR property which holds the foreign
-        // key for this relationship, a shadow property is created.
-        public Blog Blog { get; set; }
-    }
-    #endregion
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
 }
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public List<Post> Posts { get; set; }
+}
+
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    // Since there is no CLR property which holds the foreign
+    // key for this relationship, a shadow property is created.
+    public Blog Blog { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/ShadowAndIndexerProperties/ShadowProperty.cs
+++ b/samples/core/Modeling/ShadowAndIndexerProperties/ShadowProperty.cs
@@ -1,24 +1,23 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.ShadowAndIndexerProperties.ShadowProperty
+namespace EFModeling.ShadowAndIndexerProperties.ShadowProperty;
+
+#region ShadowProperty
+internal class MyContext : DbContext
 {
-    #region ShadowProperty
-    internal class MyContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property<DateTime>("LastUpdated");
-        }
-    }
-
-    public class Blog
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+        modelBuilder.Entity<Blog>()
+            .Property<DateTime>("LastUpdated");
     }
-    #endregion
 }
+
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+}
+#endregion

--- a/samples/core/Modeling/ShadowAndIndexerProperties/SharedType.cs
+++ b/samples/core/Modeling/ShadowAndIndexerProperties/SharedType.cs
@@ -2,23 +2,22 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.ShadowAndIndexerProperties.SharedType
-{
-    #region SharedType
-    internal class MyContext : DbContext
-    {
-        public DbSet<Dictionary<string, object>> Blogs => Set<Dictionary<string, object>>("Blog");
+namespace EFModeling.ShadowAndIndexerProperties.SharedType;
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.SharedTypeEntity<Dictionary<string, object>>(
-                "Blog", bb =>
-                {
-                    bb.Property<int>("BlogId");
-                    bb.Property<string>("Url");
-                    bb.Property<DateTime>("LastUpdated");
-                });
-        }
+#region SharedType
+internal class MyContext : DbContext
+{
+    public DbSet<Dictionary<string, object>> Blogs => Set<Dictionary<string, object>>("Blog");
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.SharedTypeEntity<Dictionary<string, object>>(
+            "Blog", bb =>
+            {
+                bb.Property<int>("BlogId");
+                bb.Property<string>("Url");
+                bb.Property<DateTime>("LastUpdated");
+            });
     }
-    #endregion
 }
+#endregion

--- a/samples/core/Modeling/TableSplitting/DetailedOrder.cs
+++ b/samples/core/Modeling/TableSplitting/DetailedOrder.cs
@@ -1,13 +1,12 @@
-﻿namespace EFModeling.TableSplitting
+﻿namespace EFModeling.TableSplitting;
+
+#region DetailedOrder
+public class DetailedOrder
 {
-    #region DetailedOrder
-    public class DetailedOrder
-    {
-        public int Id { get; set; }
-        public OrderStatus? Status { get; set; }
-        public string BillingAddress { get; set; }
-        public string ShippingAddress { get; set; }
-        public byte[] Version { get; set; }
-    }
-    #endregion
+    public int Id { get; set; }
+    public OrderStatus? Status { get; set; }
+    public string BillingAddress { get; set; }
+    public string ShippingAddress { get; set; }
+    public byte[] Version { get; set; }
 }
+#endregion

--- a/samples/core/Modeling/TableSplitting/Order.cs
+++ b/samples/core/Modeling/TableSplitting/Order.cs
@@ -1,11 +1,10 @@
-﻿namespace EFModeling.TableSplitting
+﻿namespace EFModeling.TableSplitting;
+
+#region Order
+public class Order
 {
-    #region Order
-    public class Order
-    {
-        public int Id { get; set; }
-        public OrderStatus? Status { get; set; }
-        public DetailedOrder DetailedOrder { get; set; }
-    }
-    #endregion
+    public int Id { get; set; }
+    public OrderStatus? Status { get; set; }
+    public DetailedOrder DetailedOrder { get; set; }
 }
+#endregion

--- a/samples/core/Modeling/TableSplitting/OrderStatus.cs
+++ b/samples/core/Modeling/TableSplitting/OrderStatus.cs
@@ -1,10 +1,9 @@
-﻿namespace EFModeling.TableSplitting
+﻿namespace EFModeling.TableSplitting;
+
+#region OrderStatus
+public enum OrderStatus
 {
-    #region OrderStatus
-    public enum OrderStatus
-    {
-        Pending,
-        Shipped
-    }
-    #endregion
+    Pending,
+    Shipped
 }
+#endregion

--- a/samples/core/Modeling/TableSplitting/Program.cs
+++ b/samples/core/Modeling/TableSplitting/Program.cs
@@ -1,45 +1,44 @@
 ﻿using System;
 using System.Linq;
 
-namespace EFModeling.TableSplitting
-{
-    public static class Program
-    {
-        private static void Main(string[] args)
-        {
-            #region Usage
-            using (var context = new TableSplittingContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+namespace EFModeling.TableSplitting;
 
-                context.Add(
-                    new Order
+public static class Program
+{
+    private static void Main(string[] args)
+    {
+        #region Usage
+        using (var context = new TableSplittingContext())
+        {
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+
+            context.Add(
+                new Order
+                {
+                    Status = OrderStatus.Pending,
+                    DetailedOrder = new DetailedOrder
                     {
                         Status = OrderStatus.Pending,
-                        DetailedOrder = new DetailedOrder
-                        {
-                            Status = OrderStatus.Pending,
-                            ShippingAddress = "221 B Baker St, London",
-                            BillingAddress = "11 Wall Street, New York"
-                        }
-                    });
+                        ShippingAddress = "221 B Baker St, London",
+                        BillingAddress = "11 Wall Street, New York"
+                    }
+                });
 
-                context.SaveChanges();
-            }
-
-            using (var context = new TableSplittingContext())
-            {
-                var pendingCount = context.Orders.Count(o => o.Status == OrderStatus.Pending);
-                Console.WriteLine($"Current number of pending orders: {pendingCount}");
-            }
-
-            using (var context = new TableSplittingContext())
-            {
-                var order = context.DetailedOrders.First(o => o.Status == OrderStatus.Pending);
-                Console.WriteLine($"First pending order will ship to: {order.ShippingAddress}");
-            }
-            #endregion
+            context.SaveChanges();
         }
+
+        using (var context = new TableSplittingContext())
+        {
+            var pendingCount = context.Orders.Count(o => o.Status == OrderStatus.Pending);
+            Console.WriteLine($"Current number of pending orders: {pendingCount}");
+        }
+
+        using (var context = new TableSplittingContext())
+        {
+            var order = context.DetailedOrders.First(o => o.Status == OrderStatus.Pending);
+            Console.WriteLine($"First pending order will ship to: {order.ShippingAddress}");
+        }
+        #endregion
     }
 }

--- a/samples/core/Modeling/TableSplitting/TableSplittingContext.cs
+++ b/samples/core/Modeling/TableSplitting/TableSplittingContext.cs
@@ -1,43 +1,42 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.TableSplitting
+namespace EFModeling.TableSplitting;
+
+public class TableSplittingContext : DbContext
 {
-    public class TableSplittingContext : DbContext
+    public DbSet<Order> Orders { get; set; }
+    public DbSet<DetailedOrder> DetailedOrders { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFTableSplitting;Trusted_Connection=True");
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Order> Orders { get; set; }
-        public DbSet<DetailedOrder> DetailedOrders { get; set; }
+        #region TableSplitting
+        modelBuilder.Entity<DetailedOrder>(
+            dob =>
+            {
+                dob.ToTable("Orders");
+                dob.Property(o => o.Status).HasColumnName("Status");
+            });
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFTableSplitting;Trusted_Connection=True");
+        modelBuilder.Entity<Order>(
+            ob =>
+            {
+                ob.ToTable("Orders");
+                ob.Property(o => o.Status).HasColumnName("Status");
+                ob.HasOne(o => o.DetailedOrder).WithOne()
+                    .HasForeignKey<DetailedOrder>(o => o.Id);
+            });
+        #endregion
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            #region TableSplitting
-            modelBuilder.Entity<DetailedOrder>(
-                dob =>
-                {
-                    dob.ToTable("Orders");
-                    dob.Property(o => o.Status).HasColumnName("Status");
-                });
+        #region ConcurrencyToken
+        modelBuilder.Entity<Order>()
+            .Property<byte[]>("Version").IsRowVersion().HasColumnName("Version");
 
-            modelBuilder.Entity<Order>(
-                ob =>
-                {
-                    ob.ToTable("Orders");
-                    ob.Property(o => o.Status).HasColumnName("Status");
-                    ob.HasOne(o => o.DetailedOrder).WithOne()
-                        .HasForeignKey<DetailedOrder>(o => o.Id);
-                });
-            #endregion
-
-            #region ConcurrencyToken
-            modelBuilder.Entity<Order>()
-                .Property<byte[]>("Version").IsRowVersion().HasColumnName("Version");
-
-            modelBuilder.Entity<DetailedOrder>()
-                .Property(o => o.Version).IsRowVersion().HasColumnName("Version");
-            #endregion
-        }
+        modelBuilder.Entity<DetailedOrder>()
+            .Property(o => o.Version).IsRowVersion().HasColumnName("Version");
+        #endregion
     }
 }

--- a/samples/core/Modeling/ValueConversions/CaseInsensitiveStrings.cs
+++ b/samples/core/Modeling/ValueConversions/CaseInsensitiveStrings.cs
@@ -8,101 +8,100 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class CaseInsensitiveStrings : Program
 {
-    public class CaseInsensitiveStrings : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing value conversions for case-insensitive string keys...");
+
+        using (var context = new SampleDbContext())
         {
-            ConsoleWriteLines("Sample showing value conversions for case-insensitive string keys...");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContext())
-            {
-                CleanDatabase(context);
+            ConsoleWriteLines("Save new entities...");
 
-                ConsoleWriteLines("Save new entities...");
-
-                context.AddRange(
-                    new Blog
-                    {
-                        Id = "dotnet",
-                        Name = ".NET Blog",
-                    },
-                    new Post
-                    {
-                        Id = "post1",
-                        BlogId = "dotnet",
-                        Title = "Some good .NET stuff"
-                    },
-                    new Post
-                    {
-                        Id = "Post2",
-                        BlogId = "DotNet",
-                        Title = "Some more good .NET stuff"
-                    });
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContext())
-            {
-                ConsoleWriteLines("Read the entities back...");
-
-                var blog = context.Set<Blog>().Include(e => e.Posts).Single();
-
-                ConsoleWriteLines($"The blog has {blog.Posts.Count} posts with foreign keys '{blog.Posts.First().BlogId}' and '{blog.Posts.Skip(1).First().BlogId}'");
-            }
-
-            ConsoleWriteLines("Sample finished.");
+            context.AddRange(
+                new Blog
+                {
+                    Id = "dotnet",
+                    Name = ".NET Blog",
+                },
+                new Post
+                {
+                    Id = "post1",
+                    BlogId = "dotnet",
+                    Title = "Some good .NET stuff"
+                },
+                new Post
+                {
+                    Id = "Post2",
+                    BlogId = "DotNet",
+                    Title = "Some more good .NET stuff"
+                });
+            context.SaveChanges();
         }
 
-        public class SampleDbContext : DbContext
+        using (var context = new SampleDbContext())
         {
-            #region ConfigureCaseInsensitiveStrings
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                var comparer = new ValueComparer<string>(
-                    (l, r) => string.Equals(l, r, StringComparison.OrdinalIgnoreCase),
-                    v => v.ToUpper().GetHashCode(),
-                    v => v);
+            ConsoleWriteLines("Read the entities back...");
 
-                modelBuilder.Entity<Blog>()
-                    .Property(e => e.Id)
-                    .Metadata.SetValueComparer(comparer);
+            var blog = context.Set<Blog>().Include(e => e.Posts).Single();
 
-                modelBuilder.Entity<Post>(
-                    b =>
-                        {
-                            b.Property(e => e.Id).Metadata.SetValueComparer(comparer);
-                            b.Property(e => e.BlogId).Metadata.SetValueComparer(comparer);
-                        });
-            }
-            #endregion
-
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=CaseInsensitiveStrings;Trusted_Connection=True")
-                    .EnableSensitiveDataLogging();
+            ConsoleWriteLines($"The blog has {blog.Posts.Count} posts with foreign keys '{blog.Posts.First().BlogId}' and '{blog.Posts.Skip(1).First().BlogId}'");
         }
 
-        #region CaseInsensitiveStringsModel
-        public class Blog
+        ConsoleWriteLines("Sample finished.");
+    }
+
+    public class SampleDbContext : DbContext
+    {
+        #region ConfigureCaseInsensitiveStrings
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            public string Id { get; set; }
-            public string Name { get; set; }
+            var comparer = new ValueComparer<string>(
+                (l, r) => string.Equals(l, r, StringComparison.OrdinalIgnoreCase),
+                v => v.ToUpper().GetHashCode(),
+                v => v);
 
-            public ICollection<Post> Posts { get; set; }
-        }
+            modelBuilder.Entity<Blog>()
+                .Property(e => e.Id)
+                .Metadata.SetValueComparer(comparer);
 
-        public class Post
-        {
-            public string Id { get; set; }
-            public string Title { get; set; }
-            public string Content { get; set; }
-
-            public string BlogId { get; set; }
-            public Blog Blog { get; set; }
+            modelBuilder.Entity<Post>(
+                b =>
+                {
+                    b.Property(e => e.Id).Metadata.SetValueComparer(comparer);
+                    b.Property(e => e.BlogId).Metadata.SetValueComparer(comparer);
+                });
         }
         #endregion
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=CaseInsensitiveStrings;Trusted_Connection=True")
+                .EnableSensitiveDataLogging();
     }
+
+    #region CaseInsensitiveStringsModel
+    public class Blog
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+
+        public ICollection<Post> Posts { get; set; }
+    }
+
+    public class Post
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+
+        public string BlogId { get; set; }
+        public Blog Blog { get; set; }
+    }
+    #endregion
 }

--- a/samples/core/Modeling/ValueConversions/CompositeValueObject.cs
+++ b/samples/core/Modeling/ValueConversions/CompositeValueObject.cs
@@ -8,87 +8,86 @@ using System.Text.Json.Serialization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class CompositeValueObject : Program
 {
-    public class CompositeValueObject : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing value conversions for a composite value object...");
+
+        using (var context = new SampleDbContext())
         {
-            ConsoleWriteLines("Sample showing value conversions for a composite value object...");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContext())
-            {
-                CleanDatabase(context);
+            ConsoleWriteLines("Save a new entity...");
 
-                ConsoleWriteLines("Save a new entity...");
-
-                context.Add(new Order { Price = new Money(3.99m, Currency.UsDollars) });
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContext())
-            {
-                ConsoleWriteLines("Read the entity back...");
-
-                var order = context.Set<Order>().Single();
-
-                ConsoleWriteLines($"Order with price {order.Price.Amount} in {order.Price.Currency}.");
-            }
-
-            ConsoleWriteLines("Sample finished.");
+            context.Add(new Order { Price = new Money(3.99m, Currency.UsDollars) });
+            context.SaveChanges();
         }
 
-        public class SampleDbContext : DbContext
+        using (var context = new SampleDbContext())
         {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                #region ConfigureCompositeValueObject
-                modelBuilder.Entity<Order>()
-                    .Property(e => e.Price)
-                    .HasConversion(
-                        v => JsonSerializer.Serialize(v, (JsonSerializerOptions)null),
-                        v => JsonSerializer.Deserialize<Money>(v, (JsonSerializerOptions)null));
-                #endregion
-            }
+            ConsoleWriteLines("Read the entity back...");
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlite("DataSource=test.db")
-                    .EnableSensitiveDataLogging();
+            var order = context.Set<Order>().Single();
+
+            ConsoleWriteLines($"Order with price {order.Price.Amount} in {order.Price.Currency}.");
         }
 
-        #region CompositeValueObjectModel
-        public class Order
-        {
-            public int Id { get; set; }
-
-            public Money Price { get; set; }
-        }
-        #endregion
-
-        #region CompositeValueObject
-        public readonly struct Money
-        {
-            [JsonConstructor]
-            public Money(decimal amount, Currency currency)
-            {
-                Amount = amount;
-                Currency = currency;
-            }
-
-            public override string ToString()
-                => (Currency == Currency.UsDollars ? "$" : "£") + Amount;
-
-            public decimal Amount { get; }
-            public Currency Currency { get; }
-        }
-
-        public enum Currency
-        {
-            UsDollars,
-            PoundsSterling
-        }
-        #endregion
+        ConsoleWriteLines("Sample finished.");
     }
+
+    public class SampleDbContext : DbContext
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            #region ConfigureCompositeValueObject
+            modelBuilder.Entity<Order>()
+                .Property(e => e.Price)
+                .HasConversion(
+                    v => JsonSerializer.Serialize(v, (JsonSerializerOptions)null),
+                    v => JsonSerializer.Deserialize<Money>(v, (JsonSerializerOptions)null));
+            #endregion
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
+                .UseSqlite("DataSource=test.db")
+                .EnableSensitiveDataLogging();
+    }
+
+    #region CompositeValueObjectModel
+    public class Order
+    {
+        public int Id { get; set; }
+
+        public Money Price { get; set; }
+    }
+    #endregion
+
+    #region CompositeValueObject
+    public readonly struct Money
+    {
+        [JsonConstructor]
+        public Money(decimal amount, Currency currency)
+        {
+            Amount = amount;
+            Currency = currency;
+        }
+
+        public override string ToString()
+            => (Currency == Currency.UsDollars ? "$" : "£") + Amount;
+
+        public decimal Amount { get; }
+        public Currency Currency { get; }
+    }
+
+    public enum Currency
+    {
+        UsDollars,
+        PoundsSterling
+    }
+    #endregion
 }

--- a/samples/core/Modeling/ValueConversions/EncryptPropertyValues.cs
+++ b/samples/core/Modeling/ValueConversions/EncryptPropertyValues.cs
@@ -6,61 +6,60 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class EncryptPropertyValues : Program
 {
-    public class EncryptPropertyValues : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing value conversions for encrypting property values...");
+
+        using (var context = new SampleDbContext())
         {
-            ConsoleWriteLines("Sample showing value conversions for encrypting property values...");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContext())
-            {
-                CleanDatabase(context);
+            ConsoleWriteLines("Save a new entity...");
 
-                ConsoleWriteLines("Save a new entity...");
-
-                context.Add(new User { Name = "arthur", Password = "password" });
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContext())
-            {
-                ConsoleWriteLines("Read the entity back...");
-
-                var user = context.Set<User>().Single();
-
-                ConsoleWriteLines($"User {user.Name} has password '{user.Password}'");
-            }
-
-            ConsoleWriteLines("Sample finished.");
+            context.Add(new User { Name = "arthur", Password = "password" });
+            context.SaveChanges();
         }
 
-        public class SampleDbContext : DbContext
+        using (var context = new SampleDbContext())
         {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                #region ConfigureEncryptPropertyValues
-                modelBuilder.Entity<User>().Property(e => e.Password).HasConversion(
-                    v => new string(v.Reverse().ToArray()),
-                    v => new string(v.Reverse().ToArray()));
-                #endregion
-            }
+            ConsoleWriteLines("Read the entity back...");
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EncryptPropertyValues;Trusted_Connection=True")
-                    .EnableSensitiveDataLogging();
+            var user = context.Set<User>().Single();
+
+            ConsoleWriteLines($"User {user.Name} has password '{user.Password}'");
         }
 
-        #region EncryptPropertyValuesModel
-        public class User
-        {
-            public int Id { get; set; }
-            public string Name { get; set; }
-            public string Password { get; set; }
-        }
-        #endregion
+        ConsoleWriteLines("Sample finished.");
     }
+
+    public class SampleDbContext : DbContext
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            #region ConfigureEncryptPropertyValues
+            modelBuilder.Entity<User>().Property(e => e.Password).HasConversion(
+                v => new string(v.Reverse().ToArray()),
+                v => new string(v.Reverse().ToArray()));
+            #endregion
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EncryptPropertyValues;Trusted_Connection=True")
+                .EnableSensitiveDataLogging();
+    }
+
+    #region EncryptPropertyValuesModel
+    public class User
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Password { get; set; }
+    }
+    #endregion
 }

--- a/samples/core/Modeling/ValueConversions/EnumToStringConversions.cs
+++ b/samples/core/Modeling/ValueConversions/EnumToStringConversions.cs
@@ -5,331 +5,330 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class EnumToStringConversions : Program
 {
-    public class EnumToStringConversions : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing explicitly configured value converter");
+
+        using (var context = new SampleDbContextExplicit())
         {
-            ConsoleWriteLines("Sample showing explicitly configured value converter");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContextExplicit())
-            {
-                CleanDatabase(context);
+            context.Add(new Rider { Mount = EquineBeast.Horse });
+            context.SaveChanges();
 
-                context.Add(new Rider { Mount = EquineBeast.Horse });
-                context.SaveChanges();
-
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContextExplicit())
-            {
-                ConsoleWriteLines($"Enum value read as '{context.Set<Rider>().Single().Mount}'.");
-            }
-
-            ConsoleWriteLines("Sample showing conversion configured by CLR type");
-
-            using (var context = new SampleDbContextByClrType())
-            {
-                CleanDatabase(context);
-
-                context.Add(new Rider { Mount = EquineBeast.Horse });
-                context.SaveChanges();
-
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContextByClrType())
-            {
-                ConsoleWriteLines($"Enum value read as '{context.Set<Rider>().Single().Mount}'.");
-            }
-
-            ConsoleWriteLines("Sample showing conversion configured by database type");
-
-            using (var context = new SampleDbContextByDatabaseType())
-            {
-                CleanDatabase(context);
-
-                context.Add(new Rider2 { Mount = EquineBeast.Horse });
-                context.SaveChanges();
-
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContextByDatabaseType())
-            {
-                ConsoleWriteLines($"Enum value read as '{context.Set<Rider2>().Single().Mount}'.");
-            }
-
-            ConsoleWriteLines("Sample showing conversion configured by a ValueConverter instance");
-
-            using (var context = new SampleDbContextByConverterInstance())
-            {
-                CleanDatabase(context);
-
-                context.Add(new Rider { Mount = EquineBeast.Horse });
-                context.SaveChanges();
-
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContextByConverterInstance())
-            {
-                ConsoleWriteLines($"Enum value read as '{context.Set<Rider>().Single().Mount}'.");
-            }
-
-            ConsoleWriteLines("Sample showing conversion configured by a built-in ValueConverter instance");
-
-            using (var context = new SampleDbContextByBuiltInInstance())
-            {
-                CleanDatabase(context);
-
-                context.Add(new Rider { Mount = EquineBeast.Horse });
-                context.SaveChanges();
-
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContextByBuiltInInstance())
-            {
-                ConsoleWriteLines($"Enum value read as '{context.Set<Rider>().Single().Mount}'.");
-            }
-
-            ConsoleWriteLines("Sample showing conversion configured by CLR type with per-property facets");
-
-            using (var context = new SampleDbContextByClrTypeWithFacets())
-            {
-                CleanDatabase(context);
-
-                context.Add(new Rider { Mount = EquineBeast.Horse });
-                context.SaveChanges();
-
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContextByClrTypeWithFacets())
-            {
-                ConsoleWriteLines($"Enum value read as '{context.Set<Rider>().Single().Mount}'.");
-            }
-
-            ConsoleWriteLines("Sample showing conversion configured by a ValueConverter instance with per-property facets");
-
-            using (var context = new SampleDbContextByConverterInstanceWithFacets())
-            {
-                CleanDatabase(context);
-
-                context.Add(new Rider { Mount = EquineBeast.Horse });
-                context.SaveChanges();
-
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContextByConverterInstanceWithFacets())
-            {
-                ConsoleWriteLines($"Enum value read as '{context.Set<Rider>().Single().Mount}'.");
-            }
+            context.SaveChanges();
         }
 
-        public class SampleDbContextExplicit : SampleDbContextBase
+        using (var context = new SampleDbContextExplicit())
         {
-            #region ExplicitConversion
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                modelBuilder
-                    .Entity<Rider>()
-                    .Property(e => e.Mount)
-                    .HasConversion(
-                        v => v.ToString(),
-                        v => (EquineBeast)Enum.Parse(typeof(EquineBeast), v));
-            }
-            #endregion
+            ConsoleWriteLines($"Enum value read as '{context.Set<Rider>().Single().Mount}'.");
         }
 
-        public class SampleDbContextByClrType : SampleDbContextBase
+        ConsoleWriteLines("Sample showing conversion configured by CLR type");
+
+        using (var context = new SampleDbContextByClrType())
         {
-            #region ConversionByClrType
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                modelBuilder
-                    .Entity<Rider>()
-                    .Property(e => e.Mount)
-                    .HasConversion<string>();
-            }
-            #endregion
+            CleanDatabase(context);
+
+            context.Add(new Rider { Mount = EquineBeast.Horse });
+            context.SaveChanges();
+
+            context.SaveChanges();
         }
 
-        public class SampleDbContextByDatabaseType : SampleDbContextBase
+        using (var context = new SampleDbContextByClrType())
         {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                modelBuilder.Entity<Rider2>();
-            }
+            ConsoleWriteLines($"Enum value read as '{context.Set<Rider>().Single().Mount}'.");
         }
 
-        public class SampleDbContextByConverterInstance : SampleDbContextBase
+        ConsoleWriteLines("Sample showing conversion configured by database type");
+
+        using (var context = new SampleDbContextByDatabaseType())
         {
-            #region ConversionByConverterInstance
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                var converter = new ValueConverter<EquineBeast, string>(
+            CleanDatabase(context);
+
+            context.Add(new Rider2 { Mount = EquineBeast.Horse });
+            context.SaveChanges();
+
+            context.SaveChanges();
+        }
+
+        using (var context = new SampleDbContextByDatabaseType())
+        {
+            ConsoleWriteLines($"Enum value read as '{context.Set<Rider2>().Single().Mount}'.");
+        }
+
+        ConsoleWriteLines("Sample showing conversion configured by a ValueConverter instance");
+
+        using (var context = new SampleDbContextByConverterInstance())
+        {
+            CleanDatabase(context);
+
+            context.Add(new Rider { Mount = EquineBeast.Horse });
+            context.SaveChanges();
+
+            context.SaveChanges();
+        }
+
+        using (var context = new SampleDbContextByConverterInstance())
+        {
+            ConsoleWriteLines($"Enum value read as '{context.Set<Rider>().Single().Mount}'.");
+        }
+
+        ConsoleWriteLines("Sample showing conversion configured by a built-in ValueConverter instance");
+
+        using (var context = new SampleDbContextByBuiltInInstance())
+        {
+            CleanDatabase(context);
+
+            context.Add(new Rider { Mount = EquineBeast.Horse });
+            context.SaveChanges();
+
+            context.SaveChanges();
+        }
+
+        using (var context = new SampleDbContextByBuiltInInstance())
+        {
+            ConsoleWriteLines($"Enum value read as '{context.Set<Rider>().Single().Mount}'.");
+        }
+
+        ConsoleWriteLines("Sample showing conversion configured by CLR type with per-property facets");
+
+        using (var context = new SampleDbContextByClrTypeWithFacets())
+        {
+            CleanDatabase(context);
+
+            context.Add(new Rider { Mount = EquineBeast.Horse });
+            context.SaveChanges();
+
+            context.SaveChanges();
+        }
+
+        using (var context = new SampleDbContextByClrTypeWithFacets())
+        {
+            ConsoleWriteLines($"Enum value read as '{context.Set<Rider>().Single().Mount}'.");
+        }
+
+        ConsoleWriteLines("Sample showing conversion configured by a ValueConverter instance with per-property facets");
+
+        using (var context = new SampleDbContextByConverterInstanceWithFacets())
+        {
+            CleanDatabase(context);
+
+            context.Add(new Rider { Mount = EquineBeast.Horse });
+            context.SaveChanges();
+
+            context.SaveChanges();
+        }
+
+        using (var context = new SampleDbContextByConverterInstanceWithFacets())
+        {
+            ConsoleWriteLines($"Enum value read as '{context.Set<Rider>().Single().Mount}'.");
+        }
+    }
+
+    public class SampleDbContextExplicit : SampleDbContextBase
+    {
+        #region ExplicitConversion
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .Entity<Rider>()
+                .Property(e => e.Mount)
+                .HasConversion(
                     v => v.ToString(),
                     v => (EquineBeast)Enum.Parse(typeof(EquineBeast), v));
-
-                modelBuilder
-                    .Entity<Rider>()
-                    .Property(e => e.Mount)
-                    .HasConversion(converter);
-            }
-            #endregion
-        }
-
-        public class SampleDbContextByClrTypeWithFacets : SampleDbContextBase
-        {
-            #region ConversionByClrTypeWithFacets
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                modelBuilder
-                    .Entity<Rider>()
-                    .Property(e => e.Mount)
-                    .HasConversion<string>()
-                    .HasMaxLength(20)
-                    .IsUnicode(false);
-            }
-            #endregion
-        }
-
-        public class SampleDbContextByConverterInstanceWithFacets : SampleDbContextBase
-        {
-            #region ConversionByConverterInstanceWithFacets
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                var converter = new ValueConverter<EquineBeast, string>(
-                    v => v.ToString(),
-                    v => (EquineBeast)Enum.Parse(typeof(EquineBeast), v));
-
-                modelBuilder
-                    .Entity<Rider>()
-                    .Property(e => e.Mount)
-                    .HasConversion(converter)
-                    .HasMaxLength(20)
-                    .IsUnicode(false);
-            }
-            #endregion
-        }
-
-        public class SampleDbContextByConverterInstanceWithMappingHints : SampleDbContextBase
-        {
-            #region ConversionByConverterInstanceWithMappingHints
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                var converter = new ValueConverter<EquineBeast, string>(
-                    v => v.ToString(),
-                    v => (EquineBeast)Enum.Parse(typeof(EquineBeast), v),
-                    new ConverterMappingHints(size: 20, unicode: false));
-
-                modelBuilder
-                    .Entity<Rider>()
-                    .Property(e => e.Mount)
-                    .HasConversion(converter);
-            }
-            #endregion
-        }
-
-        public class SampleDbContextByBuiltInInstance : SampleDbContextBase
-        {
-            #region ConversionByBuiltInInstance
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                var converter = new EnumToStringConverter<EquineBeast>();
-
-                modelBuilder
-                    .Entity<Rider>()
-                    .Property(e => e.Mount)
-                    .HasConversion(converter);
-            }
-            #endregion
-        }
-
-        public class SampleDbContextBoolToInt : SampleDbContextBase
-        {
-            #region ConversionByBuiltInBoolToInt
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                modelBuilder
-                    .Entity<User>()
-                    .Property(e => e.IsActive)
-                    .HasConversion<int>();
-            }
-            #endregion
-        }
-
-        public class SampleDbContextBoolToIntExplicit : SampleDbContextBase
-        {
-            #region ConversionByBuiltInBoolToIntExplicit
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                var converter = new BoolToZeroOneConverter<int>();
-
-                modelBuilder
-                    .Entity<User>()
-                    .Property(e => e.IsActive)
-                    .HasConversion(converter);
-            }
-            #endregion
-        }
-
-        public class SampleDbContextRider2 : SampleDbContextBase
-        {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                #region ConversionByDatabaseTypeFluent
-                modelBuilder
-                    .Entity<Rider2>()
-                    .Property(e => e.Mount)
-                    .HasColumnType("nvarchar(24)");
-                #endregion
-            }
-        }
-        public class SampleDbContextBase : DbContext
-        {
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EnumConversions;Trusted_Connection=True")
-                    .EnableSensitiveDataLogging();
-        }
-
-        #region BeastAndRider
-        public class Rider
-        {
-            public int Id { get; set; }
-            public EquineBeast Mount { get; set; }
-        }
-
-        public enum EquineBeast
-        {
-            Donkey,
-            Mule,
-            Horse,
-            Unicorn
         }
         #endregion
+    }
 
-        #region ConversionByDatabaseType
-        public class Rider2
+    public class SampleDbContextByClrType : SampleDbContextBase
+    {
+        #region ConversionByClrType
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            public int Id { get; set; }
-
-            [Column(TypeName = "nvarchar(24)")]
-            public EquineBeast Mount { get; set; }
+            modelBuilder
+                .Entity<Rider>()
+                .Property(e => e.Mount)
+                .HasConversion<string>();
         }
         #endregion
+    }
 
-        public class User
+    public class SampleDbContextByDatabaseType : SampleDbContextBase
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            public int Id { get; set; }
-            public bool IsActive { get; set; }
+            modelBuilder.Entity<Rider2>();
         }
+    }
+
+    public class SampleDbContextByConverterInstance : SampleDbContextBase
+    {
+        #region ConversionByConverterInstance
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            var converter = new ValueConverter<EquineBeast, string>(
+                v => v.ToString(),
+                v => (EquineBeast)Enum.Parse(typeof(EquineBeast), v));
+
+            modelBuilder
+                .Entity<Rider>()
+                .Property(e => e.Mount)
+                .HasConversion(converter);
+        }
+        #endregion
+    }
+
+    public class SampleDbContextByClrTypeWithFacets : SampleDbContextBase
+    {
+        #region ConversionByClrTypeWithFacets
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .Entity<Rider>()
+                .Property(e => e.Mount)
+                .HasConversion<string>()
+                .HasMaxLength(20)
+                .IsUnicode(false);
+        }
+        #endregion
+    }
+
+    public class SampleDbContextByConverterInstanceWithFacets : SampleDbContextBase
+    {
+        #region ConversionByConverterInstanceWithFacets
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            var converter = new ValueConverter<EquineBeast, string>(
+                v => v.ToString(),
+                v => (EquineBeast)Enum.Parse(typeof(EquineBeast), v));
+
+            modelBuilder
+                .Entity<Rider>()
+                .Property(e => e.Mount)
+                .HasConversion(converter)
+                .HasMaxLength(20)
+                .IsUnicode(false);
+        }
+        #endregion
+    }
+
+    public class SampleDbContextByConverterInstanceWithMappingHints : SampleDbContextBase
+    {
+        #region ConversionByConverterInstanceWithMappingHints
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            var converter = new ValueConverter<EquineBeast, string>(
+                v => v.ToString(),
+                v => (EquineBeast)Enum.Parse(typeof(EquineBeast), v),
+                new ConverterMappingHints(size: 20, unicode: false));
+
+            modelBuilder
+                .Entity<Rider>()
+                .Property(e => e.Mount)
+                .HasConversion(converter);
+        }
+        #endregion
+    }
+
+    public class SampleDbContextByBuiltInInstance : SampleDbContextBase
+    {
+        #region ConversionByBuiltInInstance
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            var converter = new EnumToStringConverter<EquineBeast>();
+
+            modelBuilder
+                .Entity<Rider>()
+                .Property(e => e.Mount)
+                .HasConversion(converter);
+        }
+        #endregion
+    }
+
+    public class SampleDbContextBoolToInt : SampleDbContextBase
+    {
+        #region ConversionByBuiltInBoolToInt
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .Entity<User>()
+                .Property(e => e.IsActive)
+                .HasConversion<int>();
+        }
+        #endregion
+    }
+
+    public class SampleDbContextBoolToIntExplicit : SampleDbContextBase
+    {
+        #region ConversionByBuiltInBoolToIntExplicit
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            var converter = new BoolToZeroOneConverter<int>();
+
+            modelBuilder
+                .Entity<User>()
+                .Property(e => e.IsActive)
+                .HasConversion(converter);
+        }
+        #endregion
+    }
+
+    public class SampleDbContextRider2 : SampleDbContextBase
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            #region ConversionByDatabaseTypeFluent
+            modelBuilder
+                .Entity<Rider2>()
+                .Property(e => e.Mount)
+                .HasColumnType("nvarchar(24)");
+            #endregion
+        }
+    }
+    public class SampleDbContextBase : DbContext
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EnumConversions;Trusted_Connection=True")
+                .EnableSensitiveDataLogging();
+    }
+
+    #region BeastAndRider
+    public class Rider
+    {
+        public int Id { get; set; }
+        public EquineBeast Mount { get; set; }
+    }
+
+    public enum EquineBeast
+    {
+        Donkey,
+        Mule,
+        Horse,
+        Unicorn
+    }
+    #endregion
+
+    #region ConversionByDatabaseType
+    public class Rider2
+    {
+        public int Id { get; set; }
+
+        [Column(TypeName = "nvarchar(24)")]
+        public EquineBeast Mount { get; set; }
+    }
+    #endregion
+
+    public class User
+    {
+        public int Id { get; set; }
+        public bool IsActive { get; set; }
     }
 }

--- a/samples/core/Modeling/ValueConversions/FixedLengthStrings.cs
+++ b/samples/core/Modeling/ValueConversions/FixedLengthStrings.cs
@@ -9,106 +9,105 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class FixedLengthStrings : Program
 {
-    public class FixedLengthStrings : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing value conversions for fixed-length, case-insensitive string keys...");
+
+        using (var context = new SampleDbContext())
         {
-            ConsoleWriteLines("Sample showing value conversions for fixed-length, case-insensitive string keys...");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContext())
-            {
-                CleanDatabase(context);
+            ConsoleWriteLines("Save new entities...");
 
-                ConsoleWriteLines("Save new entities...");
-
-                context.AddRange(
-                    new Blog
-                    {
-                        Id = "dotnet",
-                        Name = ".NET Blog",
-                    },
-                    new Post
-                    {
-                        Id = "post1",
-                        BlogId = "dotnet",
-                        Title = "Some good .NET stuff"
-                    },
-                    new Post
-                    {
-                        Id = "Post2",
-                        BlogId = "DotNet",
-                        Title = "Some more good .NET stuff"
-                    });
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContext())
-            {
-                ConsoleWriteLines("Read the entities back...");
-
-                var blog = context.Set<Blog>().Include(e => e.Posts).Single();
-
-                ConsoleWriteLines($"The blog has {blog.Posts.Count} posts with foreign keys '{blog.Posts.First().BlogId}' and '{blog.Posts.Skip(1).First().BlogId}'");
-            }
-
-            ConsoleWriteLines("Sample finished.");
+            context.AddRange(
+                new Blog
+                {
+                    Id = "dotnet",
+                    Name = ".NET Blog",
+                },
+                new Post
+                {
+                    Id = "post1",
+                    BlogId = "dotnet",
+                    Title = "Some good .NET stuff"
+                },
+                new Post
+                {
+                    Id = "Post2",
+                    BlogId = "DotNet",
+                    Title = "Some more good .NET stuff"
+                });
+            context.SaveChanges();
         }
 
-        public class SampleDbContext : DbContext
+        using (var context = new SampleDbContext())
         {
-            #region ConfigureFixedLengthStrings
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                var converter = new ValueConverter<string, string>(
-                    v => v,
-                    v => v.Trim());
+            ConsoleWriteLines("Read the entities back...");
+
+            var blog = context.Set<Blog>().Include(e => e.Posts).Single();
+
+            ConsoleWriteLines($"The blog has {blog.Posts.Count} posts with foreign keys '{blog.Posts.First().BlogId}' and '{blog.Posts.Skip(1).First().BlogId}'");
+        }
+
+        ConsoleWriteLines("Sample finished.");
+    }
+
+    public class SampleDbContext : DbContext
+    {
+        #region ConfigureFixedLengthStrings
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            var converter = new ValueConverter<string, string>(
+                v => v,
+                v => v.Trim());
                 
-                var comparer = new ValueComparer<string>(
-                    (l, r) => string.Equals(l, r, StringComparison.OrdinalIgnoreCase),
-                    v => v.ToUpper().GetHashCode(),
-                    v => v);
+            var comparer = new ValueComparer<string>(
+                (l, r) => string.Equals(l, r, StringComparison.OrdinalIgnoreCase),
+                v => v.ToUpper().GetHashCode(),
+                v => v);
 
-                modelBuilder.Entity<Blog>()
-                    .Property(e => e.Id)
-                    .HasColumnType("char(20)")
-                    .HasConversion(converter, comparer);
+            modelBuilder.Entity<Blog>()
+                .Property(e => e.Id)
+                .HasColumnType("char(20)")
+                .HasConversion(converter, comparer);
 
-                modelBuilder.Entity<Post>(
-                    b =>
-                        {
-                            b.Property(e => e.Id).HasColumnType("char(20)").HasConversion(converter, comparer);
-                            b.Property(e => e.BlogId).HasColumnType("char(20)").HasConversion(converter, comparer);
-                        });
-            }
-            #endregion
-
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=FixedLengthStrings;Trusted_Connection=True")
-                    .EnableSensitiveDataLogging();
-        }
-
-        #region FixedLengthStringsModel
-        public class Blog
-        {
-            public string Id { get; set; }
-            public string Name { get; set; }
-
-            public ICollection<Post> Posts { get; set; }
-        }
-
-        public class Post
-        {
-            public string Id { get; set; }
-            public string Title { get; set; }
-            public string Content { get; set; }
-
-            public string BlogId { get; set; }
-            public Blog Blog { get; set; }
+            modelBuilder.Entity<Post>(
+                b =>
+                {
+                    b.Property(e => e.Id).HasColumnType("char(20)").HasConversion(converter, comparer);
+                    b.Property(e => e.BlogId).HasColumnType("char(20)").HasConversion(converter, comparer);
+                });
         }
         #endregion
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=FixedLengthStrings;Trusted_Connection=True")
+                .EnableSensitiveDataLogging();
     }
+
+    #region FixedLengthStringsModel
+    public class Blog
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+
+        public ICollection<Post> Posts { get; set; }
+    }
+
+    public class Post
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+
+        public string BlogId { get; set; }
+        public Blog Blog { get; set; }
+    }
+    #endregion
 }

--- a/samples/core/Modeling/ValueConversions/KeyValueObjects.cs
+++ b/samples/core/Modeling/ValueConversions/KeyValueObjects.cs
@@ -8,109 +8,108 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class KeyValueObjects : Program
 {
-    public class KeyValueObjects : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing value conversions for a value objects used as keys...");
+
+        using (var context = new SampleDbContext())
         {
-            ConsoleWriteLines("Sample showing value conversions for a value objects used as keys...");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContext())
+            ConsoleWriteLines("Save a new entity...");
+
+            var blog = new Blog
             {
-                CleanDatabase(context);
-
-                ConsoleWriteLines("Save a new entity...");
-
-                var blog = new Blog
+                Id = new BlogKey(1),
+                Posts = new List<Post>
                 {
-                    Id = new BlogKey(1),
-                    Posts = new List<Post>
+                    new Post
                     {
-                        new Post
-                        {
-                            Id = new PostKey(1)
-                        },
-                        new Post
-                        {
-                            Id = new PostKey(2)
-                        },
-                    }
-                };
-                context.Add(blog);
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContext())
-            {
-                ConsoleWriteLines("Read the entity back...");
-
-                var blog = context.Set<Blog>().Include(e => e.Posts).Single();
-            }
-
-            ConsoleWriteLines("Sample finished.");
+                        Id = new PostKey(1)
+                    },
+                    new Post
+                    {
+                        Id = new PostKey(2)
+                    },
+                }
+            };
+            context.Add(blog);
+            context.SaveChanges();
         }
 
-        public class SampleDbContext : DbContext
+        using (var context = new SampleDbContext())
         {
-            #region ConfigureKeyValueObjects
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                var blogKeyConverter = new ValueConverter<BlogKey, int>(
-                    v => v.Id,
-                    v => new BlogKey(v));
+            ConsoleWriteLines("Read the entity back...");
 
-                modelBuilder.Entity<Blog>().Property(e => e.Id).HasConversion(blogKeyConverter);
-
-                modelBuilder.Entity<Post>(
-                    b =>
-                        {
-                            b.Property(e => e.Id).HasConversion(v => v.Id, v => new PostKey(v));
-                            b.Property(e => e.BlogId).HasConversion(blogKeyConverter);
-                        });
-            }
-            #endregion
-
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlite("DataSource=test.db")
-                    .EnableSensitiveDataLogging();
+            var blog = context.Set<Blog>().Include(e => e.Posts).Single();
         }
 
-        #region KeyValueObjectsModel
-        public class Blog
-        {
-            public BlogKey Id { get; set; }
-            public string Name { get; set; }
-
-            public ICollection<Post> Posts { get; set; }
-        }
-
-        public class Post
-        {
-            public PostKey Id { get; set; }
-
-            public string Title { get; set; }
-            public string Content { get; set; }
-
-            public BlogKey? BlogId { get; set; }
-            public Blog Blog { get; set; }
-        }
-        #endregion
-
-        #region KeyValueObjects
-        public readonly struct BlogKey
-        {
-            public BlogKey(int id) => Id = id;
-            public int Id { get; }
-        }
-
-        public readonly struct PostKey
-        {
-            public PostKey(int id) => Id = id;
-            public int Id { get; }
-        }
-        #endregion
+        ConsoleWriteLines("Sample finished.");
     }
+
+    public class SampleDbContext : DbContext
+    {
+        #region ConfigureKeyValueObjects
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            var blogKeyConverter = new ValueConverter<BlogKey, int>(
+                v => v.Id,
+                v => new BlogKey(v));
+
+            modelBuilder.Entity<Blog>().Property(e => e.Id).HasConversion(blogKeyConverter);
+
+            modelBuilder.Entity<Post>(
+                b =>
+                {
+                    b.Property(e => e.Id).HasConversion(v => v.Id, v => new PostKey(v));
+                    b.Property(e => e.BlogId).HasConversion(blogKeyConverter);
+                });
+        }
+        #endregion
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
+                .UseSqlite("DataSource=test.db")
+                .EnableSensitiveDataLogging();
+    }
+
+    #region KeyValueObjectsModel
+    public class Blog
+    {
+        public BlogKey Id { get; set; }
+        public string Name { get; set; }
+
+        public ICollection<Post> Posts { get; set; }
+    }
+
+    public class Post
+    {
+        public PostKey Id { get; set; }
+
+        public string Title { get; set; }
+        public string Content { get; set; }
+
+        public BlogKey? BlogId { get; set; }
+        public Blog Blog { get; set; }
+    }
+    #endregion
+
+    #region KeyValueObjects
+    public readonly struct BlogKey
+    {
+        public BlogKey(int id) => Id = id;
+        public int Id { get; }
+    }
+
+    public readonly struct PostKey
+    {
+        public PostKey(int id) => Id = id;
+        public int Id { get; }
+    }
+    #endregion
 }

--- a/samples/core/Modeling/ValueConversions/MappingImmutableClassProperty.cs
+++ b/samples/core/Modeling/ValueConversions/MappingImmutableClassProperty.cs
@@ -3,93 +3,92 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class MappingImmutableClassProperty : Program
 {
-    public class MappingImmutableClassProperty : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing value conversions for a simple immutable class...");
+
+        using (var context = new SampleDbContext())
         {
-            ConsoleWriteLines("Sample showing value conversions for a simple immutable class...");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContext())
-            {
-                CleanDatabase(context);
+            ConsoleWriteLines("Save a new entity...");
 
-                ConsoleWriteLines("Save a new entity...");
+            var entity = new MyEntityType { MyProperty = new ImmutableClass(7) };
+            context.Add(entity);
+            context.SaveChanges();
 
-                var entity = new MyEntityType { MyProperty = new ImmutableClass(7) };
-                context.Add(entity);
-                context.SaveChanges();
+            ConsoleWriteLines("Change the property value and save again...");
 
-                ConsoleWriteLines("Change the property value and save again...");
+            // This will be detected and EF will update the database on SaveChanges
+            entity.MyProperty = new ImmutableClass(77);
 
-                // This will be detected and EF will update the database on SaveChanges
-                entity.MyProperty = new ImmutableClass(77);
-
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContext())
-            {
-                ConsoleWriteLines("Read the entity back...");
-
-                var entity = context.Set<MyEntityType>().Single();
-
-                Debug.Assert(entity.MyProperty.Value == 77);
-            }
-
-            ConsoleWriteLines("Sample finished.");
+            context.SaveChanges();
         }
 
-        public class SampleDbContext : DbContext
+        using (var context = new SampleDbContext())
         {
-            private static readonly ILoggerFactory
-                Logger = LoggerFactory.Create(x => x.AddConsole()); //.SetMinimumLevel(LogLevel.Debug));
+            ConsoleWriteLines("Read the entity back...");
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                #region ConfigureImmutableClassProperty
-                modelBuilder
-                    .Entity<MyEntityType>()
-                    .Property(e => e.MyProperty)
-                    .HasConversion(
-                        v => v.Value,
-                        v => new ImmutableClass(v));
-                #endregion
-            }
+            var entity = context.Set<MyEntityType>().Single();
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .UseLoggerFactory(Logger)
-                    .UseSqlite("DataSource=test.db")
-                    .EnableSensitiveDataLogging();
+            Debug.Assert(entity.MyProperty.Value == 77);
         }
 
-        public class MyEntityType
-        {
-            public int Id { get; set; }
-            public ImmutableClass MyProperty { get; set; }
-        }
-
-        #region SimpleImmutableClass
-        public sealed class ImmutableClass
-        {
-            public ImmutableClass(int value)
-            {
-                Value = value;
-            }
-
-            public int Value { get; }
-
-            private bool Equals(ImmutableClass other)
-                => Value == other.Value;
-
-            public override bool Equals(object obj)
-                => ReferenceEquals(this, obj) || obj is ImmutableClass other && Equals(other);
-
-            public override int GetHashCode()
-                => Value.GetHashCode();
-        }
-        #endregion
+        ConsoleWriteLines("Sample finished.");
     }
+
+    public class SampleDbContext : DbContext
+    {
+        private static readonly ILoggerFactory
+            Logger = LoggerFactory.Create(x => x.AddConsole()); //.SetMinimumLevel(LogLevel.Debug));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            #region ConfigureImmutableClassProperty
+            modelBuilder
+                .Entity<MyEntityType>()
+                .Property(e => e.MyProperty)
+                .HasConversion(
+                    v => v.Value,
+                    v => new ImmutableClass(v));
+            #endregion
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .UseLoggerFactory(Logger)
+                .UseSqlite("DataSource=test.db")
+                .EnableSensitiveDataLogging();
+    }
+
+    public class MyEntityType
+    {
+        public int Id { get; set; }
+        public ImmutableClass MyProperty { get; set; }
+    }
+
+    #region SimpleImmutableClass
+    public sealed class ImmutableClass
+    {
+        public ImmutableClass(int value)
+        {
+            Value = value;
+        }
+
+        public int Value { get; }
+
+        private bool Equals(ImmutableClass other)
+            => Value == other.Value;
+
+        public override bool Equals(object obj)
+            => ReferenceEquals(this, obj) || obj is ImmutableClass other && Equals(other);
+
+        public override int GetHashCode()
+            => Value.GetHashCode();
+    }
+    #endregion
 }

--- a/samples/core/Modeling/ValueConversions/MappingImmutableStructProperty.cs
+++ b/samples/core/Modeling/ValueConversions/MappingImmutableStructProperty.cs
@@ -3,84 +3,83 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class MappingImmutableStructProperty : Program
 {
-    public class MappingImmutableStructProperty : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing value conversions for a simple immutable struct...");
+
+        using (var context = new SampleDbContext())
         {
-            ConsoleWriteLines("Sample showing value conversions for a simple immutable struct...");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContext())
-            {
-                CleanDatabase(context);
+            ConsoleWriteLines("Save a new entity...");
 
-                ConsoleWriteLines("Save a new entity...");
+            var entity = new EntityType { MyProperty = new ImmutableStruct(6) };
+            context.Add(entity);
+            context.SaveChanges();
 
-                var entity = new EntityType { MyProperty = new ImmutableStruct(6) };
-                context.Add(entity);
-                context.SaveChanges();
+            ConsoleWriteLines("Change the property value and save again...");
 
-                ConsoleWriteLines("Change the property value and save again...");
+            // This will be detected and EF will update the database on SaveChanges
+            entity.MyProperty = new ImmutableStruct(66);
 
-                // This will be detected and EF will update the database on SaveChanges
-                entity.MyProperty = new ImmutableStruct(66);
-
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContext())
-            {
-                ConsoleWriteLines("Read the entity back...");
-
-                var entity = context.Set<EntityType>().Single();
-
-                Debug.Assert(entity.MyProperty.Value == 66);
-            }
-
-            ConsoleWriteLines("Sample finished.");
+            context.SaveChanges();
         }
 
-        public class SampleDbContext : DbContext
+        using (var context = new SampleDbContext())
         {
-            private static readonly ILoggerFactory
-                Logger = LoggerFactory.Create(x => x.AddConsole()); //.SetMinimumLevel(LogLevel.Debug));
+            ConsoleWriteLines("Read the entity back...");
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                #region ConfigureImmutableStructProperty
-                modelBuilder
-                    .Entity<EntityType>()
-                    .Property(e => e.MyProperty)
-                    .HasConversion(
-                        v => v.Value,
-                        v => new ImmutableStruct(v));
-                #endregion
-            }
+            var entity = context.Set<EntityType>().Single();
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .UseLoggerFactory(Logger)
-                    .UseSqlite("DataSource=test.db")
-                    .EnableSensitiveDataLogging();
+            Debug.Assert(entity.MyProperty.Value == 66);
         }
 
-        public class EntityType
-        {
-            public int Id { get; set; }
-            public ImmutableStruct MyProperty { get; set; }
-        }
-
-        #region SimpleImmutableStruct
-        public readonly struct ImmutableStruct
-        {
-            public ImmutableStruct(int value)
-            {
-                Value = value;
-            }
-
-            public int Value { get; }
-        }
-        #endregion
+        ConsoleWriteLines("Sample finished.");
     }
+
+    public class SampleDbContext : DbContext
+    {
+        private static readonly ILoggerFactory
+            Logger = LoggerFactory.Create(x => x.AddConsole()); //.SetMinimumLevel(LogLevel.Debug));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            #region ConfigureImmutableStructProperty
+            modelBuilder
+                .Entity<EntityType>()
+                .Property(e => e.MyProperty)
+                .HasConversion(
+                    v => v.Value,
+                    v => new ImmutableStruct(v));
+            #endregion
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .UseLoggerFactory(Logger)
+                .UseSqlite("DataSource=test.db")
+                .EnableSensitiveDataLogging();
+    }
+
+    public class EntityType
+    {
+        public int Id { get; set; }
+        public ImmutableStruct MyProperty { get; set; }
+    }
+
+    #region SimpleImmutableStruct
+    public readonly struct ImmutableStruct
+    {
+        public ImmutableStruct(int value)
+        {
+            Value = value;
+        }
+
+        public int Value { get; }
+    }
+    #endregion
 }

--- a/samples/core/Modeling/ValueConversions/MappingListProperty.cs
+++ b/samples/core/Modeling/ValueConversions/MappingListProperty.cs
@@ -7,79 +7,78 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.Extensions.Logging;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class MappingListProperty : Program
 {
-    public class MappingListProperty : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing value conversions for a List<int>...");
+
+        using (var context = new SampleDbContext())
         {
-            ConsoleWriteLines("Sample showing value conversions for a List<int>...");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContext())
-            {
-                CleanDatabase(context);
+            ConsoleWriteLines("Save a new entity...");
 
-                ConsoleWriteLines("Save a new entity...");
+            var entity = new EntityType { MyListProperty = new List<int> { 1, 2, 3 } };
+            context.Add(entity);
+            context.SaveChanges();
 
-                var entity = new EntityType { MyListProperty = new List<int> { 1, 2, 3 } };
-                context.Add(entity);
-                context.SaveChanges();
+            ConsoleWriteLines("Mutate the property value and save again...");
 
-                ConsoleWriteLines("Mutate the property value and save again...");
+            // This will be detected and EF will update the database on SaveChanges
+            entity.MyListProperty.Add(4);
 
-                // This will be detected and EF will update the database on SaveChanges
-                entity.MyListProperty.Add(4);
-
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContext())
-            {
-                ConsoleWriteLines("Read the entity back...");
-
-                var entity = context.Set<EntityType>().Single();
-
-                Debug.Assert(entity.MyListProperty.SequenceEqual(new List<int> { 1, 2, 3, 4 }));
-            }
-
-            ConsoleWriteLines("Sample finished.");
+            context.SaveChanges();
         }
 
-        public class SampleDbContext : DbContext
+        using (var context = new SampleDbContext())
         {
-            private static readonly ILoggerFactory
-                Logger = LoggerFactory.Create(x => x.AddConsole()); //.SetMinimumLevel(LogLevel.Debug));
+            ConsoleWriteLines("Read the entity back...");
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                #region ConfigureListProperty
-                modelBuilder
-                    .Entity<EntityType>()
-                    .Property(e => e.MyListProperty)
-                    .HasConversion(
-                        v => JsonSerializer.Serialize(v, (JsonSerializerOptions)null),
-                        v => JsonSerializer.Deserialize<List<int>>(v, (JsonSerializerOptions)null),
-                        new ValueComparer<List<int>>(
-                            (c1, c2) => c1.SequenceEqual(c2),
-                            c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
-                            c => c.ToList()));
-                #endregion
-            }
+            var entity = context.Set<EntityType>().Single();
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .UseLoggerFactory(Logger)
-                    .UseSqlite("DataSource=test.db")
-                    .EnableSensitiveDataLogging();
+            Debug.Assert(entity.MyListProperty.SequenceEqual(new List<int> { 1, 2, 3, 4 }));
         }
 
-        public class EntityType
-        {
-            public int Id { get; set; }
+        ConsoleWriteLines("Sample finished.");
+    }
 
-            #region ListProperty
-            public List<int> MyListProperty { get; set; }
+    public class SampleDbContext : DbContext
+    {
+        private static readonly ILoggerFactory
+            Logger = LoggerFactory.Create(x => x.AddConsole()); //.SetMinimumLevel(LogLevel.Debug));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            #region ConfigureListProperty
+            modelBuilder
+                .Entity<EntityType>()
+                .Property(e => e.MyListProperty)
+                .HasConversion(
+                    v => JsonSerializer.Serialize(v, (JsonSerializerOptions)null),
+                    v => JsonSerializer.Deserialize<List<int>>(v, (JsonSerializerOptions)null),
+                    new ValueComparer<List<int>>(
+                        (c1, c2) => c1.SequenceEqual(c2),
+                        c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
+                        c => c.ToList()));
             #endregion
         }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .UseLoggerFactory(Logger)
+                .UseSqlite("DataSource=test.db")
+                .EnableSensitiveDataLogging();
+    }
+
+    public class EntityType
+    {
+        public int Id { get; set; }
+
+        #region ListProperty
+        public List<int> MyListProperty { get; set; }
+        #endregion
     }
 }

--- a/samples/core/Modeling/ValueConversions/MappingListPropertyOld.cs
+++ b/samples/core/Modeling/ValueConversions/MappingListPropertyOld.cs
@@ -7,86 +7,85 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.Extensions.Logging;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class MappingListPropertyOld : Program
 {
-    public class MappingListPropertyOld : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing value conversions for a List<int>...");
+
+        using (var context = new SampleDbContext())
         {
-            ConsoleWriteLines("Sample showing value conversions for a List<int>...");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContext())
-            {
-                CleanDatabase(context);
+            ConsoleWriteLines("Save a new entity...");
 
-                ConsoleWriteLines("Save a new entity...");
+            var entity = new EntityType { MyListProperty = new List<int> { 1, 2, 3 } };
+            context.Add(entity);
+            context.SaveChanges();
 
-                var entity = new EntityType { MyListProperty = new List<int> { 1, 2, 3 } };
-                context.Add(entity);
-                context.SaveChanges();
+            ConsoleWriteLines("Mutate the property value and save again...");
 
-                ConsoleWriteLines("Mutate the property value and save again...");
+            // This will be detected and EF will update the database on SaveChanges
+            entity.MyListProperty.Add(4);
 
-                // This will be detected and EF will update the database on SaveChanges
-                entity.MyListProperty.Add(4);
-
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContext())
-            {
-                ConsoleWriteLines("Read the entity back...");
-
-                var entity = context.Set<EntityType>().Single();
-
-                Debug.Assert(entity.MyListProperty.SequenceEqual(new List<int> { 1, 2, 3, 4 }));
-            }
-
-            ConsoleWriteLines("Sample finished.");
+            context.SaveChanges();
         }
 
-        public class SampleDbContext : DbContext
+        using (var context = new SampleDbContext())
         {
-            private static readonly ILoggerFactory
-                Logger = LoggerFactory.Create(x => x.AddConsole()); //.SetMinimumLevel(LogLevel.Debug));
+            ConsoleWriteLines("Read the entity back...");
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                #region ConfigureListProperty
-                modelBuilder
-                    .Entity<EntityType>()
-                    .Property(e => e.MyListProperty)
-                    .HasConversion(
-                        v => JsonSerializer.Serialize(v, (JsonSerializerOptions)null),
-                        v => JsonSerializer.Deserialize<List<int>>(v, (JsonSerializerOptions)null));
+            var entity = context.Set<EntityType>().Single();
 
-                var valueComparer = new ValueComparer<List<int>>(
-                    (c1, c2) => c1.SequenceEqual(c2),
-                    c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
-                    c => c.ToList());
-
-                modelBuilder
-                    .Entity<EntityType>()
-                    .Property(e => e.MyListProperty)
-                    .Metadata
-                    .SetValueComparer(valueComparer);
-                #endregion
-            }
-
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .UseLoggerFactory(Logger)
-                    .UseSqlite("DataSource=test.db")
-                    .EnableSensitiveDataLogging();
+            Debug.Assert(entity.MyListProperty.SequenceEqual(new List<int> { 1, 2, 3, 4 }));
         }
 
-        public class EntityType
-        {
-            public int Id { get; set; }
+        ConsoleWriteLines("Sample finished.");
+    }
 
-            #region ListProperty
-            public List<int> MyListProperty { get; set; }
+    public class SampleDbContext : DbContext
+    {
+        private static readonly ILoggerFactory
+            Logger = LoggerFactory.Create(x => x.AddConsole()); //.SetMinimumLevel(LogLevel.Debug));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            #region ConfigureListProperty
+            modelBuilder
+                .Entity<EntityType>()
+                .Property(e => e.MyListProperty)
+                .HasConversion(
+                    v => JsonSerializer.Serialize(v, (JsonSerializerOptions)null),
+                    v => JsonSerializer.Deserialize<List<int>>(v, (JsonSerializerOptions)null));
+
+            var valueComparer = new ValueComparer<List<int>>(
+                (c1, c2) => c1.SequenceEqual(c2),
+                c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
+                c => c.ToList());
+
+            modelBuilder
+                .Entity<EntityType>()
+                .Property(e => e.MyListProperty)
+                .Metadata
+                .SetValueComparer(valueComparer);
             #endregion
         }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .UseLoggerFactory(Logger)
+                .UseSqlite("DataSource=test.db")
+                .EnableSensitiveDataLogging();
+    }
+
+    public class EntityType
+    {
+        public int Id { get; set; }
+
+        #region ListProperty
+        public List<int> MyListProperty { get; set; }
+        #endregion
     }
 }

--- a/samples/core/Modeling/ValueConversions/OverridingByteArrayComparisons.cs
+++ b/samples/core/Modeling/ValueConversions/OverridingByteArrayComparisons.cs
@@ -5,77 +5,76 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.Extensions.Logging;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class OverridingByteArrayComparisons : Program
 {
-    public class OverridingByteArrayComparisons : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing overriding byte array comparisons...");
+
+        using (var context = new SampleDbContext())
         {
-            ConsoleWriteLines("Sample showing overriding byte array comparisons...");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContext())
-            {
-                CleanDatabase(context);
+            ConsoleWriteLines("Save a new entity...");
 
-                ConsoleWriteLines("Save a new entity...");
+            var entity = new EntityType { MyBytes = new byte[] { 1, 2, 3 } };
+            context.Add(entity);
+            context.SaveChanges();
 
-                var entity = new EntityType { MyBytes = new byte[] { 1, 2, 3 } };
-                context.Add(entity);
-                context.SaveChanges();
+            ConsoleWriteLines("Mutate the property value and save again...");
 
-                ConsoleWriteLines("Mutate the property value and save again...");
+            // Normally mutating the byte array would not be detected by EF Core.
+            // In this case it will be detected because the comparer in the model is overridden.
+            entity.MyBytes[1] = 4;
 
-                // Normally mutating the byte array would not be detected by EF Core.
-                // In this case it will be detected because the comparer in the model is overridden.
-                entity.MyBytes[1] = 4;
-
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContext())
-            {
-                ConsoleWriteLines("Read the entity back...");
-
-                var entity = context.Set<EntityType>().Single();
-
-                Debug.Assert(entity.MyBytes.SequenceEqual(new byte[] { 1, 4, 3 }));
-            }
-
-            ConsoleWriteLines("Sample finished.");
+            context.SaveChanges();
         }
 
-        public class SampleDbContext : DbContext
+        using (var context = new SampleDbContext())
         {
-            private static readonly ILoggerFactory
-                Logger = LoggerFactory.Create(x => x.AddConsole()); //.SetMinimumLevel(LogLevel.Debug));
+            ConsoleWriteLines("Read the entity back...");
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                #region OverrideComparer
-                modelBuilder
-                    .Entity<EntityType>()
-                    .Property(e => e.MyBytes)
-                    .Metadata
-                    .SetValueComparer(
-                        new ValueComparer<byte[]>(
-                            (c1, c2) => c1.SequenceEqual(c2),
-                            c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
-                            c => c.ToArray()));
-                #endregion
-            }
+            var entity = context.Set<EntityType>().Single();
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .UseLoggerFactory(Logger)
-                    .UseSqlite("DataSource=test.db")
-                    .EnableSensitiveDataLogging();
+            Debug.Assert(entity.MyBytes.SequenceEqual(new byte[] { 1, 4, 3 }));
         }
 
-        public class EntityType
-        {
-            public int Id { get; set; }
+        ConsoleWriteLines("Sample finished.");
+    }
 
-            public byte[] MyBytes { get; set; }
+    public class SampleDbContext : DbContext
+    {
+        private static readonly ILoggerFactory
+            Logger = LoggerFactory.Create(x => x.AddConsole()); //.SetMinimumLevel(LogLevel.Debug));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            #region OverrideComparer
+            modelBuilder
+                .Entity<EntityType>()
+                .Property(e => e.MyBytes)
+                .Metadata
+                .SetValueComparer(
+                    new ValueComparer<byte[]>(
+                        (c1, c2) => c1.SequenceEqual(c2),
+                        c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
+                        c => c.ToArray()));
+            #endregion
         }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .UseLoggerFactory(Logger)
+                .UseSqlite("DataSource=test.db")
+                .EnableSensitiveDataLogging();
+    }
+
+    public class EntityType
+    {
+        public int Id { get; set; }
+
+        public byte[] MyBytes { get; set; }
     }
 }

--- a/samples/core/Modeling/ValueConversions/PreserveDateTimeKind.cs
+++ b/samples/core/Modeling/ValueConversions/PreserveDateTimeKind.cs
@@ -6,100 +6,99 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class PreserveDateTimeKind : Program
 {
-    public class PreserveDateTimeKind : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing value conversions for preserving/setting DateTime.Kind...");
+
+        using (var context = new SampleDbContext())
         {
-            ConsoleWriteLines("Sample showing value conversions for preserving/setting DateTime.Kind...");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContext())
-            {
-                CleanDatabase(context);
+            ConsoleWriteLines("Save new entities...");
 
-                ConsoleWriteLines("Save new entities...");
-
-                context.AddRange(
-                    new Post
-                    {
-                        Title = "Post 1",
-                        PostedOn = new DateTime(1973, 9, 3, 0, 0, 0, 0, DateTimeKind.Utc),
-                        LastUpdated = new DateTime(1974, 9, 3, 0, 0, 0, 0, DateTimeKind.Utc),
-                        DeletedOn = new DateTime(2007, 9, 3, 0, 0, 0, 0, DateTimeKind.Utc)
-                    },
-                    new Post
-                    {
-                        Title = "Post 2",
-                        PostedOn = new DateTime(1975, 9, 3, 0, 0, 0, 0, DateTimeKind.Local),
-                        LastUpdated = new DateTime(1976, 9, 3, 0, 0, 0, 0, DateTimeKind.Utc),
-                        DeletedOn = new DateTime(2017, 9, 3, 0, 0, 0, 0, DateTimeKind.Utc)
-                    });
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContext())
-            {
-                ConsoleWriteLines("Read the entities back...");
-
-                var blog1 = context.Set<Post>().Single(e => e.Title == "Post 1");
-
-                ConsoleWriteLines($"Blog 1: PostedOn.Kind = {blog1.PostedOn.Kind} LastUpdated.Kind = {blog1.LastUpdated.Kind} DeletedOn.Kind = {blog1.DeletedOn.Kind}");
-
-                var blog2 = context.Set<Post>().Single(e => e.Title == "Post 2");
-
-                ConsoleWriteLines($"Blog 2: PostedOn.Kind = {blog2.PostedOn.Kind} LastUpdated.Kind = {blog2.LastUpdated.Kind} DeletedOn.Kind = {blog2.DeletedOn.Kind}");
-            }
-
-            ConsoleWriteLines("Sample finished.");
+            context.AddRange(
+                new Post
+                {
+                    Title = "Post 1",
+                    PostedOn = new DateTime(1973, 9, 3, 0, 0, 0, 0, DateTimeKind.Utc),
+                    LastUpdated = new DateTime(1974, 9, 3, 0, 0, 0, 0, DateTimeKind.Utc),
+                    DeletedOn = new DateTime(2007, 9, 3, 0, 0, 0, 0, DateTimeKind.Utc)
+                },
+                new Post
+                {
+                    Title = "Post 2",
+                    PostedOn = new DateTime(1975, 9, 3, 0, 0, 0, 0, DateTimeKind.Local),
+                    LastUpdated = new DateTime(1976, 9, 3, 0, 0, 0, 0, DateTimeKind.Utc),
+                    DeletedOn = new DateTime(2017, 9, 3, 0, 0, 0, 0, DateTimeKind.Utc)
+                });
+            context.SaveChanges();
         }
 
-        public class SampleDbContext : DbContext
+        using (var context = new SampleDbContext())
         {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                #region ConfigurePreserveDateTimeKind1
-                modelBuilder.Entity<Post>()
-                    .Property(e => e.PostedOn)
-                    .HasConversion<long>();
-                #endregion
+            ConsoleWriteLines("Read the entities back...");
 
-                #region ConfigurePreserveDateTimeKind2
-                modelBuilder.Entity<Post>()
-                    .Property(e => e.LastUpdated)
-                    .HasConversion(
-                        v => v,
-                        v => new DateTime(v.Ticks, DateTimeKind.Utc));
-                #endregion
+            var blog1 = context.Set<Post>().Single(e => e.Title == "Post 1");
 
-                #region ConfigurePreserveDateTimeKind3
-                modelBuilder.Entity<Post>()
-                    .Property(e => e.LastUpdated)
-                    .HasConversion(
-                        v => v.ToUniversalTime(),
-                        v => new DateTime(v.Ticks, DateTimeKind.Utc));
-                #endregion
-            }
+            ConsoleWriteLines($"Blog 1: PostedOn.Kind = {blog1.PostedOn.Kind} LastUpdated.Kind = {blog1.LastUpdated.Kind} DeletedOn.Kind = {blog1.DeletedOn.Kind}");
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=PreserveDateTimeKind;Trusted_Connection=True")
-                    .EnableSensitiveDataLogging();
+            var blog2 = context.Set<Post>().Single(e => e.Title == "Post 2");
+
+            ConsoleWriteLines($"Blog 2: PostedOn.Kind = {blog2.PostedOn.Kind} LastUpdated.Kind = {blog2.LastUpdated.Kind} DeletedOn.Kind = {blog2.DeletedOn.Kind}");
         }
 
-        #region PreserveDateTimeKindModel
-        public class Post
-        {
-            public int Id { get; set; }
-
-            public string Title { get; set; }
-            public string Content { get; set; }
-
-            public DateTime PostedOn { get; set; }
-            public DateTime LastUpdated { get; set; }
-            public DateTime DeletedOn { get; set; }
-        }
-        #endregion
+        ConsoleWriteLines("Sample finished.");
     }
+
+    public class SampleDbContext : DbContext
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            #region ConfigurePreserveDateTimeKind1
+            modelBuilder.Entity<Post>()
+                .Property(e => e.PostedOn)
+                .HasConversion<long>();
+            #endregion
+
+            #region ConfigurePreserveDateTimeKind2
+            modelBuilder.Entity<Post>()
+                .Property(e => e.LastUpdated)
+                .HasConversion(
+                    v => v,
+                    v => new DateTime(v.Ticks, DateTimeKind.Utc));
+            #endregion
+
+            #region ConfigurePreserveDateTimeKind3
+            modelBuilder.Entity<Post>()
+                .Property(e => e.LastUpdated)
+                .HasConversion(
+                    v => v.ToUniversalTime(),
+                    v => new DateTime(v.Ticks, DateTimeKind.Utc));
+            #endregion
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=PreserveDateTimeKind;Trusted_Connection=True")
+                .EnableSensitiveDataLogging();
+    }
+
+    #region PreserveDateTimeKindModel
+    public class Post
+    {
+        public int Id { get; set; }
+
+        public string Title { get; set; }
+        public string Content { get; set; }
+
+        public DateTime PostedOn { get; set; }
+        public DateTime LastUpdated { get; set; }
+        public DateTime DeletedOn { get; set; }
+    }
+    #endregion
 }

--- a/samples/core/Modeling/ValueConversions/Program.cs
+++ b/samples/core/Modeling/ValueConversions/Program.cs
@@ -1,51 +1,50 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+/// <summary>
+///     Samples for value conversions and comparisons.
+/// </summary>
+public class Program
 {
-    /// <summary>
-    ///     Samples for value conversions and comparisons.
-    /// </summary>
-    public class Program
+    public static void Main()
     {
-        public static void Main()
+        new MappingImmutableClassProperty().Run();
+        new MappingImmutableStructProperty().Run();
+        new MappingListProperty().Run();
+        new MappingListPropertyOld().Run();
+        new OverridingByteArrayComparisons().Run();
+        new EnumToStringConversions().Run();
+        new KeyValueObjects().Run();
+        new SimpleValueObject().Run();
+        new CompositeValueObject().Run();
+        new PrimitiveCollection().Run();
+        new ValueObjectCollection().Run();
+        new ULongConcurrency().Run();
+        new PreserveDateTimeKind().Run();
+        new CaseInsensitiveStrings().Run();
+        new FixedLengthStrings().Run();
+        new EncryptPropertyValues().Run();
+        new WithMappingHints().Run();
+    }
+
+    protected static void ConsoleWriteLines(params string[] values)
+    {
+        Console.WriteLine();
+        foreach (var value in values)
         {
-            new MappingImmutableClassProperty().Run();
-            new MappingImmutableStructProperty().Run();
-            new MappingListProperty().Run();
-            new MappingListPropertyOld().Run();
-            new OverridingByteArrayComparisons().Run();
-            new EnumToStringConversions().Run();
-            new KeyValueObjects().Run();
-            new SimpleValueObject().Run();
-            new CompositeValueObject().Run();
-            new PrimitiveCollection().Run();
-            new ValueObjectCollection().Run();
-            new ULongConcurrency().Run();
-            new PreserveDateTimeKind().Run();
-            new CaseInsensitiveStrings().Run();
-            new FixedLengthStrings().Run();
-            new EncryptPropertyValues().Run();
-            new WithMappingHints().Run();
+            Console.WriteLine(value);
         }
 
-        protected static void ConsoleWriteLines(params string[] values)
-        {
-            Console.WriteLine();
-            foreach (var value in values)
-            {
-                Console.WriteLine(value);
-            }
+        Console.WriteLine();
+    }
 
-            Console.WriteLine();
-        }
-
-        protected static void CleanDatabase(DbContext context)
-        {
-            ConsoleWriteLines("Deleting and re-creating database...");
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-            ConsoleWriteLines("Done. Database is clean and fresh.");
-        }
+    protected static void CleanDatabase(DbContext context)
+    {
+        ConsoleWriteLines("Deleting and re-creating database...");
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+        ConsoleWriteLines("Done. Database is clean and fresh.");
     }
 }

--- a/samples/core/Modeling/ValueConversions/SimpleValueObject.cs
+++ b/samples/core/Modeling/ValueConversions/SimpleValueObject.cs
@@ -6,74 +6,73 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class SimpleValueObject : Program
 {
-    public class SimpleValueObject : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing value conversions for a simple value object...");
+
+        using (var context = new SampleDbContext())
         {
-            ConsoleWriteLines("Sample showing value conversions for a simple value object...");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContext())
-            {
-                CleanDatabase(context);
+            ConsoleWriteLines("Save a new entity...");
 
-                ConsoleWriteLines("Save a new entity...");
-
-                context.Add(new Order { Price = new Dollars(3.99m) });
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContext())
-            {
-                ConsoleWriteLines("Read the entity back...");
-
-                var entity = context.Set<Order>().Single();
-            }
-
-            ConsoleWriteLines("Sample finished.");
+            context.Add(new Order { Price = new Dollars(3.99m) });
+            context.SaveChanges();
         }
 
-        public class SampleDbContext : DbContext
+        using (var context = new SampleDbContext())
         {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                #region ConfigureImmutableStructProperty
-                modelBuilder.Entity<Order>()
-                    .Property(e => e.Price)
-                    .HasConversion(
-                        v => v.Amount,
-                        v => new Dollars(v));
-                #endregion
-            }
+            ConsoleWriteLines("Read the entity back...");
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlite("DataSource=test.db")
-                    .EnableSensitiveDataLogging();
+            var entity = context.Set<Order>().Single();
         }
 
-        #region SimpleValueObjectModel
-        public class Order
-        {
-            public int Id { get; set; }
-
-            public Dollars Price { get; set; }
-        }
-        #endregion
-
-        #region SimpleValueObject
-        public readonly struct Dollars
-        {
-            public Dollars(decimal amount) 
-                => Amount = amount;
-            
-            public decimal Amount { get; }
-
-            public override string ToString() 
-                => $"${Amount}";
-        }
-        #endregion
+        ConsoleWriteLines("Sample finished.");
     }
+
+    public class SampleDbContext : DbContext
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            #region ConfigureImmutableStructProperty
+            modelBuilder.Entity<Order>()
+                .Property(e => e.Price)
+                .HasConversion(
+                    v => v.Amount,
+                    v => new Dollars(v));
+            #endregion
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
+                .UseSqlite("DataSource=test.db")
+                .EnableSensitiveDataLogging();
+    }
+
+    #region SimpleValueObjectModel
+    public class Order
+    {
+        public int Id { get; set; }
+
+        public Dollars Price { get; set; }
+    }
+    #endregion
+
+    #region SimpleValueObject
+    public readonly struct Dollars
+    {
+        public Dollars(decimal amount) 
+            => Amount = amount;
+            
+        public decimal Amount { get; }
+
+        public override string ToString() 
+            => $"${Amount}";
+    }
+    #endregion
 }

--- a/samples/core/Modeling/ValueConversions/ULongConcurrency.cs
+++ b/samples/core/Modeling/ValueConversions/ULongConcurrency.cs
@@ -6,91 +6,90 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class ULongConcurrency : Program
 {
-    public class ULongConcurrency : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing how to map rowversion to ulong...");
+
+        using (var context = new SampleDbContext())
         {
-            ConsoleWriteLines("Sample showing how to map rowversion to ulong...");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContext())
+            ConsoleWriteLines("Save a new entity...");
+
+            context.Add(
+                new Blog
+                {
+                    Name = "OneUnicorn"
+                });
+            context.SaveChanges();
+        }
+
+        using (var context = new SampleDbContext())
+        {
+            ConsoleWriteLines("Read the entity back in one context...");
+
+            var blog = context.Set<Blog>().Single();
+            blog.Name = "TwoUnicorns";
+
+            using (var context2 = new SampleDbContext())
             {
-                CleanDatabase(context);
+                ConsoleWriteLines("Change the blog name and save in a different context...");
 
-                ConsoleWriteLines("Save a new entity...");
+                context2.Set<Blog>().Single().Name = "1unicorn2";
+                context2.SaveChanges();
+            }
 
-                context.Add(
-                    new Blog
-                    {
-                        Name = "OneUnicorn"
-                    });
+            try
+            {
+                ConsoleWriteLines("Change the blog name and save in the first context...");
+
                 context.SaveChanges();
             }
-
-            using (var context = new SampleDbContext())
+            catch (DbUpdateConcurrencyException e)
             {
-                ConsoleWriteLines("Read the entity back in one context...");
+                ConsoleWriteLines($"{e.GetType().FullName}: {e.Message}");
 
-                var blog = context.Set<Blog>().Single();
-                blog.Name = "TwoUnicorns";
+                var databaseValues = context.Entry(blog).GetDatabaseValues();
+                context.Entry(blog).OriginalValues.SetValues(databaseValues);
 
-                using (var context2 = new SampleDbContext())
-                {
-                    ConsoleWriteLines("Change the blog name and save in a different context...");
+                ConsoleWriteLines("Refresh original values and save again...");
 
-                    context2.Set<Blog>().Single().Name = "1unicorn2";
-                    context2.SaveChanges();
-                }
-
-                try
-                {
-                    ConsoleWriteLines("Change the blog name and save in the first context...");
-
-                    context.SaveChanges();
-                }
-                catch (DbUpdateConcurrencyException e)
-                {
-                    ConsoleWriteLines($"{e.GetType().FullName}: {e.Message}");
-
-                    var databaseValues = context.Entry(blog).GetDatabaseValues();
-                    context.Entry(blog).OriginalValues.SetValues(databaseValues);
-
-                    ConsoleWriteLines("Refresh original values and save again...");
-
-                    context.SaveChanges();
-                }
+                context.SaveChanges();
             }
-
-            ConsoleWriteLines("Sample finished.");
         }
 
-        public class SampleDbContext : DbContext
-        {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                #region ConfigureULongConcurrency
-                modelBuilder.Entity<Blog>()
-                    .Property(e => e.Version)
-                    .IsRowVersion()
-                    .HasConversion<byte[]>();
-                #endregion
-            }
-
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=ULongConcurrency;Trusted_Connection=True")
-                    .EnableSensitiveDataLogging();
-        }
-
-        #region ULongConcurrencyModel
-        public class Blog
-        {
-            public int Id { get; set; }
-            public string Name { get; set; }
-            public ulong Version { get; set; }
-        }
-        #endregion
+        ConsoleWriteLines("Sample finished.");
     }
+
+    public class SampleDbContext : DbContext
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            #region ConfigureULongConcurrency
+            modelBuilder.Entity<Blog>()
+                .Property(e => e.Version)
+                .IsRowVersion()
+                .HasConversion<byte[]>();
+            #endregion
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=ULongConcurrency;Trusted_Connection=True")
+                .EnableSensitiveDataLogging();
+    }
+
+    #region ULongConcurrencyModel
+    public class Blog
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public ulong Version { get; set; }
+    }
+    #endregion
 }

--- a/samples/core/Modeling/ValueConversions/ValueObjectCollection.cs
+++ b/samples/core/Modeling/ValueConversions/ValueObjectCollection.cs
@@ -10,124 +10,123 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class ValueObjectCollection : Program
 {
-    public class ValueObjectCollection : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing value conversions for a collection of value objects...");
+
+        using (var context = new SampleDbContext())
         {
-            ConsoleWriteLines("Sample showing value conversions for a collection of value objects...");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContext())
-            {
-                CleanDatabase(context);
+            ConsoleWriteLines("Save a new entity...");
 
-                ConsoleWriteLines("Save a new entity...");
-
-                context.Add(
-                    new Blog
+            context.Add(
+                new Blog
+                {
+                    Finances = new List<AnnualFinance>
                     {
-                        Finances = new List<AnnualFinance>
-                        {
-                            new AnnualFinance(2018, new Money(326.65m, Currency.UsDollars), new Money(125m, Currency.UsDollars)),
-                            new AnnualFinance(2019, new Money(112.20m, Currency.UsDollars), new Money(125m, Currency.UsDollars)),
-                            new AnnualFinance(2020, new Money(25.77m, Currency.UsDollars), new Money(125m, Currency.UsDollars))
-                        }
-                    });
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContext())
-            {
-                ConsoleWriteLines("Read the entity back...");
-
-                var blog = context.Set<Blog>().Single();
-
-                ConsoleWriteLines($"Blog with finances {string.Join(", ", blog.Finances.Select(f => $"{f.Year}: I={f.Income} E={f.Expenses} R={f.Revenue}"))}.");
-
-                ConsoleWriteLines("Changing the value object and saving again");
-
-                blog.Finances.Add(new AnnualFinance(2021, new Money(12.0m, Currency.UsDollars), new Money(125m, Currency.UsDollars)));
-                context.SaveChanges();
-            }
-
-            ConsoleWriteLines("Sample finished.");
+                        new AnnualFinance(2018, new Money(326.65m, Currency.UsDollars), new Money(125m, Currency.UsDollars)),
+                        new AnnualFinance(2019, new Money(112.20m, Currency.UsDollars), new Money(125m, Currency.UsDollars)),
+                        new AnnualFinance(2020, new Money(25.77m, Currency.UsDollars), new Money(125m, Currency.UsDollars))
+                    }
+                });
+            context.SaveChanges();
         }
 
-        public class SampleDbContext : DbContext
+        using (var context = new SampleDbContext())
         {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                #region ConfigureValueObjectCollection
-                modelBuilder.Entity<Blog>()
-                    .Property(e => e.Finances)
-                    .HasConversion(
-                        v => JsonSerializer.Serialize(v, (JsonSerializerOptions)null),
-                        v => JsonSerializer.Deserialize<List<AnnualFinance>>(v, (JsonSerializerOptions)null),
-                        new ValueComparer<IList<AnnualFinance>>(
-                            (c1, c2) => c1.SequenceEqual(c2),
-                            c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
-                            c => (IList<AnnualFinance>)c.ToList()));
-                #endregion
-            }
+            ConsoleWriteLines("Read the entity back...");
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlite("DataSource=test.db")
-                    .EnableSensitiveDataLogging();
+            var blog = context.Set<Blog>().Single();
+
+            ConsoleWriteLines($"Blog with finances {string.Join(", ", blog.Finances.Select(f => $"{f.Year}: I={f.Income} E={f.Expenses} R={f.Revenue}"))}.");
+
+            ConsoleWriteLines("Changing the value object and saving again");
+
+            blog.Finances.Add(new AnnualFinance(2021, new Money(12.0m, Currency.UsDollars), new Money(125m, Currency.UsDollars)));
+            context.SaveChanges();
         }
 
-        #region ValueObjectCollection
-        public readonly struct AnnualFinance
-        {
-            [JsonConstructor]
-            public AnnualFinance(int year, Money income, Money expenses)
-            {
-                Year = year;
-                Income = income;
-                Expenses = expenses;
-            }
-
-            public int Year { get; }
-            public Money Income { get; }
-            public Money Expenses { get; }
-            public Money Revenue => new Money(Income.Amount - Expenses.Amount, Income.Currency);
-        }
-        #endregion
-
-        #region ValueObjectCollectionMoney
-        public readonly struct Money
-        {
-            [JsonConstructor]
-            public Money(decimal amount, Currency currency)
-            {
-                Amount = amount;
-                Currency = currency;
-            }
-
-            public override string ToString()
-                => (Currency == Currency.UsDollars ? "$" : "£") + Amount;
-
-            public decimal Amount { get; }
-            public Currency Currency { get; }
-        }
-
-        public enum Currency
-        {
-            UsDollars,
-            PoundsSterling
-        }
-        #endregion
-
-        #region ValueObjectCollectionModel
-        public class Blog
-        {
-            public int Id { get; set; }
-            public string Name { get; set; }
-
-            public IList<AnnualFinance> Finances { get; set; }
-        }
-        #endregion
+        ConsoleWriteLines("Sample finished.");
     }
+
+    public class SampleDbContext : DbContext
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            #region ConfigureValueObjectCollection
+            modelBuilder.Entity<Blog>()
+                .Property(e => e.Finances)
+                .HasConversion(
+                    v => JsonSerializer.Serialize(v, (JsonSerializerOptions)null),
+                    v => JsonSerializer.Deserialize<List<AnnualFinance>>(v, (JsonSerializerOptions)null),
+                    new ValueComparer<IList<AnnualFinance>>(
+                        (c1, c2) => c1.SequenceEqual(c2),
+                        c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
+                        c => (IList<AnnualFinance>)c.ToList()));
+            #endregion
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
+                .UseSqlite("DataSource=test.db")
+                .EnableSensitiveDataLogging();
+    }
+
+    #region ValueObjectCollection
+    public readonly struct AnnualFinance
+    {
+        [JsonConstructor]
+        public AnnualFinance(int year, Money income, Money expenses)
+        {
+            Year = year;
+            Income = income;
+            Expenses = expenses;
+        }
+
+        public int Year { get; }
+        public Money Income { get; }
+        public Money Expenses { get; }
+        public Money Revenue => new Money(Income.Amount - Expenses.Amount, Income.Currency);
+    }
+    #endregion
+
+    #region ValueObjectCollectionMoney
+    public readonly struct Money
+    {
+        [JsonConstructor]
+        public Money(decimal amount, Currency currency)
+        {
+            Amount = amount;
+            Currency = currency;
+        }
+
+        public override string ToString()
+            => (Currency == Currency.UsDollars ? "$" : "£") + Amount;
+
+        public decimal Amount { get; }
+        public Currency Currency { get; }
+    }
+
+    public enum Currency
+    {
+        UsDollars,
+        PoundsSterling
+    }
+    #endregion
+
+    #region ValueObjectCollectionModel
+    public class Blog
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public IList<AnnualFinance> Finances { get; set; }
+    }
+    #endregion
 }

--- a/samples/core/Modeling/ValueConversions/WithMappingHints.cs
+++ b/samples/core/Modeling/ValueConversions/WithMappingHints.cs
@@ -7,84 +7,83 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace EFModeling.ValueConversions
+namespace EFModeling.ValueConversions;
+
+public class WithMappingHints : Program
 {
-    public class WithMappingHints : Program
+    public void Run()
     {
-        public void Run()
+        ConsoleWriteLines("Sample showing value conversions with mapping hints for facets...");
+
+        using (var context = new SampleDbContext())
         {
-            ConsoleWriteLines("Sample showing value conversions with mapping hints for facets...");
+            CleanDatabase(context);
 
-            using (var context = new SampleDbContext())
-            {
-                CleanDatabase(context);
+            ConsoleWriteLines("Save a entities...");
 
-                ConsoleWriteLines("Save a entities...");
-
-                context.Add(new Order1 { Price = new Dollars(3.99m) });
-                context.Add(new Order2 { Price = new Dollars(3.99m) });
-                context.SaveChanges();
-            }
-
-            using (var context = new SampleDbContext())
-            {
-                ConsoleWriteLines("Read the entities back...");
-
-                var entity1 = context.Set<Order1>().Single();
-                var entity2 = context.Set<Order2>().Single();
-            }
-
-            ConsoleWriteLines("Sample finished.");
+            context.Add(new Order1 { Price = new Dollars(3.99m) });
+            context.Add(new Order2 { Price = new Dollars(3.99m) });
+            context.SaveChanges();
         }
 
-        public class SampleDbContext : DbContext
+        using (var context = new SampleDbContext())
         {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                #region ConverterWithMappingHints
-                var converter = new ValueConverter<Dollars, decimal>(
-                    v => v.Amount,
-                    v => new Dollars(v),
-                    new ConverterMappingHints(precision: 16, scale: 2));
-                #endregion
+            ConsoleWriteLines("Read the entities back...");
 
-                modelBuilder.Entity<Order1>()
-                    .Property(e => e.Price)
-                    .HasConversion(converter);
-
-                #region ConfigureWithFacets
-                modelBuilder.Entity<Order2>()
-                    .Property(e => e.Price)
-                    .HasConversion(converter)
-                    .HasPrecision(20, 2);
-                #endregion
-            }
-
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
-                    .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=WithMappingHints;Trusted_Connection=True")
-                    .EnableSensitiveDataLogging();
+            var entity1 = context.Set<Order1>().Single();
+            var entity2 = context.Set<Order2>().Single();
         }
 
-        public class Order1
-        {
-            public int Id { get; set; }
+        ConsoleWriteLines("Sample finished.");
+    }
 
-            public Dollars Price { get; set; }
+    public class SampleDbContext : DbContext
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            #region ConverterWithMappingHints
+            var converter = new ValueConverter<Dollars, decimal>(
+                v => v.Amount,
+                v => new Dollars(v),
+                new ConverterMappingHints(precision: 16, scale: 2));
+            #endregion
+
+            modelBuilder.Entity<Order1>()
+                .Property(e => e.Price)
+                .HasConversion(converter);
+
+            #region ConfigureWithFacets
+            modelBuilder.Entity<Order2>()
+                .Property(e => e.Price)
+                .HasConversion(converter)
+                .HasPrecision(20, 2);
+            #endregion
         }
 
-        public class Order2
-        {
-            public int Id { get; set; }
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .LogTo(Console.WriteLine, new[] { RelationalEventId.CommandExecuted })
+                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=WithMappingHints;Trusted_Connection=True")
+                .EnableSensitiveDataLogging();
+    }
 
-            public Dollars Price { get; set; }
-        }
+    public class Order1
+    {
+        public int Id { get; set; }
 
-        public readonly struct Dollars
-        {
-            public Dollars(decimal amount) => Amount = amount;
-            public decimal Amount { get; }
-        }
+        public Dollars Price { get; set; }
+    }
+
+    public class Order2
+    {
+        public int Id { get; set; }
+
+        public Dollars Price { get; set; }
+    }
+
+    public readonly struct Dollars
+    {
+        public Dollars(decimal amount) => Amount = amount;
+        public decimal Amount { get; }
     }
 }

--- a/samples/core/Performance/AspNetContextPooling/Controllers/WeatherForecastController.cs
+++ b/samples/core/Performance/AspNetContextPooling/Controllers/WeatherForecastController.cs
@@ -1,18 +1,17 @@
 using Microsoft.AspNetCore.Mvc;
 
-namespace Performance.AspNetContextPooling.Controllers
+namespace Performance.AspNetContextPooling.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class WeatherForecastController : ControllerBase
 {
-    [ApiController]
-    [Route("[controller]")]
-    public class WeatherForecastController : ControllerBase
-    {
-        private readonly WeatherForecastContext _dbContext;
+    private readonly WeatherForecastContext _dbContext;
 
-        public WeatherForecastController(WeatherForecastContext dbContext)
-            => _dbContext = dbContext;
+    public WeatherForecastController(WeatherForecastContext dbContext)
+        => _dbContext = dbContext;
 
-        [HttpGet(Name = "GetWeatherForecast")]
-        public IEnumerable<WeatherForecast> Get()
-            => _dbContext.Forecasts.OrderBy(f => f.Date).Take(5).ToArray();
-    }
+    [HttpGet(Name = "GetWeatherForecast")]
+    public IEnumerable<WeatherForecast> Get()
+        => _dbContext.Forecasts.OrderBy(f => f.Date).Take(5).ToArray();
 }

--- a/samples/core/Performance/AspNetContextPooling/WeatherForecast.cs
+++ b/samples/core/Performance/AspNetContextPooling/WeatherForecast.cs
@@ -1,12 +1,11 @@
-namespace Performance.AspNetContextPooling
-{
-    public class WeatherForecast
-    {
-        public int Id { get; set; }
+namespace Performance.AspNetContextPooling;
 
-        public DateTime Date { get; set; }
-        public int TemperatureC { get; set; }
-        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-        public string Summary { get; set; }
-    }
+public class WeatherForecast
+{
+    public int Id { get; set; }
+
+    public DateTime Date { get; set; }
+    public int TemperatureC { get; set; }
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    public string Summary { get; set; }
 }

--- a/samples/core/Performance/AspNetContextPooling/WeatherForecastContext.cs
+++ b/samples/core/Performance/AspNetContextPooling/WeatherForecastContext.cs
@@ -1,40 +1,39 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace Performance.AspNetContextPooling
+namespace Performance.AspNetContextPooling;
+
+public class WeatherForecastContext : DbContext
 {
-    public class WeatherForecastContext : DbContext
+    public WeatherForecastContext(DbContextOptions options)
+        : base(options)
     {
-        public WeatherForecastContext(DbContextOptions options)
-            : base(options)
-        {
-        }
+    }
 
-        public DbSet<WeatherForecast> Forecasts { get; set; }
+    public DbSet<WeatherForecast> Forecasts { get; set; }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<WeatherForecast>().HasData(
-                new WeatherForecast
-                {
-                    Id = 1,
-                    Date = new(2022, 1, 1),
-                    Summary = "Chilly",
-                    TemperatureC = -17
-                },
-                new WeatherForecast
-                {
-                    Id = 2,
-                    Date = new(2022, 1, 2),
-                    Summary = "Balmy",
-                    TemperatureC = 38
-                },
-                new WeatherForecast
-                {
-                    Id = 3,
-                    Date = new(2022, 1, 3),
-                    Summary = "Sweltering",
-                    TemperatureC = -7
-                });
-        }
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<WeatherForecast>().HasData(
+            new WeatherForecast
+            {
+                Id = 1,
+                Date = new(2022, 1, 1),
+                Summary = "Chilly",
+                TemperatureC = -17
+            },
+            new WeatherForecast
+            {
+                Id = 2,
+                Date = new(2022, 1, 2),
+                Summary = "Balmy",
+                TemperatureC = 38
+            },
+            new WeatherForecast
+            {
+                Id = 3,
+                Date = new(2022, 1, 3),
+                Summary = "Sweltering",
+                TemperatureC = -7
+            });
     }
 }

--- a/samples/core/Performance/AspNetContextPoolingWithState/Controllers/WeatherForecastController.cs
+++ b/samples/core/Performance/AspNetContextPoolingWithState/Controllers/WeatherForecastController.cs
@@ -1,18 +1,17 @@
 using Microsoft.AspNetCore.Mvc;
 
-namespace Performance.AspNetContextPoolingWithState.Controllers
+namespace Performance.AspNetContextPoolingWithState.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class WeatherForecastController : ControllerBase
 {
-    [ApiController]
-    [Route("[controller]")]
-    public class WeatherForecastController : ControllerBase
-    {
-        private readonly WeatherForecastContext _dbContext;
+    private readonly WeatherForecastContext _dbContext;
 
-        public WeatherForecastController(WeatherForecastContext dbContext)
-            => _dbContext = dbContext;
+    public WeatherForecastController(WeatherForecastContext dbContext)
+        => _dbContext = dbContext;
 
-        [HttpGet(Name = "GetWeatherForecast")]
-        public IEnumerable<WeatherForecast> Get()
-            => _dbContext.Forecasts.OrderBy(f => f.Date).Take(5).ToArray();
-    }
+    [HttpGet(Name = "GetWeatherForecast")]
+    public IEnumerable<WeatherForecast> Get()
+        => _dbContext.Forecasts.OrderBy(f => f.Date).Take(5).ToArray();
 }

--- a/samples/core/Performance/AspNetContextPoolingWithState/WeatherForecast.cs
+++ b/samples/core/Performance/AspNetContextPoolingWithState/WeatherForecast.cs
@@ -1,13 +1,12 @@
-namespace Performance.AspNetContextPoolingWithState
-{
-    public class WeatherForecast
-    {
-        public int Id { get; set; }
-        public int TenantId { get; set; }
+namespace Performance.AspNetContextPoolingWithState;
 
-        public DateTime Date { get; set; }
-        public int TemperatureC { get; set; }
-        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-        public string Summary { get; set; }
-    }
+public class WeatherForecast
+{
+    public int Id { get; set; }
+    public int TenantId { get; set; }
+
+    public DateTime Date { get; set; }
+    public int TemperatureC { get; set; }
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    public string Summary { get; set; }
 }

--- a/samples/core/Performance/AspNetContextPoolingWithState/WeatherForecastContext.cs
+++ b/samples/core/Performance/AspNetContextPoolingWithState/WeatherForecastContext.cs
@@ -1,47 +1,46 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace Performance.AspNetContextPoolingWithState
+namespace Performance.AspNetContextPoolingWithState;
+
+public class WeatherForecastContext : DbContext
 {
-    public class WeatherForecastContext : DbContext
+    public int TenantId { get; set; }
+
+    public WeatherForecastContext(DbContextOptions options)
+        : base(options)
     {
-        public int TenantId { get; set; }
+    }
 
-        public WeatherForecastContext(DbContextOptions options)
-            : base(options)
-        {
-        }
+    public DbSet<WeatherForecast> Forecasts { get; set; }
 
-        public DbSet<WeatherForecast> Forecasts { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<WeatherForecast>()
-                .HasQueryFilter(f => f.TenantId == TenantId)
-                .HasData(
-                    new WeatherForecast
-                    {
-                        Id = 1,
-                        TenantId = 0,
-                        Date = new(2022, 1, 1),
-                        Summary = "Chilly",
-                        TemperatureC = -17
-                    },
-                    new WeatherForecast
-                    {
-                        Id = 2,
-                        TenantId = 0,
-                        Date = new(2022, 1, 2),
-                        Summary = "Balmy",
-                        TemperatureC = 38
-                    },
-                    new WeatherForecast
-                    {
-                        Id = 3,
-                        TenantId = 1,
-                        Date = new(2022, 1, 3),
-                        Summary = "Sweltering",
-                        TemperatureC = -7
-                    });
-        }
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<WeatherForecast>()
+            .HasQueryFilter(f => f.TenantId == TenantId)
+            .HasData(
+                new WeatherForecast
+                {
+                    Id = 1,
+                    TenantId = 0,
+                    Date = new(2022, 1, 1),
+                    Summary = "Chilly",
+                    TemperatureC = -17
+                },
+                new WeatherForecast
+                {
+                    Id = 2,
+                    TenantId = 0,
+                    Date = new(2022, 1, 2),
+                    Summary = "Balmy",
+                    TemperatureC = 38
+                },
+                new WeatherForecast
+                {
+                    Id = 3,
+                    TenantId = 1,
+                    Date = new(2022, 1, 3),
+                    Summary = "Sweltering",
+                    TemperatureC = -7
+                });
     }
 }

--- a/samples/core/Performance/AspNetContextPoolingWithState/WeatherForecastScopedFactory.cs
+++ b/samples/core/Performance/AspNetContextPoolingWithState/WeatherForecastScopedFactory.cs
@@ -1,35 +1,34 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Primitives;
 
-namespace Performance.AspNetContextPoolingWithState
+namespace Performance.AspNetContextPoolingWithState;
+
+#region WeatherForecastScopedFactory
+public class WeatherForecastScopedFactory : IDbContextFactory<WeatherForecastContext>
 {
-    #region WeatherForecastScopedFactory
-    public class WeatherForecastScopedFactory : IDbContextFactory<WeatherForecastContext>
+    private readonly IDbContextFactory<WeatherForecastContext> _pooledFactory;
+    private readonly int _tenantId;
+
+    public WeatherForecastScopedFactory(
+        IDbContextFactory<WeatherForecastContext> pooledFactory,
+        IHttpContextAccessor httpContextAccessor)
     {
-        private readonly IDbContextFactory<WeatherForecastContext> _pooledFactory;
-        private readonly int _tenantId;
+        _pooledFactory = pooledFactory;
 
-        public WeatherForecastScopedFactory(
-            IDbContextFactory<WeatherForecastContext> pooledFactory,
-            IHttpContextAccessor httpContextAccessor)
+        // In this sample, we simply accept the tenant ID as a request query, which means that a client can impersonate any tenant.
+        // In a real application, the tenant ID would be set based on secure authentication data.
+        var tenantIdString = httpContextAccessor.HttpContext.Request.Query["TenantId"];
+        if (tenantIdString != StringValues.Empty && int.TryParse(tenantIdString, out var tenantId))
         {
-            _pooledFactory = pooledFactory;
-
-            // In this sample, we simply accept the tenant ID as a request query, which means that a client can impersonate any tenant.
-            // In a real application, the tenant ID would be set based on secure authentication data.
-            var tenantIdString = httpContextAccessor.HttpContext.Request.Query["TenantId"];
-            if (tenantIdString != StringValues.Empty && int.TryParse(tenantIdString, out var tenantId))
-            {
-                _tenantId = tenantId;
-            }
-        }
-
-        public WeatherForecastContext CreateDbContext()
-        {
-            var context = _pooledFactory.CreateDbContext();
-            context.TenantId = _tenantId;
-            return context;
+            _tenantId = tenantId;
         }
     }
-    #endregion
+
+    public WeatherForecastContext CreateDbContext()
+    {
+        var context = _pooledFactory.CreateDbContext();
+        context.TenantId = _tenantId;
+        return context;
+    }
 }
+#endregion

--- a/samples/core/Performance/Other/BatchTweakingContext.cs
+++ b/samples/core/Performance/Other/BatchTweakingContext.cs
@@ -1,18 +1,17 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace Performance
+namespace Performance;
+
+public class BatchTweakingContext : DbContext
 {
-    public class BatchTweakingContext : DbContext
+    #region BatchTweaking
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        #region BatchTweaking
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True",
-                o => o
-                    .MinBatchSize(1)
-                    .MaxBatchSize(100));
-        }
-        #endregion
+        optionsBuilder.UseSqlServer(
+            @"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True",
+            o => o
+                .MinBatchSize(1)
+                .MaxBatchSize(100));
     }
+    #endregion
 }

--- a/samples/core/Performance/Other/BloggingContext.cs
+++ b/samples/core/Performance/Other/BloggingContext.cs
@@ -3,41 +3,40 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace Performance
+namespace Performance;
+
+public class BloggingContext : DbContext
 {
-    public class BloggingContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
-                .LogTo(Console.WriteLine, LogLevel.Information);
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Post>().HasIndex(p => p.Title);
-        }
+        optionsBuilder
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
+            .LogTo(Console.WriteLine, LogLevel.Information);
     }
 
-    public class Blog
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public int Rating { get; set; }
-        public List<Post> Posts { get; set; }
+        modelBuilder.Entity<Post>().HasIndex(p => p.Title);
     }
+}
 
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public int Rating { get; set; }
+    public List<Post> Posts { get; set; }
+}
 
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
 }

--- a/samples/core/Performance/Other/EmployeeContext.cs
+++ b/samples/core/Performance/Other/EmployeeContext.cs
@@ -2,24 +2,23 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace Performance
+namespace Performance;
+
+public class EmployeeContext : DbContext
 {
-    public class EmployeeContext : DbContext
-    {
-        public DbSet<Employee> Employees { get; set; }
+    public DbSet<Employee> Employees { get; set; }
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
-                .LogTo(Console.WriteLine, LogLevel.Information);
-        }
-    }
-
-    public class Employee
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        public int Id { get; set; }
-        public string Name { get; set; }
-        public int Salary { get; set; }
+        optionsBuilder
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
+            .LogTo(Console.WriteLine, LogLevel.Information);
     }
+}
+
+public class Employee
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public int Salary { get; set; }
 }

--- a/samples/core/Performance/Other/ExtensionsLoggingContext.cs
+++ b/samples/core/Performance/Other/ExtensionsLoggingContext.cs
@@ -1,20 +1,19 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace Performance
-{
-    public class ExtensionsLoggingContext : DbContext
-    {
-        #region ExtensionsLogging
-        private static ILoggerFactory ContextLoggerFactory
-            => LoggerFactory.Create(b => b.AddConsole().AddFilter("", LogLevel.Information));
+namespace Performance;
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
-                .UseLoggerFactory(ContextLoggerFactory);
-        }
-        #endregion
+public class ExtensionsLoggingContext : DbContext
+{
+    #region ExtensionsLogging
+    private static ILoggerFactory ContextLoggerFactory
+        => LoggerFactory.Create(b => b.AddConsole().AddFilter("", LogLevel.Information));
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
+            .UseLoggerFactory(ContextLoggerFactory);
     }
+    #endregion
 }

--- a/samples/core/Performance/Other/LazyLoading/LazyBloggingContext.cs
+++ b/samples/core/Performance/Other/LazyLoading/LazyBloggingContext.cs
@@ -3,35 +3,34 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace Performance.LazyLoading
+namespace Performance.LazyLoading;
+
+public class LazyBloggingContext : DbContext
 {
-    public class LazyBloggingContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
-                .LogTo(Console.WriteLine, LogLevel.Information)
-                .UseLazyLoadingProxies();
-    }
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
+            .LogTo(Console.WriteLine, LogLevel.Information)
+            .UseLazyLoadingProxies();
+}
 
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public int Rating { get; set; }
-        public virtual List<Post> Posts { get; set; }
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public int Rating { get; set; }
+    public virtual List<Post> Posts { get; set; }
+}
 
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
 
-        public int BlogId { get; set; }
-        public virtual Blog Blog { get; set; }
-    }
+    public int BlogId { get; set; }
+    public virtual Blog Blog { get; set; }
 }

--- a/samples/core/Performance/Other/PooledBloggingContext.cs
+++ b/samples/core/Performance/Other/PooledBloggingContext.cs
@@ -1,12 +1,11 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace Performance
-{
-    public class PooledBloggingContext : DbContext
-    {
-        public PooledBloggingContext(DbContextOptions options) : base(options) {}
+namespace Performance;
 
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-    }
+public class PooledBloggingContext : DbContext
+{
+    public PooledBloggingContext(DbContextOptions options) : base(options) {}
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
 }

--- a/samples/core/Performance/Other/Program.cs
+++ b/samples/core/Performance/Other/Program.cs
@@ -6,243 +6,242 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Performance.LazyLoading;
 
-namespace Performance
+namespace Performance;
+
+internal class Program
 {
-    internal class Program
+    #region CompiledQueryCompile
+    private static readonly Func<BloggingContext, int, IAsyncEnumerable<Blog>> _compiledQuery
+        = EF.CompileAsyncQuery(
+            (BloggingContext context, int length) => context.Blogs.Where(b => b.Url.StartsWith("http://") && b.Url.Length == length));
+    #endregion
+
+    private static async Task Main(string[] args)
     {
-        #region CompiledQueryCompile
-        private static readonly Func<BloggingContext, int, IAsyncEnumerable<Blog>> _compiledQuery
-            = EF.CompileAsyncQuery(
-                (BloggingContext context, int length) => context.Blogs.Where(b => b.Url.StartsWith("http://") && b.Url.Length == length));
-        #endregion
-
-        private static async Task Main(string[] args)
+        using (var context = new BloggingContext())
         {
-            using (var context = new BloggingContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
 
-                context.Add(
-                    new Blog
+            context.Add(
+                new Blog
+                {
+                    Url = "http://someblog.microsoft.com",
+                    Rating = 0,
+                    Posts = new List<Post>
                     {
-                        Url = "http://someblog.microsoft.com",
-                        Rating = 0,
-                        Posts = new List<Post>
-                        {
-                            new Post { Title = "Post 1", Content = "Sometimes..." },
-                            new Post { Title = "Post 2", Content = "Other times..." }
-                        }
-                    });
-
-                context.SaveChanges();
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region Indexes
-                // Matches on start, so uses an index (on SQL Server)
-                var posts1 = context.Posts.Where(p => p.Title.StartsWith("A")).ToList();
-                // Matches on end, so does not use the index
-                var posts2 = context.Posts.Where(p => p.Title.EndsWith("A")).ToList();
-                #endregion
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region ProjectEntities
-                foreach (var blog in context.Blogs)
-                {
-                    Console.WriteLine("Blog: " + blog.Url);
-                }
-                #endregion
-
-                #region ProjectSingleProperty
-                foreach (var blogName in context.Blogs.Select(b => b.Url))
-                {
-                    Console.WriteLine("Blog: " + blogName);
-                }
-                #endregion
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region NoLimit
-                var blogsAll = context.Posts
-                    .Where(p => p.Title.StartsWith("A"))
-                    .ToList();
-                #endregion
-
-                #region Limit25
-                var blogs25 = context.Posts
-                    .Where(p => p.Title.StartsWith("A"))
-                    .Take(25)
-                    .ToList();
-                #endregion
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region EagerlyLoadRelatedAndProject
-                foreach (var blog in context.Blogs.Select(b => new { b.Url, b.Posts }).ToList())
-                {
-                    foreach (var post in blog.Posts)
-                    {
-                        Console.WriteLine($"Blog {blog.Url}, Post: {post.Title}");
+                        new Post { Title = "Post 1", Content = "Sometimes..." },
+                        new Post { Title = "Post 2", Content = "Other times..." }
                     }
-                }
-                #endregion
-            }
+                });
 
-            using (var context = new BloggingContext())
+            context.SaveChanges();
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region Indexes
+            // Matches on start, so uses an index (on SQL Server)
+            var posts1 = context.Posts.Where(p => p.Title.StartsWith("A")).ToList();
+            // Matches on end, so does not use the index
+            var posts2 = context.Posts.Where(p => p.Title.EndsWith("A")).ToList();
+            #endregion
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region ProjectEntities
+            foreach (var blog in context.Blogs)
             {
-                #region BufferingAndStreaming
-                // ToList and ToArray cause the entire resultset to be buffered:
-                var blogsList = context.Posts.Where(p => p.Title.StartsWith("A")).ToList();
-                var blogsArray = context.Posts.Where(p => p.Title.StartsWith("A")).ToArray();
-
-                // Foreach streams, processing one row at a time:
-                foreach (var blog in context.Posts.Where(p => p.Title.StartsWith("A")))
-                {
-                    // ...
-                }
-
-                // AsEnumerable also streams, allowing you to execute LINQ operators on the client-side:
-                var doubleFilteredBlogs = context.Posts
-                    .Where(p => p.Title.StartsWith("A")) // Translated to SQL and executed in the database
-                    .AsEnumerable()
-                    .Where(p => SomeDotNetMethod(p)); // Executed at the client on all database results
-                #endregion
-
-                // This method represents a filter that cannot be translated to SQL for execution in the
-                // database, and must be run on the client as a .NET method
-                static bool SomeDotNetMethod(Post post) => true;
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region SaveChangesBatching
-                var blog = context.Blogs.Single(b => b.Url == "http://someblog.microsoft.com");
-                blog.Url = "http://someotherblog.microsoft.com";
-                context.Add(new Blog { Url = "http://newblog1.microsoft.com" });
-                context.Add(new Blog { Url = "http://newblog2.microsoft.com" });
-                context.SaveChanges();
-                #endregion
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region QueriesWithConstants
-                var post1 = context.Posts.FirstOrDefault(p => p.Title == "post1");
-                var post2 = context.Posts.FirstOrDefault(p => p.Title == "post2");
-                #endregion
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region QueriesWithParameterization
-                var postTitle = "post1";
-                var post1 = context.Posts.FirstOrDefault(p => p.Title == postTitle);
-                postTitle = "post2";
-                var post2 = context.Posts.FirstOrDefault(p => p.Title == postTitle);
-                #endregion
-            }
-
-            using (var context = new LazyBloggingContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-
-                for (var i = 0; i < 10; i++)
-                {
-                    context.Blogs.Add(
-                        new LazyLoading.Blog
-                        {
-                            Url = $"http://blog{i}.microsoft.com",
-                            Posts = new List<LazyLoading.Post>
-                            {
-                                new() { Title = $"1st post of blog{i}" }, new() { Title = $"2nd post of blog{i}" }
-                            }
-                        });
-                }
-
-                context.SaveChanges();
-            }
-
-            using (var context = new LazyBloggingContext())
-            {
-                #region NPlusOne
-                foreach (var blog in context.Blogs.ToList())
-                {
-                    foreach (var post in blog.Posts)
-                    {
-                        Console.WriteLine($"Blog {blog.Url}, Post: {post.Title}");
-                    }
-                }
-                #endregion
-            }
-
-            using (var context = new EmployeeContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-
-                for (var i = 0; i < 10; i++)
-                {
-                    context.Employees.Add(new Employee());
-                }
-            }
-
-            using (var context = new EmployeeContext())
-            {
-                #region UpdateWithoutBulk
-                foreach (var employee in context.Employees)
-                {
-                    employee.Salary += 1000;
-                }
-
-                context.SaveChanges();
-                #endregion
-            }
-
-            using (var context = new EmployeeContext())
-            {
-                #region UpdateWithBulk
-                context.Database.ExecuteSqlRaw("UPDATE [Employees] SET [Salary] = [Salary] + 1000");
-                #endregion
-            }
-
-            using (var context = new PooledBloggingContext(
-                       new DbContextOptionsBuilder()
-                           .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
-                           .Options))
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-            }
-
-            #region DbContextPoolingWithoutDI
-            var options = new DbContextOptionsBuilder<PooledBloggingContext>()
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
-                .Options;
-
-            var factory = new PooledDbContextFactory<PooledBloggingContext>(options);
-
-            using (var context = factory.CreateDbContext())
-            {
-                var allPosts = context.Posts.ToList();
+                Console.WriteLine("Blog: " + blog.Url);
             }
             #endregion
 
-            using (var context = new BloggingContext())
+            #region ProjectSingleProperty
+            foreach (var blogName in context.Blogs.Select(b => b.Url))
             {
-                #region CompiledQueryExecute
-                await foreach (var blog in _compiledQuery(context, 8))
-                {
-                    // Do something with the results
-                }
-                #endregion
+                Console.WriteLine("Blog: " + blogName);
             }
+            #endregion
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region NoLimit
+            var blogsAll = context.Posts
+                .Where(p => p.Title.StartsWith("A"))
+                .ToList();
+            #endregion
+
+            #region Limit25
+            var blogs25 = context.Posts
+                .Where(p => p.Title.StartsWith("A"))
+                .Take(25)
+                .ToList();
+            #endregion
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region EagerlyLoadRelatedAndProject
+            foreach (var blog in context.Blogs.Select(b => new { b.Url, b.Posts }).ToList())
+            {
+                foreach (var post in blog.Posts)
+                {
+                    Console.WriteLine($"Blog {blog.Url}, Post: {post.Title}");
+                }
+            }
+            #endregion
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region BufferingAndStreaming
+            // ToList and ToArray cause the entire resultset to be buffered:
+            var blogsList = context.Posts.Where(p => p.Title.StartsWith("A")).ToList();
+            var blogsArray = context.Posts.Where(p => p.Title.StartsWith("A")).ToArray();
+
+            // Foreach streams, processing one row at a time:
+            foreach (var blog in context.Posts.Where(p => p.Title.StartsWith("A")))
+            {
+                // ...
+            }
+
+            // AsEnumerable also streams, allowing you to execute LINQ operators on the client-side:
+            var doubleFilteredBlogs = context.Posts
+                .Where(p => p.Title.StartsWith("A")) // Translated to SQL and executed in the database
+                .AsEnumerable()
+                .Where(p => SomeDotNetMethod(p)); // Executed at the client on all database results
+            #endregion
+
+            // This method represents a filter that cannot be translated to SQL for execution in the
+            // database, and must be run on the client as a .NET method
+            static bool SomeDotNetMethod(Post post) => true;
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region SaveChangesBatching
+            var blog = context.Blogs.Single(b => b.Url == "http://someblog.microsoft.com");
+            blog.Url = "http://someotherblog.microsoft.com";
+            context.Add(new Blog { Url = "http://newblog1.microsoft.com" });
+            context.Add(new Blog { Url = "http://newblog2.microsoft.com" });
+            context.SaveChanges();
+            #endregion
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region QueriesWithConstants
+            var post1 = context.Posts.FirstOrDefault(p => p.Title == "post1");
+            var post2 = context.Posts.FirstOrDefault(p => p.Title == "post2");
+            #endregion
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region QueriesWithParameterization
+            var postTitle = "post1";
+            var post1 = context.Posts.FirstOrDefault(p => p.Title == postTitle);
+            postTitle = "post2";
+            var post2 = context.Posts.FirstOrDefault(p => p.Title == postTitle);
+            #endregion
+        }
+
+        using (var context = new LazyBloggingContext())
+        {
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+
+            for (var i = 0; i < 10; i++)
+            {
+                context.Blogs.Add(
+                    new LazyLoading.Blog
+                    {
+                        Url = $"http://blog{i}.microsoft.com",
+                        Posts = new List<LazyLoading.Post>
+                        {
+                            new() { Title = $"1st post of blog{i}" }, new() { Title = $"2nd post of blog{i}" }
+                        }
+                    });
+            }
+
+            context.SaveChanges();
+        }
+
+        using (var context = new LazyBloggingContext())
+        {
+            #region NPlusOne
+            foreach (var blog in context.Blogs.ToList())
+            {
+                foreach (var post in blog.Posts)
+                {
+                    Console.WriteLine($"Blog {blog.Url}, Post: {post.Title}");
+                }
+            }
+            #endregion
+        }
+
+        using (var context = new EmployeeContext())
+        {
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+
+            for (var i = 0; i < 10; i++)
+            {
+                context.Employees.Add(new Employee());
+            }
+        }
+
+        using (var context = new EmployeeContext())
+        {
+            #region UpdateWithoutBulk
+            foreach (var employee in context.Employees)
+            {
+                employee.Salary += 1000;
+            }
+
+            context.SaveChanges();
+            #endregion
+        }
+
+        using (var context = new EmployeeContext())
+        {
+            #region UpdateWithBulk
+            context.Database.ExecuteSqlRaw("UPDATE [Employees] SET [Salary] = [Salary] + 1000");
+            #endregion
+        }
+
+        using (var context = new PooledBloggingContext(
+                   new DbContextOptionsBuilder()
+                       .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
+                       .Options))
+        {
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+        }
+
+        #region DbContextPoolingWithoutDI
+        var options = new DbContextOptionsBuilder<PooledBloggingContext>()
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
+            .Options;
+
+        var factory = new PooledDbContextFactory<PooledBloggingContext>(options);
+
+        using (var context = factory.CreateDbContext())
+        {
+            var allPosts = context.Posts.ToList();
+        }
+        #endregion
+
+        using (var context = new BloggingContext())
+        {
+            #region CompiledQueryExecute
+            await foreach (var blog in _compiledQuery(context, 8))
+            {
+                // Do something with the results
+            }
+            #endregion
         }
     }
 }

--- a/samples/core/Querying/ClientEvaluation/Blog.cs
+++ b/samples/core/Querying/ClientEvaluation/Blog.cs
@@ -1,9 +1,8 @@
-﻿namespace EFQuerying.ClientEvaluation
+﻿namespace EFQuerying.ClientEvaluation;
+
+public class Blog
 {
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public int? Rating { get; set; }
-    }
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public int? Rating { get; set; }
 }

--- a/samples/core/Querying/ClientEvaluation/BloggingContext.cs
+++ b/samples/core/Querying/ClientEvaluation/BloggingContext.cs
@@ -1,23 +1,22 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.ClientEvaluation
+namespace EFQuerying.ClientEvaluation;
+
+public class BloggingContext : DbContext
 {
-    public class BloggingContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasData(
+                new Blog { BlogId = 1, Url = @"https://devblogs.microsoft.com/dotnet", Rating = 5 },
+                new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4 });
+    }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasData(
-                    new Blog { BlogId = 1, Url = @"https://devblogs.microsoft.com/dotnet", Rating = 5 },
-                    new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4 });
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.ClientEvaluation;Trusted_Connection=True");
-        }
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseSqlServer(
+            @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.ClientEvaluation;Trusted_Connection=True");
     }
 }

--- a/samples/core/Querying/ClientEvaluation/Program.cs
+++ b/samples/core/Querying/ClientEvaluation/Program.cs
@@ -1,68 +1,67 @@
 ﻿using System;
 using System.Linq;
 
-namespace EFQuerying.ClientEvaluation
+namespace EFQuerying.ClientEvaluation;
+
+internal class Program
 {
-    internal class Program
+    #region ClientMethod
+    public static string StandardizeUrl(string url)
     {
-        #region ClientMethod
-        public static string StandardizeUrl(string url)
+        url = url.ToLower();
+
+        if (!url.StartsWith("http://"))
         {
-            url = url.ToLower();
-
-            if (!url.StartsWith("http://"))
-            {
-                url = string.Concat("http://", url);
-            }
-
-            return url;
+            url = string.Concat("http://", url);
         }
-        #endregion
 
-        private static void Main(string[] args)
+        return url;
+    }
+    #endregion
+
+    private static void Main(string[] args)
+    {
+        using (var context = new BloggingContext())
         {
-            using (var context = new BloggingContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-            }
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+        }
 
-            using (var context = new BloggingContext())
+        using (var context = new BloggingContext())
+        {
+            #region ClientProjection
+            var blogs = context.Blogs
+                .OrderByDescending(blog => blog.Rating)
+                .Select(
+                    blog => new { Id = blog.BlogId, Url = StandardizeUrl(blog.Url) })
+                .ToList();
+            #endregion
+        }
+
+        using (var context = new BloggingContext())
+        {
+            try
             {
-                #region ClientProjection
+                #region ClientWhere
                 var blogs = context.Blogs
-                    .OrderByDescending(blog => blog.Rating)
-                    .Select(
-                        blog => new { Id = blog.BlogId, Url = StandardizeUrl(blog.Url) })
-                    .ToList();
-                #endregion
-            }
-
-            using (var context = new BloggingContext())
-            {
-                try
-                {
-                    #region ClientWhere
-                    var blogs = context.Blogs
-                        .Where(blog => StandardizeUrl(blog.Url).Contains("dotnet"))
-                        .ToList();
-                    #endregion
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine(e.Message);
-                }
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region ExplicitClientEvaluation
-                var blogs = context.Blogs
-                    .AsEnumerable()
                     .Where(blog => StandardizeUrl(blog.Url).Contains("dotnet"))
                     .ToList();
                 #endregion
             }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+            }
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region ExplicitClientEvaluation
+            var blogs = context.Blogs
+                .AsEnumerable()
+                .Where(blog => StandardizeUrl(blog.Url).Contains("dotnet"))
+                .ToList();
+            #endregion
         }
     }
 }

--- a/samples/core/Querying/ComplexQuery/Blog.cs
+++ b/samples/core/Querying/ComplexQuery/Blog.cs
@@ -1,16 +1,15 @@
 ﻿using System.Collections.Generic;
 
-namespace EFQuerying.ComplexQuery
+namespace EFQuerying.ComplexQuery;
+
+public class Blog
 {
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public int? Rating { get; set; }
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public int? Rating { get; set; }
 
-        public List<Post> Posts { get; set; }
+    public List<Post> Posts { get; set; }
 
-        public int OwnerId { get; set; }
-        public Person Owner { get; set; }
-    }
+    public int OwnerId { get; set; }
+    public Person Owner { get; set; }
 }

--- a/samples/core/Querying/ComplexQuery/BloggingContext.cs
+++ b/samples/core/Querying/ComplexQuery/BloggingContext.cs
@@ -1,109 +1,108 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.ComplexQuery
+namespace EFQuerying.ComplexQuery;
+
+public class BloggingContext : DbContext
 {
-    public class BloggingContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasMany(b => b.Posts)
+            .WithOne(p => p.Blog)
+            .OnDelete(DeleteBehavior.NoAction);
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasMany(b => b.Posts)
-                .WithOne(p => p.Blog)
-                .OnDelete(DeleteBehavior.NoAction);
+        modelBuilder.Entity<PostTag>()
+            .HasOne(pt => pt.Post)
+            .WithMany(p => p.Tags)
+            .HasForeignKey(pt => pt.PostId);
 
-            modelBuilder.Entity<PostTag>()
-                .HasOne(pt => pt.Post)
-                .WithMany(p => p.Tags)
-                .HasForeignKey(pt => pt.PostId);
+        modelBuilder.Entity<PostTag>()
+            .HasOne(pt => pt.Tag)
+            .WithMany(t => t.Posts)
+            .HasForeignKey(pt => pt.TagId);
 
-            modelBuilder.Entity<PostTag>()
-                .HasOne(pt => pt.Tag)
-                .WithMany(t => t.Posts)
-                .HasForeignKey(pt => pt.TagId);
+        modelBuilder.Entity<Blog>()
+            .HasData(
+                new Blog
+                {
+                    BlogId = 1, Url = @"https://devblogs.microsoft.com/dotnet", Rating = 5, OwnerId = 1,
+                },
+                new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4, OwnerId = 3 });
 
-            modelBuilder.Entity<Blog>()
-                .HasData(
-                    new Blog
-                    {
-                        BlogId = 1, Url = @"https://devblogs.microsoft.com/dotnet", Rating = 5, OwnerId = 1,
-                    },
-                    new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4, OwnerId = 3 });
+        modelBuilder.Entity<Post>()
+            .HasData(
+                new Post
+                {
+                    PostId = 1,
+                    BlogId = 1,
+                    Title = "What's new",
+                    Content = "Lorem ipsum dolor sit amet",
+                    Rating = 5,
+                    AuthorId = 1
+                },
+                new Post
+                {
+                    PostId = 2,
+                    BlogId = 2,
+                    Title = "Around the World in Eighty Days",
+                    Content = "consectetur adipiscing elit",
+                    Rating = 5,
+                    AuthorId = 2
+                },
+                new Post
+                {
+                    PostId = 3,
+                    BlogId = 2,
+                    Title = "Glamping *is* the way",
+                    Content = "sed do eiusmod tempor incididunt",
+                    Rating = 4,
+                    AuthorId = 3
+                },
+                new Post
+                {
+                    PostId = 4,
+                    BlogId = 2,
+                    Title = "Travel in the time of pandemic",
+                    Content = "ut labore et dolore magna aliqua",
+                    Rating = 3,
+                    AuthorId = 3
+                });
 
-            modelBuilder.Entity<Post>()
-                .HasData(
-                    new Post
-                    {
-                        PostId = 1,
-                        BlogId = 1,
-                        Title = "What's new",
-                        Content = "Lorem ipsum dolor sit amet",
-                        Rating = 5,
-                        AuthorId = 1
-                    },
-                    new Post
-                    {
-                        PostId = 2,
-                        BlogId = 2,
-                        Title = "Around the World in Eighty Days",
-                        Content = "consectetur adipiscing elit",
-                        Rating = 5,
-                        AuthorId = 2
-                    },
-                    new Post
-                    {
-                        PostId = 3,
-                        BlogId = 2,
-                        Title = "Glamping *is* the way",
-                        Content = "sed do eiusmod tempor incididunt",
-                        Rating = 4,
-                        AuthorId = 3
-                    },
-                    new Post
-                    {
-                        PostId = 4,
-                        BlogId = 2,
-                        Title = "Travel in the time of pandemic",
-                        Content = "ut labore et dolore magna aliqua",
-                        Rating = 3,
-                        AuthorId = 3
-                    });
+        modelBuilder.Entity<Person>()
+            .HasData(
+                new Person { PersonId = 1, Name = "Dotnet Blog Admin", PhotoId = 1 },
+                new Person { PersonId = 2, Name = "Phileas Fogg", PhotoId = 2 },
+                new Person { PersonId = 3, Name = "Jane Doe", PhotoId = 3 });
 
-            modelBuilder.Entity<Person>()
-                .HasData(
-                    new Person { PersonId = 1, Name = "Dotnet Blog Admin", PhotoId = 1 },
-                    new Person { PersonId = 2, Name = "Phileas Fogg", PhotoId = 2 },
-                    new Person { PersonId = 3, Name = "Jane Doe", PhotoId = 3 });
+        modelBuilder.Entity<PersonPhoto>()
+            .HasData(
+                new PersonPhoto { PersonPhotoId = 1, Caption = "SN", Photo = new byte[] { 0x00, 0x01 } },
+                new PersonPhoto { PersonPhotoId = 2, Caption = "PF", Photo = new byte[] { 0x01, 0x02, 0x03 } },
+                new PersonPhoto { PersonPhotoId = 3, Caption = "JD", Photo = new byte[] { 0x01, 0x01, 0x01 } });
 
-            modelBuilder.Entity<PersonPhoto>()
-                .HasData(
-                    new PersonPhoto { PersonPhotoId = 1, Caption = "SN", Photo = new byte[] { 0x00, 0x01 } },
-                    new PersonPhoto { PersonPhotoId = 2, Caption = "PF", Photo = new byte[] { 0x01, 0x02, 0x03 } },
-                    new PersonPhoto { PersonPhotoId = 3, Caption = "JD", Photo = new byte[] { 0x01, 0x01, 0x01 } });
+        modelBuilder.Entity<Tag>()
+            .HasData(
+                new Tag { TagId = "general" },
+                new Tag { TagId = "classic" },
+                new Tag { TagId = "opinion" },
+                new Tag { TagId = "informative" });
 
-            modelBuilder.Entity<Tag>()
-                .HasData(
-                    new Tag { TagId = "general" },
-                    new Tag { TagId = "classic" },
-                    new Tag { TagId = "opinion" },
-                    new Tag { TagId = "informative" });
+        modelBuilder.Entity<PostTag>()
+            .HasData(
+                new PostTag { PostTagId = 1, PostId = 1, TagId = "general" },
+                new PostTag { PostTagId = 2, PostId = 1, TagId = "informative" },
+                new PostTag { PostTagId = 3, PostId = 2, TagId = "classic" },
+                new PostTag { PostTagId = 4, PostId = 3, TagId = "opinion" },
+                new PostTag { PostTagId = 5, PostId = 4, TagId = "opinion" },
+                new PostTag { PostTagId = 6, PostId = 4, TagId = "informative" });
+    }
 
-            modelBuilder.Entity<PostTag>()
-                .HasData(
-                    new PostTag { PostTagId = 1, PostId = 1, TagId = "general" },
-                    new PostTag { PostTagId = 2, PostId = 1, TagId = "informative" },
-                    new PostTag { PostTagId = 3, PostId = 2, TagId = "classic" },
-                    new PostTag { PostTagId = 4, PostId = 3, TagId = "opinion" },
-                    new PostTag { PostTagId = 5, PostId = 4, TagId = "opinion" },
-                    new PostTag { PostTagId = 6, PostId = 4, TagId = "informative" });
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.ComplexQuery;Trusted_Connection=True");
-        }
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseSqlServer(
+            @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.ComplexQuery;Trusted_Connection=True");
     }
 }

--- a/samples/core/Querying/ComplexQuery/Person.cs
+++ b/samples/core/Querying/ComplexQuery/Person.cs
@@ -1,16 +1,15 @@
 ﻿using System.Collections.Generic;
 
-namespace EFQuerying.ComplexQuery
+namespace EFQuerying.ComplexQuery;
+
+public class Person
 {
-    public class Person
-    {
-        public int PersonId { get; set; }
-        public string Name { get; set; }
+    public int PersonId { get; set; }
+    public string Name { get; set; }
 
-        public List<Post> AuthoredPosts { get; set; }
-        public List<Blog> OwnedBlogs { get; set; }
+    public List<Post> AuthoredPosts { get; set; }
+    public List<Blog> OwnedBlogs { get; set; }
 
-        public int? PhotoId { get; set; }
-        public PersonPhoto Photo { get; set; }
-    }
+    public int? PhotoId { get; set; }
+    public PersonPhoto Photo { get; set; }
 }

--- a/samples/core/Querying/ComplexQuery/PersonPhoto.cs
+++ b/samples/core/Querying/ComplexQuery/PersonPhoto.cs
@@ -1,11 +1,10 @@
-﻿namespace EFQuerying.ComplexQuery
-{
-    public class PersonPhoto
-    {
-        public int PersonPhotoId { get; set; }
-        public string Caption { get; set; }
-        public byte[] Photo { get; set; }
+﻿namespace EFQuerying.ComplexQuery;
 
-        public Person Person { get; set; }
-    }
+public class PersonPhoto
+{
+    public int PersonPhotoId { get; set; }
+    public string Caption { get; set; }
+    public byte[] Photo { get; set; }
+
+    public Person Person { get; set; }
 }

--- a/samples/core/Querying/ComplexQuery/Post.cs
+++ b/samples/core/Querying/ComplexQuery/Post.cs
@@ -1,20 +1,19 @@
 ﻿using System.Collections.Generic;
 
-namespace EFQuerying.ComplexQuery
+namespace EFQuerying.ComplexQuery;
+
+public class Post
 {
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-        public int Rating { get; set; }
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+    public int Rating { get; set; }
 
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
 
-        public int AuthorId { get; set; }
-        public Person Author { get; set; }
+    public int AuthorId { get; set; }
+    public Person Author { get; set; }
 
-        public List<PostTag> Tags { get; set; }
-    }
+    public List<PostTag> Tags { get; set; }
 }

--- a/samples/core/Querying/ComplexQuery/PostTag.cs
+++ b/samples/core/Querying/ComplexQuery/PostTag.cs
@@ -1,13 +1,12 @@
-﻿namespace EFQuerying.ComplexQuery
+﻿namespace EFQuerying.ComplexQuery;
+
+public class PostTag
 {
-    public class PostTag
-    {
-        public int PostTagId { get; set; }
+    public int PostTagId { get; set; }
 
-        public int PostId { get; set; }
-        public Post Post { get; set; }
+    public int PostId { get; set; }
+    public Post Post { get; set; }
 
-        public string TagId { get; set; }
-        public Tag Tag { get; set; }
-    }
+    public string TagId { get; set; }
+    public Tag Tag { get; set; }
 }

--- a/samples/core/Querying/ComplexQuery/Program.cs
+++ b/samples/core/Querying/ComplexQuery/Program.cs
@@ -1,119 +1,118 @@
 ﻿using System.Linq;
 
-namespace EFQuerying.ComplexQuery
+namespace EFQuerying.ComplexQuery;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
+        using (var context = new BloggingContext())
         {
-            using (var context = new BloggingContext())
-            {
-                #region Join
-                var query = from photo in context.Set<PersonPhoto>()
-                            join person in context.Set<Person>()
-                                on photo.PersonPhotoId equals person.PhotoId
-                            select new { person, photo };
-                #endregion
-            }
+            #region Join
+            var query = from photo in context.Set<PersonPhoto>()
+                        join person in context.Set<Person>()
+                            on photo.PersonPhotoId equals person.PhotoId
+                        select new { person, photo };
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region JoinComposite
-                var query = from photo in context.Set<PersonPhoto>()
-                            join person in context.Set<Person>()
-                                on new { Id = (int?)photo.PersonPhotoId, photo.Caption }
-                                equals new { Id = person.PhotoId, Caption = "SN" }
-                            select new { person, photo };
-                #endregion
-            }
+        using (var context = new BloggingContext())
+        {
+            #region JoinComposite
+            var query = from photo in context.Set<PersonPhoto>()
+                        join person in context.Set<Person>()
+                            on new { Id = (int?)photo.PersonPhotoId, photo.Caption }
+                            equals new { Id = person.PhotoId, Caption = "SN" }
+                        select new { person, photo };
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region GroupJoin
-                var query = from b in context.Set<Blog>()
-                            join p in context.Set<Post>()
-                                on b.BlogId equals p.PostId into grouping
-                            select new { b, grouping };
-                #endregion
-            }
+        using (var context = new BloggingContext())
+        {
+            #region GroupJoin
+            var query = from b in context.Set<Blog>()
+                        join p in context.Set<Post>()
+                            on b.BlogId equals p.PostId into grouping
+                        select new { b, grouping };
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region GroupJoinComposed
-                var query = from b in context.Set<Blog>()
-                            join p in context.Set<Post>()
-                                on b.BlogId equals p.PostId into grouping
-                            select new { b, Posts = grouping.Where(p => p.Content.Contains("EF")).ToList() };
-                #endregion
-            }
+        using (var context = new BloggingContext())
+        {
+            #region GroupJoinComposed
+            var query = from b in context.Set<Blog>()
+                        join p in context.Set<Post>()
+                            on b.BlogId equals p.PostId into grouping
+                        select new { b, Posts = grouping.Where(p => p.Content.Contains("EF")).ToList() };
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region SelectManyConvertedToCrossJoin
-                var query = from b in context.Set<Blog>()
-                            from p in context.Set<Post>()
-                            select new { b, p };
-                #endregion
-            }
+        using (var context = new BloggingContext())
+        {
+            #region SelectManyConvertedToCrossJoin
+            var query = from b in context.Set<Blog>()
+                        from p in context.Set<Post>()
+                        select new { b, p };
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region SelectManyConvertedToJoin
-                var query = from b in context.Set<Blog>()
-                            from p in context.Set<Post>().Where(p => b.BlogId == p.BlogId)
-                            select new { b, p };
+        using (var context = new BloggingContext())
+        {
+            #region SelectManyConvertedToJoin
+            var query = from b in context.Set<Blog>()
+                        from p in context.Set<Post>().Where(p => b.BlogId == p.BlogId)
+                        select new { b, p };
 
-                var query2 = from b in context.Set<Blog>()
-                             from p in context.Set<Post>().Where(p => b.BlogId == p.BlogId).DefaultIfEmpty()
-                             select new { b, p };
-                #endregion
-            }
+            var query2 = from b in context.Set<Blog>()
+                         from p in context.Set<Post>().Where(p => b.BlogId == p.BlogId).DefaultIfEmpty()
+                         select new { b, p };
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region SelectManyConvertedToApply
-                var query = from b in context.Set<Blog>()
-                            from p in context.Set<Post>().Select(p => b.Url + "=>" + p.Title)
-                            select new { b, p };
+        using (var context = new BloggingContext())
+        {
+            #region SelectManyConvertedToApply
+            var query = from b in context.Set<Blog>()
+                        from p in context.Set<Post>().Select(p => b.Url + "=>" + p.Title)
+                        select new { b, p };
 
-                var query2 = from b in context.Set<Blog>()
-                             from p in context.Set<Post>().Select(p => b.Url + "=>" + p.Title).DefaultIfEmpty()
-                             select new { b, p };
-                #endregion
-            }
+            var query2 = from b in context.Set<Blog>()
+                         from p in context.Set<Post>().Select(p => b.Url + "=>" + p.Title).DefaultIfEmpty()
+                         select new { b, p };
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region GroupBy
-                var query = from p in context.Set<Post>()
-                            group p by p.AuthorId
-                            into g
-                            select new { g.Key, Count = g.Count() };
-                #endregion
-            }
+        using (var context = new BloggingContext())
+        {
+            #region GroupBy
+            var query = from p in context.Set<Post>()
+                        group p by p.AuthorId
+                        into g
+                        select new { g.Key, Count = g.Count() };
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region GroupByFilter
-                var query = from p in context.Set<Post>()
-                            group p by p.AuthorId
-                            into g
-                            where g.Count() > 0
-                            orderby g.Key
-                            select new { g.Key, Count = g.Count() };
-                #endregion
-            }
+        using (var context = new BloggingContext())
+        {
+            #region GroupByFilter
+            var query = from p in context.Set<Post>()
+                        group p by p.AuthorId
+                        into g
+                        where g.Count() > 0
+                        orderby g.Key
+                        select new { g.Key, Count = g.Count() };
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region LeftJoin
-                var query = from b in context.Set<Blog>()
-                            join p in context.Set<Post>()
-                                on b.BlogId equals p.BlogId into grouping
-                            from p in grouping.DefaultIfEmpty()
-                            select new { b, p };
-                #endregion
-            }
+        using (var context = new BloggingContext())
+        {
+            #region LeftJoin
+            var query = from b in context.Set<Blog>()
+                        join p in context.Set<Post>()
+                            on b.BlogId equals p.BlogId into grouping
+                        from p in grouping.DefaultIfEmpty()
+                        select new { b, p };
+            #endregion
         }
     }
 }

--- a/samples/core/Querying/ComplexQuery/Tag.cs
+++ b/samples/core/Querying/ComplexQuery/Tag.cs
@@ -1,11 +1,10 @@
 ﻿using System.Collections.Generic;
 
-namespace EFQuerying.ComplexQuery
-{
-    public class Tag
-    {
-        public string TagId { get; set; }
+namespace EFQuerying.ComplexQuery;
 
-        public List<PostTag> Posts { get; set; }
-    }
+public class Tag
+{
+    public string TagId { get; set; }
+
+    public List<PostTag> Posts { get; set; }
 }

--- a/samples/core/Querying/NullSemantics/NullSemanticsContext.cs
+++ b/samples/core/Querying/NullSemantics/NullSemanticsContext.cs
@@ -1,69 +1,68 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-namespace NullSemantics
+namespace NullSemantics;
+
+public class NullSemanticsContext : DbContext
 {
-    public class NullSemanticsContext : DbContext
+    public DbSet<NullSemanticsEntity> Entities { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        public DbSet<NullSemanticsEntity> Entities { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        var relationalNulls = false;
+        if (relationalNulls)
         {
-            var relationalNulls = false;
-            if (relationalNulls)
+            #region UseRelationalNulls
+            new SqlServerDbContextOptionsBuilder(optionsBuilder).UseRelationalNulls();
+            #endregion
+        }
+
+        optionsBuilder.UseSqlServer(
+            @"Server=(localdb)\mssqllocaldb;Database=NullSemanticsSample;Trusted_Connection=True;MultipleActiveResultSets=true");
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<NullSemanticsEntity>().HasData(
+            new NullSemanticsEntity
             {
-                #region UseRelationalNulls
-                new SqlServerDbContextOptionsBuilder(optionsBuilder).UseRelationalNulls();
-                #endregion
-            }
-
-            optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=NullSemanticsSample;Trusted_Connection=True;MultipleActiveResultSets=true");
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<NullSemanticsEntity>().HasData(
-                new NullSemanticsEntity
-                {
-                    Id = 1,
-                    Int = 1,
-                    NullableInt = 1,
-                    String1 = "A",
-                    String2 = "A"
-                },
-                new NullSemanticsEntity
-                {
-                    Id = 2,
-                    Int = 2,
-                    NullableInt = 2,
-                    String1 = "A",
-                    String2 = "B"
-                },
-                new NullSemanticsEntity
-                {
-                    Id = 3,
-                    Int = 2,
-                    NullableInt = null,
-                    String1 = null,
-                    String2 = "A"
-                },
-                new NullSemanticsEntity
-                {
-                    Id = 4,
-                    Int = 2,
-                    NullableInt = null,
-                    String1 = "B",
-                    String2 = null
-                },
-                new NullSemanticsEntity
-                {
-                    Id = 5,
-                    Int = 1,
-                    NullableInt = 3,
-                    String1 = null,
-                    String2 = null
-                });
-        }
+                Id = 1,
+                Int = 1,
+                NullableInt = 1,
+                String1 = "A",
+                String2 = "A"
+            },
+            new NullSemanticsEntity
+            {
+                Id = 2,
+                Int = 2,
+                NullableInt = 2,
+                String1 = "A",
+                String2 = "B"
+            },
+            new NullSemanticsEntity
+            {
+                Id = 3,
+                Int = 2,
+                NullableInt = null,
+                String1 = null,
+                String2 = "A"
+            },
+            new NullSemanticsEntity
+            {
+                Id = 4,
+                Int = 2,
+                NullableInt = null,
+                String1 = "B",
+                String2 = null
+            },
+            new NullSemanticsEntity
+            {
+                Id = 5,
+                Int = 1,
+                NullableInt = 3,
+                String1 = null,
+                String2 = null
+            });
     }
 }

--- a/samples/core/Querying/NullSemantics/NullSemanticsEntity.cs
+++ b/samples/core/Querying/NullSemantics/NullSemanticsEntity.cs
@@ -1,13 +1,12 @@
-﻿namespace NullSemantics
+﻿namespace NullSemantics;
+
+#region Entity
+public class NullSemanticsEntity
 {
-    #region Entity
-    public class NullSemanticsEntity
-    {
-        public int Id { get; set; }
-        public int Int { get; set; }
-        public int? NullableInt { get; set; }
-        public string String1 { get; set; }
-        public string String2 { get; set; }
-    }
-    #endregion
+    public int Id { get; set; }
+    public int Int { get; set; }
+    public int? NullableInt { get; set; }
+    public string String1 { get; set; }
+    public string String2 { get; set; }
 }
+#endregion

--- a/samples/core/Querying/NullSemantics/Program.cs
+++ b/samples/core/Querying/NullSemantics/Program.cs
@@ -1,71 +1,70 @@
 ﻿using System.Linq;
 
-namespace NullSemantics
+namespace NullSemantics;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
-        {
-            using var context = new NullSemanticsContext();
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
+        using var context = new NullSemanticsContext();
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
 
-            //#region FunctionSqlRaw
-            //context.Database.ExecuteSqlRaw(
-            //    @"create function [dbo].[ConcatStrings] (@prm1 nvarchar(max), @prm2 nvarchar(max))
-            //        returns nvarchar(max)
-            //        as
-            //        begin
-            //            return @prm1 + @prm2;
-            //        end");
-            //#endregion
+        //#region FunctionSqlRaw
+        //context.Database.ExecuteSqlRaw(
+        //    @"create function [dbo].[ConcatStrings] (@prm1 nvarchar(max), @prm2 nvarchar(max))
+        //        returns nvarchar(max)
+        //        as
+        //        begin
+        //            return @prm1 + @prm2;
+        //        end");
+        //#endregion
 
-            //BasicExamples();
-            Functions();
-            //ManualOptimization();
-        }
+        //BasicExamples();
+        Functions();
+        //ManualOptimization();
+    }
 
-        private static void BasicExamples()
-        {
-            using var context = new NullSemanticsContext();
-            #region BasicExamples
-            var query1 = context.Entities.Where(e => e.Id == e.Int);
-            var query2 = context.Entities.Where(e => e.Id == e.NullableInt);
-            var query3 = context.Entities.Where(e => e.Id != e.NullableInt);
-            var query4 = context.Entities.Where(e => e.String1 == e.String2);
-            var query5 = context.Entities.Where(e => e.String1 != e.String2);
-            #endregion
+    private static void BasicExamples()
+    {
+        using var context = new NullSemanticsContext();
+        #region BasicExamples
+        var query1 = context.Entities.Where(e => e.Id == e.Int);
+        var query2 = context.Entities.Where(e => e.Id == e.NullableInt);
+        var query3 = context.Entities.Where(e => e.Id != e.NullableInt);
+        var query4 = context.Entities.Where(e => e.String1 == e.String2);
+        var query5 = context.Entities.Where(e => e.String1 != e.String2);
+        #endregion
 
-            var result1 = query1.ToList();
-            var result2 = query2.ToList();
-            var result3 = query3.ToList();
-            var result4 = query4.ToList();
-            var result5 = query5.ToList();
-        }
+        var result1 = query1.ToList();
+        var result2 = query2.ToList();
+        var result3 = query3.ToList();
+        var result4 = query4.ToList();
+        var result5 = query5.ToList();
+    }
 
-        private static void Functions()
-        {
-            using var context = new NullSemanticsContext();
+    private static void Functions()
+    {
+        using var context = new NullSemanticsContext();
 
-            #region Functions
-            var query = context.Entities.Where(e => e.String1.Substring(0, e.String2.Length) == null);
-            #endregion
+        #region Functions
+        var query = context.Entities.Where(e => e.String1.Substring(0, e.String2.Length) == null);
+        #endregion
 
-            var result = query.ToList();
-        }
+        var result = query.ToList();
+    }
 
-        private static void ManualOptimization()
-        {
-            using var context = new NullSemanticsContext();
+    private static void ManualOptimization()
+    {
+        using var context = new NullSemanticsContext();
 
-            #region ManualOptimization
-            var query1 = context.Entities.Where(e => e.String1 != e.String2 || e.String1.Length == e.String2.Length);
-            var query2 = context.Entities.Where(
-                e => e.String1 != null && e.String2 != null && (e.String1 != e.String2 || e.String1.Length == e.String2.Length));
-            #endregion
+        #region ManualOptimization
+        var query1 = context.Entities.Where(e => e.String1 != e.String2 || e.String1.Length == e.String2.Length);
+        var query2 = context.Entities.Where(
+            e => e.String1 != null && e.String2 != null && (e.String1 != e.String2 || e.String1.Length == e.String2.Length));
+        #endregion
 
-            var result1 = query1.ToList();
-            var result2 = query2.ToList();
-        }
+        var result1 = query1.ToList();
+        var result2 = query2.ToList();
     }
 }

--- a/samples/core/Querying/Overview/Blog.cs
+++ b/samples/core/Querying/Overview/Blog.cs
@@ -1,9 +1,8 @@
-﻿namespace EFQuerying.Overview
+﻿namespace EFQuerying.Overview;
+
+public class Blog
 {
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public int? Rating { get; set; }
-    }
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public int? Rating { get; set; }
 }

--- a/samples/core/Querying/Overview/BloggingContext.cs
+++ b/samples/core/Querying/Overview/BloggingContext.cs
@@ -1,23 +1,22 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.Overview
+namespace EFQuerying.Overview;
+
+public class BloggingContext : DbContext
 {
-    public class BloggingContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasData(
+                new Blog { BlogId = 1, Url = @"https://devblogs.microsoft.com/dotnet", Rating = 5 },
+                new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4 });
+    }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasData(
-                    new Blog { BlogId = 1, Url = @"https://devblogs.microsoft.com/dotnet", Rating = 5 },
-                    new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4 });
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.Overview;Trusted_Connection=True");
-        }
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseSqlServer(
+            @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.Overview;Trusted_Connection=True");
     }
 }

--- a/samples/core/Querying/Overview/Program.cs
+++ b/samples/core/Querying/Overview/Program.cs
@@ -1,40 +1,39 @@
 ﻿using System.Linq;
 
-namespace EFQuerying.Overview
+namespace EFQuerying.Overview;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
+        using (var context = new BloggingContext())
         {
-            using (var context = new BloggingContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-            }
-
-            #region LoadingAllData
-            using (var context = new BloggingContext())
-            {
-                var blogs = context.Blogs.ToList();
-            }
-            #endregion
-
-            #region LoadingSingleEntity
-            using (var context = new BloggingContext())
-            {
-                var blog = context.Blogs
-                    .Single(b => b.BlogId == 1);
-            }
-            #endregion
-
-            #region Filtering
-            using (var context = new BloggingContext())
-            {
-                var blogs = context.Blogs
-                    .Where(b => b.Url.Contains("dotnet"))
-                    .ToList();
-            }
-            #endregion
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
         }
+
+        #region LoadingAllData
+        using (var context = new BloggingContext())
+        {
+            var blogs = context.Blogs.ToList();
+        }
+        #endregion
+
+        #region LoadingSingleEntity
+        using (var context = new BloggingContext())
+        {
+            var blog = context.Blogs
+                .Single(b => b.BlogId == 1);
+        }
+        #endregion
+
+        #region Filtering
+        using (var context = new BloggingContext())
+        {
+            var blogs = context.Blogs
+                .Where(b => b.Url.Contains("dotnet"))
+                .ToList();
+        }
+        #endregion
     }
 }

--- a/samples/core/Querying/Pagination/BloggingContext.cs
+++ b/samples/core/Querying/Pagination/BloggingContext.cs
@@ -3,44 +3,43 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace EFQuerying.Pagination
+namespace EFQuerying.Pagination;
+
+public class BloggingContext : DbContext
 {
-    public class BloggingContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    #region SimpleLogging
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        #region SimpleLogging
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
-                .LogTo(Console.WriteLine, LogLevel.Information);
-        }
-        #endregion
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Post>().HasIndex(p => p.Title);
-        }
+        optionsBuilder
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
+            .LogTo(Console.WriteLine, LogLevel.Information);
     }
+    #endregion
 
-    public class Blog
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public int Rating { get; set; }
-        public List<Post> Posts { get; set; }
+        modelBuilder.Entity<Post>().HasIndex(p => p.Title);
     }
+}
 
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-        public DateTime Date { get; set; }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public int Rating { get; set; }
+    public List<Post> Posts { get; set; }
+}
 
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+    public DateTime Date { get; set; }
+
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
 }

--- a/samples/core/Querying/Pagination/Program.cs
+++ b/samples/core/Querying/Pagination/Program.cs
@@ -2,49 +2,48 @@
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.Pagination
+namespace EFQuerying.Pagination;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
+        using (var context = new BloggingContext())
         {
-            using (var context = new BloggingContext())
-            {
-                #region OffsetPagination
-                var position = 20;
-                var nextPage = context.Posts
-                    .OrderBy(b => b.PostId)
-                    .Skip(position)
-                    .Take(10)
-                    .ToList();
-                #endregion
-            }
+            #region OffsetPagination
+            var position = 20;
+            var nextPage = context.Posts
+                .OrderBy(b => b.PostId)
+                .Skip(position)
+                .Take(10)
+                .ToList();
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region KeySetPagination
-                var lastId = 55;
-                var nextPage = context.Posts
-                    .OrderBy(b => b.PostId)
-                    .Where(b => b.PostId > lastId)
-                    .Take(10)
-                    .ToList();
-                #endregion
-            }
+        using (var context = new BloggingContext())
+        {
+            #region KeySetPagination
+            var lastId = 55;
+            var nextPage = context.Posts
+                .OrderBy(b => b.PostId)
+                .Where(b => b.PostId > lastId)
+                .Take(10)
+                .ToList();
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region KeySetPaginationWithMultipleKeys
-                var lastDate = new DateTime(2020, 1, 1);
-                var lastId = 55;
-                var nextPage = context.Posts
-                    .OrderBy(b => b.Date)
-                    .ThenBy(b => b.PostId)
-                    .Where(b => b.Date > lastDate || (b.Date == lastDate && b.PostId > lastId))
-                    .Take(10)
-                    .ToList();
-                #endregion
-            }
+        using (var context = new BloggingContext())
+        {
+            #region KeySetPaginationWithMultipleKeys
+            var lastDate = new DateTime(2020, 1, 1);
+            var lastId = 55;
+            var nextPage = context.Posts
+                .OrderBy(b => b.Date)
+                .ThenBy(b => b.PostId)
+                .Where(b => b.Date > lastDate || (b.Date == lastDate && b.PostId > lastId))
+                .Take(10)
+                .ToList();
+            #endregion
         }
     }
 }

--- a/samples/core/Querying/QueryFilters/AnimalContext.cs
+++ b/samples/core/Querying/QueryFilters/AnimalContext.cs
@@ -1,31 +1,30 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.QueryFilters
+namespace EFQuerying.QueryFilters;
+
+public class AnimalContext : DbContext
 {
-    public class AnimalContext : DbContext
+    public DbSet<Person> People { get; set; }
+    public DbSet<Animal> Animals { get; set; }
+    public DbSet<Toy> Toys { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        public DbSet<Person> People { get; set; }
-        public DbSet<Animal> Animals { get; set; }
-        public DbSet<Toy> Toys { get; set; }
+        optionsBuilder
+            .UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=Querying.QueryFilters.Animals;Trusted_Connection=True");
+    }
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=Querying.QueryFilters.Animals;Trusted_Connection=True");
-        }
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Cat>().HasOne(c => c.Tolerates).WithOne(d => d.FriendsWith).HasForeignKey<Cat>(c => c.ToleratesId);
+        modelBuilder.Entity<Dog>().HasOne(d => d.FavoriteToy).WithOne(t => t.BelongsTo).HasForeignKey<Toy>(d => d.BelongsToId);
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Cat>().HasOne(c => c.Tolerates).WithOne(d => d.FriendsWith).HasForeignKey<Cat>(c => c.ToleratesId);
-            modelBuilder.Entity<Dog>().HasOne(d => d.FavoriteToy).WithOne(t => t.BelongsTo).HasForeignKey<Toy>(d => d.BelongsToId);
+        modelBuilder.Entity<Person>().HasQueryFilter(p => p.Pets.Count > 0);
+        modelBuilder.Entity<Animal>().HasQueryFilter(a => !a.Name.StartsWith("P"));
+        modelBuilder.Entity<Toy>().HasQueryFilter(a => a.Name.Length > 5);
 
-            modelBuilder.Entity<Person>().HasQueryFilter(p => p.Pets.Count > 0);
-            modelBuilder.Entity<Animal>().HasQueryFilter(a => !a.Name.StartsWith("P"));
-            modelBuilder.Entity<Toy>().HasQueryFilter(a => a.Name.Length > 5);
-
-            // Invalid query filter configuration as it causes cycles in query filters
-            //modelBuilder.Entity<Animal>().HasQueryFilter(a => a.Owner.Name != "John");
-        }
+        // Invalid query filter configuration as it causes cycles in query filters
+        //modelBuilder.Entity<Animal>().HasQueryFilter(a => a.Owner.Name != "John");
     }
 }

--- a/samples/core/Querying/QueryFilters/BloggingContext.cs
+++ b/samples/core/Querying/QueryFilters/BloggingContext.cs
@@ -1,56 +1,55 @@
 ﻿using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.QueryFilters
+namespace EFQuerying.QueryFilters;
+
+public class BloggingContext : DbContext
 {
-    public class BloggingContext : DbContext
+    private readonly string _tenantId;
+
+    public BloggingContext(string tenant)
     {
-        private readonly string _tenantId;
+        _tenantId = tenant;
+    }
 
-        public BloggingContext(string tenant)
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=Querying.QueryFilters.Blogging;Trusted_Connection=True");
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Blog>().Property<string>("_tenantId").HasColumnName("TenantId");
+
+        // Configure entity filters
+        #region FilterConfiguration
+        modelBuilder.Entity<Blog>().HasQueryFilter(b => EF.Property<string>(b, "_tenantId") == _tenantId);
+        modelBuilder.Entity<Post>().HasQueryFilter(p => !p.IsDeleted);
+        #endregion
+    }
+
+    public override int SaveChanges()
+    {
+        ChangeTracker.DetectChanges();
+
+        foreach (var item in ChangeTracker.Entries().Where(
+                     e =>
+                         e.State == EntityState.Added && e.Metadata.GetProperties().Any(p => p.Name == "_tenantId")))
         {
-            _tenantId = tenant;
+            item.CurrentValues["_tenantId"] = _tenantId;
         }
 
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        foreach (var item in ChangeTracker.Entries<Post>().Where(e => e.State == EntityState.Deleted))
         {
-            optionsBuilder
-                .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=Querying.QueryFilters.Blogging;Trusted_Connection=True");
+            item.State = EntityState.Modified;
+            item.CurrentValues["IsDeleted"] = true;
         }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>().Property<string>("_tenantId").HasColumnName("TenantId");
-
-            // Configure entity filters
-            #region FilterConfiguration
-            modelBuilder.Entity<Blog>().HasQueryFilter(b => EF.Property<string>(b, "_tenantId") == _tenantId);
-            modelBuilder.Entity<Post>().HasQueryFilter(p => !p.IsDeleted);
-            #endregion
-        }
-
-        public override int SaveChanges()
-        {
-            ChangeTracker.DetectChanges();
-
-            foreach (var item in ChangeTracker.Entries().Where(
-                e =>
-                    e.State == EntityState.Added && e.Metadata.GetProperties().Any(p => p.Name == "_tenantId")))
-            {
-                item.CurrentValues["_tenantId"] = _tenantId;
-            }
-
-            foreach (var item in ChangeTracker.Entries<Post>().Where(e => e.State == EntityState.Deleted))
-            {
-                item.State = EntityState.Modified;
-                item.CurrentValues["IsDeleted"] = true;
-            }
-
-            return base.SaveChanges();
-        }
+        return base.SaveChanges();
     }
 }

--- a/samples/core/Querying/QueryFilters/Entities.cs
+++ b/samples/core/Querying/QueryFilters/Entities.cs
@@ -1,66 +1,65 @@
 ﻿using System.Collections.Generic;
 
-namespace EFQuerying.QueryFilters
+namespace EFQuerying.QueryFilters;
+
+#region Entities
+public class Blog
 {
-    #region Entities
-    public class Blog
-    {
 #pragma warning disable IDE0051, CS0169 // Remove unused private members
-        private string _tenantId;
+    private string _tenantId;
 #pragma warning restore IDE0051, CS0169 // Remove unused private members
 
-        public int BlogId { get; set; }
-        public string Name { get; set; }
-        public string Url { get; set; }
+    public int BlogId { get; set; }
+    public string Name { get; set; }
+    public string Url { get; set; }
 
-        public List<Post> Posts { get; set; }
-    }
+    public List<Post> Posts { get; set; }
+}
 
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-        public bool IsDeleted { get; set; }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+    public bool IsDeleted { get; set; }
 
-        public Blog Blog { get; set; }
-    }
-    #endregion
+    public Blog Blog { get; set; }
+}
+#endregion
 
-    public class Person
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-        public List<Animal> Pets { get; set; }
-    }
+public class Person
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public List<Animal> Pets { get; set; }
+}
 
-    public abstract class Animal
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-        public Person Owner { get; set; }
-    }
+public abstract class Animal
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public Person Owner { get; set; }
+}
 
-    public class Cat : Animal
-    {
-        public bool PrefersCardboardBoxes { get; set; }
+public class Cat : Animal
+{
+    public bool PrefersCardboardBoxes { get; set; }
 
-        public int? ToleratesId { get; set; }
+    public int? ToleratesId { get; set; }
 
-        public Dog Tolerates { get; set; }
-    }
+    public Dog Tolerates { get; set; }
+}
 
-    public class Dog : Animal
-    {
-        public Toy FavoriteToy { get; set; }
-        public Cat FriendsWith { get; set; }
-    }
+public class Dog : Animal
+{
+    public Toy FavoriteToy { get; set; }
+    public Cat FriendsWith { get; set; }
+}
 
-    public class Toy
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-        public int? BelongsToId { get; set; }
-        public Dog BelongsTo { get; set; }
-    }
+public class Toy
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public int? BelongsToId { get; set; }
+    public Dog BelongsTo { get; set; }
 }

--- a/samples/core/Querying/QueryFilters/FilteredBloggingContextRequired.cs
+++ b/samples/core/Querying/QueryFilters/FilteredBloggingContextRequired.cs
@@ -1,57 +1,56 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.QueryFilters
+namespace EFQuerying.QueryFilters;
+
+public class FilteredBloggingContextRequired : DbContext
 {
-    public class FilteredBloggingContextRequired : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+        optionsBuilder
+            .UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=Querying.QueryFilters.BloggingRequired;Trusted_Connection=True");
+    }
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        var setup = "OptionalNav";
+        if (setup == "Faulty")
         {
-            optionsBuilder
-                .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=Querying.QueryFilters.BloggingRequired;Trusted_Connection=True");
+            // Incorrect setup - Required navigation used to reference entity that has query filter defined,
+            // but no query filter for the entity on the other side of the navigation.
+            #region IncorrectFilter
+            modelBuilder.Entity<Blog>().HasMany(b => b.Posts).WithOne(p => p.Blog).IsRequired();
+            modelBuilder.Entity<Blog>().HasQueryFilter(b => b.Url.Contains("fish"));
+            #endregion
         }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        else if (setup == "OptionalNav")
         {
-            var setup = "OptionalNav";
-            if (setup == "Faulty")
-            {
-                // Incorrect setup - Required navigation used to reference entity that has query filter defined,
-                // but no query filter for the entity on the other side of the navigation.
-                #region IncorrectFilter
-                modelBuilder.Entity<Blog>().HasMany(b => b.Posts).WithOne(p => p.Blog).IsRequired();
-                modelBuilder.Entity<Blog>().HasQueryFilter(b => b.Url.Contains("fish"));
-                #endregion
-            }
-            else if (setup == "OptionalNav")
-            {
-                // The relationship is marked as optional so dependent can exist even if principal is filtered out.
-                #region OptionalNavigation
-                modelBuilder.Entity<Blog>().HasMany(b => b.Posts).WithOne(p => p.Blog).IsRequired(false);
-                modelBuilder.Entity<Blog>().HasQueryFilter(b => b.Url.Contains("fish"));
-                #endregion
-            }
-            else if (setup == "NavigationInFilter")
-            {
-                #region NavigationInFilter
-                modelBuilder.Entity<Blog>().HasMany(b => b.Posts).WithOne(p => p.Blog);
-                modelBuilder.Entity<Blog>().HasQueryFilter(b => b.Posts.Count > 0);
-                modelBuilder.Entity<Post>().HasQueryFilter(p => p.Title.Contains("fish"));
-                #endregion
-            }
-            else
-            {
-                // The relationship is still required but there is a matching filter configured on dependent side too,
-                // which matches principal side. So if principal is filtered out, the dependent would also be.
-                #region MatchingFilters
-                modelBuilder.Entity<Blog>().HasMany(b => b.Posts).WithOne(p => p.Blog).IsRequired();
-                modelBuilder.Entity<Blog>().HasQueryFilter(b => b.Url.Contains("fish"));
-                modelBuilder.Entity<Post>().HasQueryFilter(p => p.Blog.Url.Contains("fish"));
-                #endregion
-            }
+            // The relationship is marked as optional so dependent can exist even if principal is filtered out.
+            #region OptionalNavigation
+            modelBuilder.Entity<Blog>().HasMany(b => b.Posts).WithOne(p => p.Blog).IsRequired(false);
+            modelBuilder.Entity<Blog>().HasQueryFilter(b => b.Url.Contains("fish"));
+            #endregion
+        }
+        else if (setup == "NavigationInFilter")
+        {
+            #region NavigationInFilter
+            modelBuilder.Entity<Blog>().HasMany(b => b.Posts).WithOne(p => p.Blog);
+            modelBuilder.Entity<Blog>().HasQueryFilter(b => b.Posts.Count > 0);
+            modelBuilder.Entity<Post>().HasQueryFilter(p => p.Title.Contains("fish"));
+            #endregion
+        }
+        else
+        {
+            // The relationship is still required but there is a matching filter configured on dependent side too,
+            // which matches principal side. So if principal is filtered out, the dependent would also be.
+            #region MatchingFilters
+            modelBuilder.Entity<Blog>().HasMany(b => b.Posts).WithOne(p => p.Blog).IsRequired();
+            modelBuilder.Entity<Blog>().HasQueryFilter(b => b.Url.Contains("fish"));
+            modelBuilder.Entity<Post>().HasQueryFilter(p => p.Blog.Url.Contains("fish"));
+            #endregion
         }
     }
 }

--- a/samples/core/Querying/QueryFilters/Program.cs
+++ b/samples/core/Querying/QueryFilters/Program.cs
@@ -3,271 +3,24 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.QueryFilters
+namespace EFQuerying.QueryFilters;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
+        QueryFiltersBasicExample();
+        QueryFiltersWithNavigationsExample();
+        QueryFiltersWithRequiredNavigationExample();
+        QueryFiltersUsingNavigationExample();
+    }
+
+    private static void QueryFiltersBasicExample()
+    {
+        using (var db = new BloggingContext("diego"))
         {
-            QueryFiltersBasicExample();
-            QueryFiltersWithNavigationsExample();
-            QueryFiltersWithRequiredNavigationExample();
-            QueryFiltersUsingNavigationExample();
-        }
-
-        private static void QueryFiltersBasicExample()
-        {
-            using (var db = new BloggingContext("diego"))
+            if (db.Database.EnsureCreated())
             {
-                if (db.Database.EnsureCreated())
-                {
-                    db.Blogs.Add(
-                        new Blog
-                        {
-                            Url = "http://sample.com/blogs/fish",
-                            Posts = new List<Post>
-                            {
-                                new Post { Title = "Fish care 101" },
-                                new Post { Title = "Caring for tropical fish" },
-                                new Post { Title = "Types of ornamental fish" }
-                            }
-                        });
-
-                    db.Blogs.Add(
-                        new Blog
-                        {
-                            Url = "http://sample.com/blogs/cats",
-                            Posts = new List<Post>
-                            {
-                                new Post { Title = "Cat care 101" },
-                                new Post { Title = "Caring for tropical cats" },
-                                new Post { Title = "Types of ornamental cats" }
-                            }
-                        });
-
-                    db.SaveChanges();
-
-                    using (var andrewDb = new BloggingContext("andrew"))
-                    {
-                        andrewDb.Blogs.Add(
-                            new Blog
-                            {
-                                Url = "http://sample.com/blogs/catfish",
-                                Posts = new List<Post>
-                                {
-                                    new Post { Title = "Catfish care 101" }, new Post { Title = "History of the catfish name" }
-                                }
-                            });
-
-                        andrewDb.SaveChanges();
-                    }
-
-                    db.Posts
-                        .Where(
-                            p => p.Title == "Caring for tropical fish"
-                                 || p.Title == "Cat care 101")
-                        .ToList()
-                        .ForEach(p => db.Posts.Remove(p));
-
-                    db.SaveChanges();
-                }
-            }
-
-            using (var db = new BloggingContext("Diego"))
-            {
-                var blogs = db.Blogs
-                    .Include(b => b.Posts)
-                    .ToList();
-
-                foreach (var blog in blogs)
-                {
-                    Console.WriteLine(
-                        $"{blog.Url,-33} [Tenant: {db.Entry(blog).Property("_tenantId").CurrentValue}]");
-
-                    foreach (var post in blog.Posts)
-                    {
-                        Console.WriteLine($" - {post.Title,-30} [IsDeleted: {post.IsDeleted}]");
-                    }
-
-                    Console.WriteLine();
-                }
-
-                #region IgnoreFilters
-                blogs = db.Blogs
-                    .Include(b => b.Posts)
-                    .IgnoreQueryFilters()
-                    .ToList();
-                #endregion
-
-                foreach (var blog in blogs)
-                {
-                    Console.WriteLine(
-                        $"{blog.Url,-33} [Tenant: {db.Entry(blog).Property("_tenantId").CurrentValue}]");
-
-                    foreach (var post in blog.Posts)
-                    {
-                        Console.WriteLine($" - {post.Title,-30} [IsDeleted: {post.IsDeleted}]");
-                    }
-                }
-            }
-        }
-
-        private static void QueryFiltersWithNavigationsExample()
-        {
-            using (var animalContext = new AnimalContext())
-            {
-                animalContext.Database.EnsureDeleted();
-                animalContext.Database.EnsureCreated();
-
-                var janice = new Person { Name = "Janice" };
-                var jamie = new Person { Name = "Jamie" };
-                var cesar = new Person { Name = "Cesar" };
-                var paul = new Person { Name = "Paul" };
-                var dominic = new Person { Name = "Dominic" };
-
-                var kibbles = new Cat { Name = "Kibbles", PrefersCardboardBoxes = false, Owner = janice };
-                var sammy = new Cat { Name = "Sammy", PrefersCardboardBoxes = true, Owner = janice };
-                var puffy = new Cat { Name = "Puffy", PrefersCardboardBoxes = true, Owner = jamie };
-                var hati = new Dog { Name = "Hati", FavoriteToy = new Toy { Name = "Squeeky duck" }, Owner = dominic, FriendsWith = puffy };
-                var simba = new Dog { Name = "Simba", FavoriteToy = new Toy { Name = "Bone" }, Owner = cesar, FriendsWith = sammy };
-                puffy.Tolerates = hati;
-                sammy.Tolerates = simba;
-
-                animalContext.People.AddRange(janice, jamie, cesar, paul, dominic);
-                animalContext.Animals.AddRange(kibbles, sammy, puffy, hati, simba);
-                animalContext.SaveChanges();
-            }
-
-            using (var animalContext = new AnimalContext())
-            {
-                Console.WriteLine("*****************");
-                Console.WriteLine("* Animal lovers *");
-                Console.WriteLine("*****************");
-
-                // Jamie and Paul are filtered out.
-                // Paul doesn't own any pets. Jamie owns Puffy, but her pet has been filtered out.
-                var animalLovers = animalContext.People.ToList();
-                DisplayResults(animalLovers);
-
-                Console.WriteLine("**************************************************");
-                Console.WriteLine("* Animal lovers and their pets - filters enabled *");
-                Console.WriteLine("**************************************************");
-
-                // Jamie and Paul are filtered out.
-                // Paul doesn't own any pets. Jamie owns Puffy, but her pet has been filtered out.
-                // Simba's favorite toy has also been filtered out.
-                // Puffy is filtered out so he doesn't show up as Hati's friend.
-                var ownersAndTheirPets = animalContext.People
-                    .Include(p => p.Pets)
-                    .ThenInclude(p => ((Dog)p).FavoriteToy)
-                    .ToList();
-
-                DisplayResults(ownersAndTheirPets);
-
-                Console.WriteLine("*********************************************************");
-                Console.WriteLine("* Animal lovers and their pets - query filters disabled *");
-                Console.WriteLine("*********************************************************");
-
-                var ownersAndTheirPetsUnfiltered = animalContext.People
-                    .IgnoreQueryFilters()
-                    .Include(p => p.Pets)
-                    .ThenInclude(p => ((Dog)p).FavoriteToy)
-                    .ToList();
-
-                DisplayResults(ownersAndTheirPetsUnfiltered);
-            }
-
-            static void DisplayResults(List<Person> people)
-            {
-                foreach (var person in people)
-                {
-                    Console.WriteLine($"{person.Name}");
-                    if (person.Pets != null)
-                    {
-                        foreach (var pet in person.Pets)
-                        {
-                            Console.Write($" - {pet.Name} [{pet.GetType().Name}] ");
-                            if (pet is Cat cat)
-                            {
-                                Console.Write($"| Prefers cardboard boxes: {(cat.PrefersCardboardBoxes ? "Yes" : "No")} ");
-                                Console.WriteLine($"| Tolerates: {(cat.Tolerates != null ? cat.Tolerates.Name : "No one")}");
-                            }
-                            else if (pet is Dog dog)
-                            {
-                                Console.Write($"| Favorite toy: {(dog.FavoriteToy != null ? dog.FavoriteToy.Name : "None")} ");
-                                Console.WriteLine($"| Friend: {(dog.FriendsWith != null ? dog.FriendsWith.Name : "The Owner")}");
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        private static void QueryFiltersWithRequiredNavigationExample()
-        {
-            using (var db = new FilteredBloggingContextRequired())
-            {
-                db.Database.EnsureDeleted();
-                db.Database.EnsureCreated();
-
-                #region SeedData
-                db.Blogs.Add(
-                    new Blog
-                    {
-                        Url = "http://sample.com/blogs/fish",
-                        Posts = new List<Post>
-                        {
-                            new Post { Title = "Fish care 101" },
-                            new Post { Title = "Caring for tropical fish" },
-                            new Post { Title = "Types of ornamental fish" }
-                        }
-                    });
-
-                db.Blogs.Add(
-                    new Blog
-                    {
-                        Url = "http://sample.com/blogs/cats",
-                        Posts = new List<Post>
-                        {
-                            new Post { Title = "Cat care 101" },
-                            new Post { Title = "Caring for tropical cats" },
-                            new Post { Title = "Types of ornamental cats" }
-                        }
-                    });
-                #endregion
-
-                db.SaveChanges();
-            }
-
-            Console.WriteLine("Use of required navigations to access entity with query filter demo");
-            using (var db = new FilteredBloggingContextRequired())
-            {
-                #region Queries
-                var allPosts = db.Posts.ToList();
-                var allPostsWithBlogsIncluded = db.Posts.Include(p => p.Blog).ToList();
-                #endregion
-
-                if (allPosts.Count == allPostsWithBlogsIncluded.Count)
-                {
-                    Console.WriteLine($"Query filters set up correctly. Result count for both queries: {allPosts.Count}.");
-                }
-                else
-                {
-                    Console.WriteLine("Unexpected discrepancy due to query filters and required navigations interaction.");
-                    Console.WriteLine($"All posts count: {allPosts.Count}.");
-                    Console.WriteLine($"All posts with blogs included count: {allPostsWithBlogsIncluded.Count}.");
-                }
-            }
-        }
-
-        private static void QueryFiltersUsingNavigationExample()
-        {
-            using (var db = new FilteredBloggingContextRequired())
-            {
-                db.Database.EnsureDeleted();
-                db.Database.EnsureCreated();
-
-                #region SeedDataNavigation
                 db.Blogs.Add(
                     new Blog
                     {
@@ -292,34 +45,280 @@ namespace EFQuerying.QueryFilters
                         }
                     });
 
-                db.Blogs.Add(
-                    new Blog
-                    {
-                        Url = "http://sample.com/blogs/catfish",
-                        Posts = new List<Post>
+                db.SaveChanges();
+
+                using (var andrewDb = new BloggingContext("andrew"))
+                {
+                    andrewDb.Blogs.Add(
+                        new Blog
                         {
-                            new Post { Title = "Catfish care 101" }, new Post { Title = "History of the catfish name" }
-                        }
-                    });
-                #endregion
+                            Url = "http://sample.com/blogs/catfish",
+                            Posts = new List<Post>
+                            {
+                                new Post { Title = "Catfish care 101" }, new Post { Title = "History of the catfish name" }
+                            }
+                        });
+
+                    andrewDb.SaveChanges();
+                }
+
+                db.Posts
+                    .Where(
+                        p => p.Title == "Caring for tropical fish"
+                             || p.Title == "Cat care 101")
+                    .ToList()
+                    .ForEach(p => db.Posts.Remove(p));
 
                 db.SaveChanges();
             }
+        }
 
-            Console.WriteLine("Query filters using navigations demo");
-            using (var db = new FilteredBloggingContextRequired())
+        using (var db = new BloggingContext("Diego"))
+        {
+            var blogs = db.Blogs
+                .Include(b => b.Posts)
+                .ToList();
+
+            foreach (var blog in blogs)
             {
-                #region QueriesNavigation
-                var filteredBlogs = db.Blogs.ToList();
-                #endregion
-                var filteredBlogsInclude = db.Blogs.Include(b => b.Posts).ToList();
-                if (filteredBlogs.Count == 2
-                    && filteredBlogsInclude.Count == 2)
+                Console.WriteLine(
+                    $"{blog.Url,-33} [Tenant: {db.Entry(blog).Property("_tenantId").CurrentValue}]");
+
+                foreach (var post in blog.Posts)
                 {
-                    Console.WriteLine("Blogs without any Posts are also filtered out. Posts must contain 'fish' in title.");
-                    Console.WriteLine(
-                        "Filters are applied recursively, so Blogs that do have Posts, but those Posts don't contain 'fish' in the title will also be filtered out.");
+                    Console.WriteLine($" - {post.Title,-30} [IsDeleted: {post.IsDeleted}]");
                 }
+
+                Console.WriteLine();
+            }
+
+            #region IgnoreFilters
+            blogs = db.Blogs
+                .Include(b => b.Posts)
+                .IgnoreQueryFilters()
+                .ToList();
+            #endregion
+
+            foreach (var blog in blogs)
+            {
+                Console.WriteLine(
+                    $"{blog.Url,-33} [Tenant: {db.Entry(blog).Property("_tenantId").CurrentValue}]");
+
+                foreach (var post in blog.Posts)
+                {
+                    Console.WriteLine($" - {post.Title,-30} [IsDeleted: {post.IsDeleted}]");
+                }
+            }
+        }
+    }
+
+    private static void QueryFiltersWithNavigationsExample()
+    {
+        using (var animalContext = new AnimalContext())
+        {
+            animalContext.Database.EnsureDeleted();
+            animalContext.Database.EnsureCreated();
+
+            var janice = new Person { Name = "Janice" };
+            var jamie = new Person { Name = "Jamie" };
+            var cesar = new Person { Name = "Cesar" };
+            var paul = new Person { Name = "Paul" };
+            var dominic = new Person { Name = "Dominic" };
+
+            var kibbles = new Cat { Name = "Kibbles", PrefersCardboardBoxes = false, Owner = janice };
+            var sammy = new Cat { Name = "Sammy", PrefersCardboardBoxes = true, Owner = janice };
+            var puffy = new Cat { Name = "Puffy", PrefersCardboardBoxes = true, Owner = jamie };
+            var hati = new Dog { Name = "Hati", FavoriteToy = new Toy { Name = "Squeeky duck" }, Owner = dominic, FriendsWith = puffy };
+            var simba = new Dog { Name = "Simba", FavoriteToy = new Toy { Name = "Bone" }, Owner = cesar, FriendsWith = sammy };
+            puffy.Tolerates = hati;
+            sammy.Tolerates = simba;
+
+            animalContext.People.AddRange(janice, jamie, cesar, paul, dominic);
+            animalContext.Animals.AddRange(kibbles, sammy, puffy, hati, simba);
+            animalContext.SaveChanges();
+        }
+
+        using (var animalContext = new AnimalContext())
+        {
+            Console.WriteLine("*****************");
+            Console.WriteLine("* Animal lovers *");
+            Console.WriteLine("*****************");
+
+            // Jamie and Paul are filtered out.
+            // Paul doesn't own any pets. Jamie owns Puffy, but her pet has been filtered out.
+            var animalLovers = animalContext.People.ToList();
+            DisplayResults(animalLovers);
+
+            Console.WriteLine("**************************************************");
+            Console.WriteLine("* Animal lovers and their pets - filters enabled *");
+            Console.WriteLine("**************************************************");
+
+            // Jamie and Paul are filtered out.
+            // Paul doesn't own any pets. Jamie owns Puffy, but her pet has been filtered out.
+            // Simba's favorite toy has also been filtered out.
+            // Puffy is filtered out so he doesn't show up as Hati's friend.
+            var ownersAndTheirPets = animalContext.People
+                .Include(p => p.Pets)
+                .ThenInclude(p => ((Dog)p).FavoriteToy)
+                .ToList();
+
+            DisplayResults(ownersAndTheirPets);
+
+            Console.WriteLine("*********************************************************");
+            Console.WriteLine("* Animal lovers and their pets - query filters disabled *");
+            Console.WriteLine("*********************************************************");
+
+            var ownersAndTheirPetsUnfiltered = animalContext.People
+                .IgnoreQueryFilters()
+                .Include(p => p.Pets)
+                .ThenInclude(p => ((Dog)p).FavoriteToy)
+                .ToList();
+
+            DisplayResults(ownersAndTheirPetsUnfiltered);
+        }
+
+        static void DisplayResults(List<Person> people)
+        {
+            foreach (var person in people)
+            {
+                Console.WriteLine($"{person.Name}");
+                if (person.Pets != null)
+                {
+                    foreach (var pet in person.Pets)
+                    {
+                        Console.Write($" - {pet.Name} [{pet.GetType().Name}] ");
+                        if (pet is Cat cat)
+                        {
+                            Console.Write($"| Prefers cardboard boxes: {(cat.PrefersCardboardBoxes ? "Yes" : "No")} ");
+                            Console.WriteLine($"| Tolerates: {(cat.Tolerates != null ? cat.Tolerates.Name : "No one")}");
+                        }
+                        else if (pet is Dog dog)
+                        {
+                            Console.Write($"| Favorite toy: {(dog.FavoriteToy != null ? dog.FavoriteToy.Name : "None")} ");
+                            Console.WriteLine($"| Friend: {(dog.FriendsWith != null ? dog.FriendsWith.Name : "The Owner")}");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void QueryFiltersWithRequiredNavigationExample()
+    {
+        using (var db = new FilteredBloggingContextRequired())
+        {
+            db.Database.EnsureDeleted();
+            db.Database.EnsureCreated();
+
+            #region SeedData
+            db.Blogs.Add(
+                new Blog
+                {
+                    Url = "http://sample.com/blogs/fish",
+                    Posts = new List<Post>
+                    {
+                        new Post { Title = "Fish care 101" },
+                        new Post { Title = "Caring for tropical fish" },
+                        new Post { Title = "Types of ornamental fish" }
+                    }
+                });
+
+            db.Blogs.Add(
+                new Blog
+                {
+                    Url = "http://sample.com/blogs/cats",
+                    Posts = new List<Post>
+                    {
+                        new Post { Title = "Cat care 101" },
+                        new Post { Title = "Caring for tropical cats" },
+                        new Post { Title = "Types of ornamental cats" }
+                    }
+                });
+            #endregion
+
+            db.SaveChanges();
+        }
+
+        Console.WriteLine("Use of required navigations to access entity with query filter demo");
+        using (var db = new FilteredBloggingContextRequired())
+        {
+            #region Queries
+            var allPosts = db.Posts.ToList();
+            var allPostsWithBlogsIncluded = db.Posts.Include(p => p.Blog).ToList();
+            #endregion
+
+            if (allPosts.Count == allPostsWithBlogsIncluded.Count)
+            {
+                Console.WriteLine($"Query filters set up correctly. Result count for both queries: {allPosts.Count}.");
+            }
+            else
+            {
+                Console.WriteLine("Unexpected discrepancy due to query filters and required navigations interaction.");
+                Console.WriteLine($"All posts count: {allPosts.Count}.");
+                Console.WriteLine($"All posts with blogs included count: {allPostsWithBlogsIncluded.Count}.");
+            }
+        }
+    }
+
+    private static void QueryFiltersUsingNavigationExample()
+    {
+        using (var db = new FilteredBloggingContextRequired())
+        {
+            db.Database.EnsureDeleted();
+            db.Database.EnsureCreated();
+
+            #region SeedDataNavigation
+            db.Blogs.Add(
+                new Blog
+                {
+                    Url = "http://sample.com/blogs/fish",
+                    Posts = new List<Post>
+                    {
+                        new Post { Title = "Fish care 101" },
+                        new Post { Title = "Caring for tropical fish" },
+                        new Post { Title = "Types of ornamental fish" }
+                    }
+                });
+
+            db.Blogs.Add(
+                new Blog
+                {
+                    Url = "http://sample.com/blogs/cats",
+                    Posts = new List<Post>
+                    {
+                        new Post { Title = "Cat care 101" },
+                        new Post { Title = "Caring for tropical cats" },
+                        new Post { Title = "Types of ornamental cats" }
+                    }
+                });
+
+            db.Blogs.Add(
+                new Blog
+                {
+                    Url = "http://sample.com/blogs/catfish",
+                    Posts = new List<Post>
+                    {
+                        new Post { Title = "Catfish care 101" }, new Post { Title = "History of the catfish name" }
+                    }
+                });
+            #endregion
+
+            db.SaveChanges();
+        }
+
+        Console.WriteLine("Query filters using navigations demo");
+        using (var db = new FilteredBloggingContextRequired())
+        {
+            #region QueriesNavigation
+            var filteredBlogs = db.Blogs.ToList();
+            #endregion
+            var filteredBlogsInclude = db.Blogs.Include(b => b.Posts).ToList();
+            if (filteredBlogs.Count == 2
+                && filteredBlogsInclude.Count == 2)
+            {
+                Console.WriteLine("Blogs without any Posts are also filtered out. Posts must contain 'fish' in title.");
+                Console.WriteLine(
+                    "Filters are applied recursively, so Blogs that do have Posts, but those Posts don't contain 'fish' in the title will also be filtered out.");
             }
         }
     }

--- a/samples/core/Querying/RawSQL/Blog.cs
+++ b/samples/core/Querying/RawSQL/Blog.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
 
-namespace EFQuerying.RawSQL
-{
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public int? Rating { get; set; }
+namespace EFQuerying.RawSQL;
 
-        public List<Post> Posts { get; set; }
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public int? Rating { get; set; }
+
+    public List<Post> Posts { get; set; }
 }

--- a/samples/core/Querying/RawSQL/BloggingContext.cs
+++ b/samples/core/Querying/RawSQL/BloggingContext.cs
@@ -1,58 +1,57 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.RawSQL
+namespace EFQuerying.RawSQL;
+
+public class BloggingContext : DbContext
 {
-    public class BloggingContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasData(
+                new Blog { BlogId = 1, Url = @"https://devblogs.microsoft.com/dotnet", Rating = 5 },
+                new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4 });
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasData(
-                    new Blog { BlogId = 1, Url = @"https://devblogs.microsoft.com/dotnet", Rating = 5 },
-                    new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4 });
+        modelBuilder.Entity<Post>()
+            .HasData(
+                new Post
+                {
+                    PostId = 1,
+                    BlogId = 1,
+                    Title = "What's new",
+                    Content = "Lorem ipsum dolor sit amet",
+                    Rating = 5
+                },
+                new Post
+                {
+                    PostId = 2,
+                    BlogId = 2,
+                    Title = "Around the World in Eighty Days",
+                    Content = "consectetur adipiscing elit",
+                    Rating = 5
+                },
+                new Post
+                {
+                    PostId = 3,
+                    BlogId = 2,
+                    Title = "Glamping *is* the way",
+                    Content = "sed do eiusmod tempor incididunt",
+                    Rating = 4
+                },
+                new Post
+                {
+                    PostId = 4,
+                    BlogId = 2,
+                    Title = "Travel in the time of pandemic",
+                    Content = "ut labore et dolore magna aliqua",
+                    Rating = 3
+                });
+    }
 
-            modelBuilder.Entity<Post>()
-                .HasData(
-                    new Post
-                    {
-                        PostId = 1,
-                        BlogId = 1,
-                        Title = "What's new",
-                        Content = "Lorem ipsum dolor sit amet",
-                        Rating = 5
-                    },
-                    new Post
-                    {
-                        PostId = 2,
-                        BlogId = 2,
-                        Title = "Around the World in Eighty Days",
-                        Content = "consectetur adipiscing elit",
-                        Rating = 5
-                    },
-                    new Post
-                    {
-                        PostId = 3,
-                        BlogId = 2,
-                        Title = "Glamping *is* the way",
-                        Content = "sed do eiusmod tempor incididunt",
-                        Rating = 4
-                    },
-                    new Post
-                    {
-                        PostId = 4,
-                        BlogId = 2,
-                        Title = "Travel in the time of pandemic",
-                        Content = "ut labore et dolore magna aliqua",
-                        Rating = 3
-                    });
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.RawSQL;Trusted_Connection=True");
-        }
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseSqlServer(
+            @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.RawSQL;Trusted_Connection=True");
     }
 }

--- a/samples/core/Querying/RawSQL/Post.cs
+++ b/samples/core/Querying/RawSQL/Post.cs
@@ -1,13 +1,12 @@
-﻿namespace EFQuerying.RawSQL
-{
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-        public int Rating { get; set; }
+﻿namespace EFQuerying.RawSQL;
 
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+    public int Rating { get; set; }
+
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
 }

--- a/samples/core/Querying/RawSQL/Program.cs
+++ b/samples/core/Querying/RawSQL/Program.cs
@@ -2,19 +2,19 @@
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.RawSQL
-{
-    internal class Program
-    {
-        private static void Main(string[] args)
-        {
-            using (var context = new BloggingContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+namespace EFQuerying.RawSQL;
 
-                context.Database.ExecuteSqlRaw(
-                    @"create function [dbo].[SearchBlogs] (@searchTerm nvarchar(max))
+internal class Program
+{
+    private static void Main(string[] args)
+    {
+        using (var context = new BloggingContext())
+        {
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+
+            context.Database.ExecuteSqlRaw(
+                @"create function [dbo].[SearchBlogs] (@searchTerm nvarchar(max))
                           returns @found table
                           (
                               BlogId int not null,
@@ -33,117 +33,116 @@ namespace EFQuerying.RawSQL
                                   return
                           end");
 
-                context.Database.ExecuteSqlRaw(
-                    @"create procedure [dbo].[GetMostPopularBlogs] as
+            context.Database.ExecuteSqlRaw(
+                @"create procedure [dbo].[GetMostPopularBlogs] as
                           begin
                               select * from dbo.Blogs order by Rating
                           end");
 
-                context.Database.ExecuteSqlRaw(
-                    @"create procedure [dbo].[GetMostPopularBlogsForUser] @filterByUser nvarchar(max) as
+            context.Database.ExecuteSqlRaw(
+                @"create procedure [dbo].[GetMostPopularBlogsForUser] @filterByUser nvarchar(max) as
                           begin
                               select * from dbo.Blogs order by Rating
                           end");
-            }
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region FromSqlRaw
-                var blogs = context.Blogs
-                    .FromSqlRaw("SELECT * FROM dbo.Blogs")
-                    .ToList();
-                #endregion
-            }
+        using (var context = new BloggingContext())
+        {
+            #region FromSqlRaw
+            var blogs = context.Blogs
+                .FromSqlRaw("SELECT * FROM dbo.Blogs")
+                .ToList();
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region FromSqlRawStoredProcedure
-                var blogs = context.Blogs
-                    .FromSqlRaw("EXECUTE dbo.GetMostPopularBlogs")
-                    .ToList();
-                #endregion
-            }
+        using (var context = new BloggingContext())
+        {
+            #region FromSqlRawStoredProcedure
+            var blogs = context.Blogs
+                .FromSqlRaw("EXECUTE dbo.GetMostPopularBlogs")
+                .ToList();
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region FromSqlRawStoredProcedureParameter
-                var user = "johndoe";
+        using (var context = new BloggingContext())
+        {
+            #region FromSqlRawStoredProcedureParameter
+            var user = "johndoe";
 
-                var blogs = context.Blogs
-                    .FromSqlRaw("EXECUTE dbo.GetMostPopularBlogsForUser {0}", user)
-                    .ToList();
-                #endregion
-            }
+            var blogs = context.Blogs
+                .FromSqlRaw("EXECUTE dbo.GetMostPopularBlogsForUser {0}", user)
+                .ToList();
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region FromSqlInterpolatedStoredProcedureParameter
-                var user = "johndoe";
+        using (var context = new BloggingContext())
+        {
+            #region FromSqlInterpolatedStoredProcedureParameter
+            var user = "johndoe";
 
-                var blogs = context.Blogs
-                    .FromSqlInterpolated($"EXECUTE dbo.GetMostPopularBlogsForUser {user}")
-                    .ToList();
-                #endregion
-            }
+            var blogs = context.Blogs
+                .FromSqlInterpolated($"EXECUTE dbo.GetMostPopularBlogsForUser {user}")
+                .ToList();
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region FromSqlRawStoredProcedureSqlParameter
-                var user = new SqlParameter("user", "johndoe");
+        using (var context = new BloggingContext())
+        {
+            #region FromSqlRawStoredProcedureSqlParameter
+            var user = new SqlParameter("user", "johndoe");
 
-                var blogs = context.Blogs
-                    .FromSqlRaw("EXECUTE dbo.GetMostPopularBlogsForUser @user", user)
-                    .ToList();
-                #endregion
-            }
+            var blogs = context.Blogs
+                .FromSqlRaw("EXECUTE dbo.GetMostPopularBlogsForUser @user", user)
+                .ToList();
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region FromSqlRawStoredProcedureNamedSqlParameter
-                var user = new SqlParameter("user", "johndoe");
+        using (var context = new BloggingContext())
+        {
+            #region FromSqlRawStoredProcedureNamedSqlParameter
+            var user = new SqlParameter("user", "johndoe");
 
-                var blogs = context.Blogs
-                    .FromSqlRaw("EXECUTE dbo.GetMostPopularBlogsForUser @filterByUser=@user", user)
-                    .ToList();
-                #endregion
-            }
+            var blogs = context.Blogs
+                .FromSqlRaw("EXECUTE dbo.GetMostPopularBlogsForUser @filterByUser=@user", user)
+                .ToList();
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region FromSqlInterpolatedComposed
-                var searchTerm = "Lorem ipsum";
+        using (var context = new BloggingContext())
+        {
+            #region FromSqlInterpolatedComposed
+            var searchTerm = "Lorem ipsum";
 
-                var blogs = context.Blogs
-                    .FromSqlInterpolated($"SELECT * FROM dbo.SearchBlogs({searchTerm})")
-                    .Where(b => b.Rating > 3)
-                    .OrderByDescending(b => b.Rating)
-                    .ToList();
-                #endregion
-            }
+            var blogs = context.Blogs
+                .FromSqlInterpolated($"SELECT * FROM dbo.SearchBlogs({searchTerm})")
+                .Where(b => b.Rating > 3)
+                .OrderByDescending(b => b.Rating)
+                .ToList();
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region FromSqlInterpolatedAsNoTracking
-                var searchTerm = "Lorem ipsum";
+        using (var context = new BloggingContext())
+        {
+            #region FromSqlInterpolatedAsNoTracking
+            var searchTerm = "Lorem ipsum";
 
-                var blogs = context.Blogs
-                    .FromSqlInterpolated($"SELECT * FROM dbo.SearchBlogs({searchTerm})")
-                    .AsNoTracking()
-                    .ToList();
-                #endregion
-            }
+            var blogs = context.Blogs
+                .FromSqlInterpolated($"SELECT * FROM dbo.SearchBlogs({searchTerm})")
+                .AsNoTracking()
+                .ToList();
+            #endregion
+        }
 
-            using (var context = new BloggingContext())
-            {
-                #region FromSqlInterpolatedInclude
-                var searchTerm = "Lorem ipsum";
+        using (var context = new BloggingContext())
+        {
+            #region FromSqlInterpolatedInclude
+            var searchTerm = "Lorem ipsum";
 
-                var blogs = context.Blogs
-                    .FromSqlInterpolated($"SELECT * FROM dbo.SearchBlogs({searchTerm})")
-                    .Include(b => b.Posts)
-                    .ToList();
-                #endregion
-            }
+            var blogs = context.Blogs
+                .FromSqlInterpolated($"SELECT * FROM dbo.SearchBlogs({searchTerm})")
+                .Include(b => b.Posts)
+                .ToList();
+            #endregion
         }
     }
 }

--- a/samples/core/Querying/RelatedData/Blog.cs
+++ b/samples/core/Querying/RelatedData/Blog.cs
@@ -1,19 +1,18 @@
 ﻿using System.Collections.Generic;
 
-namespace EFQuerying.RelatedData
+namespace EFQuerying.RelatedData;
+
+public class Blog
 {
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public int? Rating { get; set; }
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public int? Rating { get; set; }
 
-        public List<Post> Posts { get; set; }
+    public List<Post> Posts { get; set; }
 
-        public int OwnerId { get; set; }
-        public Person Owner { get; set; }
+    public int OwnerId { get; set; }
+    public Person Owner { get; set; }
 
-        public int ThemeId { get; set; }
-        public Theme Theme { get; set; }
-    }
+    public int ThemeId { get; set; }
+    public Theme Theme { get; set; }
 }

--- a/samples/core/Querying/RelatedData/BloggingContext.cs
+++ b/samples/core/Querying/RelatedData/BloggingContext.cs
@@ -1,128 +1,127 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.RelatedData
+namespace EFQuerying.RelatedData;
+
+public class BloggingContext : DbContext
 {
-    public class BloggingContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+    public DbSet<Theme> Themes { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<Theme> Themes { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasMany(b => b.Posts)
+            .WithOne(p => p.Blog)
+            .OnDelete(DeleteBehavior.NoAction);
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasMany(b => b.Posts)
-                .WithOne(p => p.Blog)
-                .OnDelete(DeleteBehavior.NoAction);
+        modelBuilder.Entity<PostTag>()
+            .HasOne(pt => pt.Post)
+            .WithMany(p => p.Tags)
+            .HasForeignKey(pt => pt.PostId);
 
-            modelBuilder.Entity<PostTag>()
-                .HasOne(pt => pt.Post)
-                .WithMany(p => p.Tags)
-                .HasForeignKey(pt => pt.PostId);
+        modelBuilder.Entity<PostTag>()
+            .HasOne(pt => pt.Tag)
+            .WithMany(t => t.Posts)
+            .HasForeignKey(pt => pt.TagId);
 
-            modelBuilder.Entity<PostTag>()
-                .HasOne(pt => pt.Tag)
-                .WithMany(t => t.Posts)
-                .HasForeignKey(pt => pt.TagId);
+        #region AutoInclude
+        modelBuilder.Entity<Theme>().Navigation(e => e.ColorScheme).AutoInclude();
+        #endregion
 
-            #region AutoInclude
-            modelBuilder.Entity<Theme>().Navigation(e => e.ColorScheme).AutoInclude();
-            #endregion
+        modelBuilder.Entity<Blog>()
+            .HasData(
+                new Blog
+                {
+                    BlogId = 1,
+                    Url = @"https://devblogs.microsoft.com/dotnet",
+                    Rating = 5,
+                    OwnerId = 1,
+                    ThemeId = 1
+                },
+                new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4, OwnerId = 3, ThemeId = 1 });
 
-            modelBuilder.Entity<Blog>()
-                .HasData(
-                    new Blog
-                    {
-                        BlogId = 1,
-                        Url = @"https://devblogs.microsoft.com/dotnet",
-                        Rating = 5,
-                        OwnerId = 1,
-                        ThemeId = 1
-                    },
-                    new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4, OwnerId = 3, ThemeId = 1 });
+        modelBuilder.Entity<Post>()
+            .HasData(
+                new Post
+                {
+                    PostId = 1,
+                    BlogId = 1,
+                    Title = "What's new",
+                    Content = "Lorem ipsum dolor sit amet",
+                    Rating = 5,
+                    AuthorId = 1
+                },
+                new Post
+                {
+                    PostId = 2,
+                    BlogId = 2,
+                    Title = "Around the World in Eighty Days",
+                    Content = "consectetur adipiscing elit",
+                    Rating = 5,
+                    AuthorId = 2
+                },
+                new Post
+                {
+                    PostId = 3,
+                    BlogId = 2,
+                    Title = "Glamping *is* the way",
+                    Content = "sed do eiusmod tempor incididunt",
+                    Rating = 4,
+                    AuthorId = 3
+                },
+                new Post
+                {
+                    PostId = 4,
+                    BlogId = 2,
+                    Title = "Travel in the time of pandemic",
+                    Content = "ut labore et dolore magna aliqua",
+                    Rating = 3,
+                    AuthorId = 3
+                });
 
-            modelBuilder.Entity<Post>()
-                .HasData(
-                    new Post
-                    {
-                        PostId = 1,
-                        BlogId = 1,
-                        Title = "What's new",
-                        Content = "Lorem ipsum dolor sit amet",
-                        Rating = 5,
-                        AuthorId = 1
-                    },
-                    new Post
-                    {
-                        PostId = 2,
-                        BlogId = 2,
-                        Title = "Around the World in Eighty Days",
-                        Content = "consectetur adipiscing elit",
-                        Rating = 5,
-                        AuthorId = 2
-                    },
-                    new Post
-                    {
-                        PostId = 3,
-                        BlogId = 2,
-                        Title = "Glamping *is* the way",
-                        Content = "sed do eiusmod tempor incididunt",
-                        Rating = 4,
-                        AuthorId = 3
-                    },
-                    new Post
-                    {
-                        PostId = 4,
-                        BlogId = 2,
-                        Title = "Travel in the time of pandemic",
-                        Content = "ut labore et dolore magna aliqua",
-                        Rating = 3,
-                        AuthorId = 3
-                    });
+        modelBuilder.Entity<Person>()
+            .HasData(
+                new Person { PersonId = 1, Name = "Dotnet Blog Admin", PhotoId = 1 },
+                new Person { PersonId = 2, Name = "Phileas Fogg", PhotoId = 2 },
+                new Person { PersonId = 3, Name = "Jane Doe", PhotoId = 3 });
 
-            modelBuilder.Entity<Person>()
-                .HasData(
-                    new Person { PersonId = 1, Name = "Dotnet Blog Admin", PhotoId = 1 },
-                    new Person { PersonId = 2, Name = "Phileas Fogg", PhotoId = 2 },
-                    new Person { PersonId = 3, Name = "Jane Doe", PhotoId = 3 });
+        modelBuilder.Entity<PersonPhoto>()
+            .HasData(
+                new PersonPhoto { PersonPhotoId = 1, Caption = "SN", Photo = new byte[] { 0x00, 0x01 } },
+                new PersonPhoto { PersonPhotoId = 2, Caption = "PF", Photo = new byte[] { 0x01, 0x02, 0x03 } },
+                new PersonPhoto { PersonPhotoId = 3, Caption = "JD", Photo = new byte[] { 0x01, 0x01, 0x01 } });
 
-            modelBuilder.Entity<PersonPhoto>()
-                .HasData(
-                    new PersonPhoto { PersonPhotoId = 1, Caption = "SN", Photo = new byte[] { 0x00, 0x01 } },
-                    new PersonPhoto { PersonPhotoId = 2, Caption = "PF", Photo = new byte[] { 0x01, 0x02, 0x03 } },
-                    new PersonPhoto { PersonPhotoId = 3, Caption = "JD", Photo = new byte[] { 0x01, 0x01, 0x01 } });
+        modelBuilder.Entity<Tag>()
+            .HasData(
+                new Tag { TagId = "general" },
+                new Tag { TagId = "classic" },
+                new Tag { TagId = "opinion" },
+                new Tag { TagId = "informative" });
 
-            modelBuilder.Entity<Tag>()
-                .HasData(
-                    new Tag { TagId = "general" },
-                    new Tag { TagId = "classic" },
-                    new Tag { TagId = "opinion" },
-                    new Tag { TagId = "informative" });
+        modelBuilder.Entity<PostTag>()
+            .HasData(
+                new PostTag { PostTagId = 1, PostId = 1, TagId = "general" },
+                new PostTag { PostTagId = 2, PostId = 1, TagId = "informative" },
+                new PostTag { PostTagId = 3, PostId = 2, TagId = "classic" },
+                new PostTag { PostTagId = 4, PostId = 3, TagId = "opinion" },
+                new PostTag { PostTagId = 5, PostId = 4, TagId = "opinion" },
+                new PostTag { PostTagId = 6, PostId = 4, TagId = "informative" });
 
-            modelBuilder.Entity<PostTag>()
-                .HasData(
-                    new PostTag { PostTagId = 1, PostId = 1, TagId = "general" },
-                    new PostTag { PostTagId = 2, PostId = 1, TagId = "informative" },
-                    new PostTag { PostTagId = 3, PostId = 2, TagId = "classic" },
-                    new PostTag { PostTagId = 4, PostId = 3, TagId = "opinion" },
-                    new PostTag { PostTagId = 5, PostId = 4, TagId = "opinion" },
-                    new PostTag { PostTagId = 6, PostId = 4, TagId = "informative" });
+        modelBuilder.Entity<ColorScheme>()
+            .HasData(
+                new ColorScheme { Id = 1, Background = "FFFFFF", HighlightColor = "00FF00" }
+            );
 
-            modelBuilder.Entity<ColorScheme>()
-                .HasData(
-                    new ColorScheme { Id = 1, Background = "FFFFFF", HighlightColor = "00FF00" }
-                );
+        modelBuilder.Entity<Theme>()
+            .HasData(
+                new Theme { Id = 1, ColorSchemeId = 1 }
+            );
+    }
 
-            modelBuilder.Entity<Theme>()
-                .HasData(
-                    new Theme { Id = 1, ColorSchemeId = 1 }
-                );
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.ComplexQuery;Trusted_Connection=True");
-        }
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseSqlServer(
+            @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.ComplexQuery;Trusted_Connection=True");
     }
 }

--- a/samples/core/Querying/RelatedData/ColorScheme.cs
+++ b/samples/core/Querying/RelatedData/ColorScheme.cs
@@ -1,9 +1,8 @@
-﻿namespace EFQuerying.RelatedData
+﻿namespace EFQuerying.RelatedData;
+
+public class ColorScheme
 {
-    public class ColorScheme
-    {
-        public int Id { get; set; }
-        public string Background { get; set; }
-        public string HighlightColor { get; set; }
-    }
+    public int Id { get; set; }
+    public string Background { get; set; }
+    public string HighlightColor { get; set; }
 }

--- a/samples/core/Querying/RelatedData/Person.cs
+++ b/samples/core/Querying/RelatedData/Person.cs
@@ -1,16 +1,15 @@
 ﻿using System.Collections.Generic;
 
-namespace EFQuerying.RelatedData
+namespace EFQuerying.RelatedData;
+
+public class Person
 {
-    public class Person
-    {
-        public int PersonId { get; set; }
-        public string Name { get; set; }
+    public int PersonId { get; set; }
+    public string Name { get; set; }
 
-        public List<Post> AuthoredPosts { get; set; }
-        public List<Blog> OwnedBlogs { get; set; }
+    public List<Post> AuthoredPosts { get; set; }
+    public List<Blog> OwnedBlogs { get; set; }
 
-        public int? PhotoId { get; set; }
-        public PersonPhoto Photo { get; set; }
-    }
+    public int? PhotoId { get; set; }
+    public PersonPhoto Photo { get; set; }
 }

--- a/samples/core/Querying/RelatedData/PersonPhoto.cs
+++ b/samples/core/Querying/RelatedData/PersonPhoto.cs
@@ -1,11 +1,10 @@
-﻿namespace EFQuerying.RelatedData
-{
-    public class PersonPhoto
-    {
-        public int PersonPhotoId { get; set; }
-        public string Caption { get; set; }
-        public byte[] Photo { get; set; }
+﻿namespace EFQuerying.RelatedData;
 
-        public Person Person { get; set; }
-    }
+public class PersonPhoto
+{
+    public int PersonPhotoId { get; set; }
+    public string Caption { get; set; }
+    public byte[] Photo { get; set; }
+
+    public Person Person { get; set; }
 }

--- a/samples/core/Querying/RelatedData/Post.cs
+++ b/samples/core/Querying/RelatedData/Post.cs
@@ -1,20 +1,19 @@
 ﻿using System.Collections.Generic;
 
-namespace EFQuerying.RelatedData
+namespace EFQuerying.RelatedData;
+
+public class Post
 {
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-        public int Rating { get; set; }
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+    public int Rating { get; set; }
 
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
 
-        public int AuthorId { get; set; }
-        public Person Author { get; set; }
+    public int AuthorId { get; set; }
+    public Person Author { get; set; }
 
-        public List<PostTag> Tags { get; set; }
-    }
+    public List<PostTag> Tags { get; set; }
 }

--- a/samples/core/Querying/RelatedData/PostTag.cs
+++ b/samples/core/Querying/RelatedData/PostTag.cs
@@ -1,13 +1,12 @@
-﻿namespace EFQuerying.RelatedData
+﻿namespace EFQuerying.RelatedData;
+
+public class PostTag
 {
-    public class PostTag
-    {
-        public int PostTagId { get; set; }
+    public int PostTagId { get; set; }
 
-        public int PostId { get; set; }
-        public Post Post { get; set; }
+    public int PostId { get; set; }
+    public Post Post { get; set; }
 
-        public string TagId { get; set; }
-        public Tag Tag { get; set; }
-    }
+    public string TagId { get; set; }
+    public Tag Tag { get; set; }
 }

--- a/samples/core/Querying/RelatedData/Program.cs
+++ b/samples/core/Querying/RelatedData/Program.cs
@@ -1,234 +1,233 @@
 ﻿using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.RelatedData
+namespace EFQuerying.RelatedData;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
+        using (var context = new BloggingContext())
         {
-            using (var context = new BloggingContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-            }
-
-            #region SingleInclude
-            using (var context = new BloggingContext())
-            {
-                var blogs = context.Blogs
-                    .Include(blog => blog.Posts)
-                    .ToList();
-            }
-            #endregion
-
-            #region IgnoredInclude
-            using (var context = new BloggingContext())
-            {
-                var blogs = context.Blogs
-                    .Include(blog => blog.Posts)
-                    .Select(
-                        blog => new { Id = blog.BlogId, blog.Url })
-                    .ToList();
-            }
-            #endregion
-
-            #region MultipleIncludes
-            using (var context = new BloggingContext())
-            {
-                var blogs = context.Blogs
-                    .Include(blog => blog.Posts)
-                    .Include(blog => blog.Owner)
-                    .ToList();
-            }
-            #endregion
-
-            #region SingleThenInclude
-            using (var context = new BloggingContext())
-            {
-                var blogs = context.Blogs
-                    .Include(blog => blog.Posts)
-                    .ThenInclude(post => post.Author)
-                    .ToList();
-            }
-            #endregion
-
-            #region MultipleThenIncludes
-            using (var context = new BloggingContext())
-            {
-                var blogs = context.Blogs
-                    .Include(blog => blog.Posts)
-                    .ThenInclude(post => post.Author)
-                    .ThenInclude(author => author.Photo)
-                    .ToList();
-            }
-            #endregion
-
-            #region IncludeTree
-            using (var context = new BloggingContext())
-            {
-                var blogs = context.Blogs
-                    .Include(blog => blog.Posts)
-                    .ThenInclude(post => post.Author)
-                    .ThenInclude(author => author.Photo)
-                    .Include(blog => blog.Owner)
-                    .ThenInclude(owner => owner.Photo)
-                    .ToList();
-            }
-            #endregion
-
-            #region MultipleLeafIncludes
-            using (var context = new BloggingContext())
-            {
-                var blogs = context.Blogs
-                    .Include(blog => blog.Posts)
-                    .ThenInclude(post => post.Author)
-                    .Include(blog => blog.Posts)
-                    .ThenInclude(post => post.Tags)
-                    .ToList();
-            }
-            #endregion
-
-            #region IncludeMultipleNavigationsWithSingleInclude
-            using (var context = new BloggingContext())
-            {
-                var blogs = context.Blogs
-                    .Include(blog => blog.Owner.AuthoredPosts)
-                    .ThenInclude(post => post.Blog.Owner.Photo)
-                    .ToList();
-            }
-            #endregion
-
-            #region AsSplitQuery
-            using (var context = new BloggingContext())
-            {
-                var blogs = context.Blogs
-                    .Include(blog => blog.Posts)
-                    .AsSplitQuery()
-                    .ToList();
-            }
-            #endregion
-
-            using (var context = new SplitQueriesBloggingContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-            }
-
-            #region WithSplitQueryAsDefault
-            using (var context = new SplitQueriesBloggingContext())
-            {
-                var blogs = context.Blogs
-                    .Include(blog => blog.Posts)
-                    .ToList();
-            }
-            #endregion
-
-            #region AsSingleQuery
-            using (var context = new SplitQueriesBloggingContext())
-            {
-                var blogs = context.Blogs
-                    .Include(blog => blog.Posts)
-                    .AsSingleQuery()
-                    .ToList();
-            }
-            #endregion
-
-            #region Explicit
-            using (var context = new BloggingContext())
-            {
-                var blog = context.Blogs
-                    .Single(b => b.BlogId == 1);
-
-                context.Entry(blog)
-                    .Collection(b => b.Posts)
-                    .Load();
-
-                context.Entry(blog)
-                    .Reference(b => b.Owner)
-                    .Load();
-            }
-            #endregion
-
-            #region NavQueryAggregate
-            using (var context = new BloggingContext())
-            {
-                var blog = context.Blogs
-                    .Single(b => b.BlogId == 1);
-
-                var postCount = context.Entry(blog)
-                    .Collection(b => b.Posts)
-                    .Query()
-                    .Count();
-            }
-            #endregion
-
-            #region NavQueryFiltered
-            using (var context = new BloggingContext())
-            {
-                var blog = context.Blogs
-                    .Single(b => b.BlogId == 1);
-
-                var goodPosts = context.Entry(blog)
-                    .Collection(b => b.Posts)
-                    .Query()
-                    .Where(p => p.Rating > 3)
-                    .ToList();
-            }
-            #endregion
-
-            #region FilteredInclude
-            using (var context = new BloggingContext())
-            {
-                var filteredBlogs = context.Blogs
-                    .Include(
-                        blog => blog.Posts
-                            .Where(post => post.BlogId == 1)
-                            .OrderByDescending(post => post.Title)
-                            .Take(5))
-                    .ToList();
-            }
-            #endregion
-
-            #region MultipleLeafIncludesFiltered1
-            using (var context = new BloggingContext())
-            {
-                var filteredBlogs = context.Blogs
-                    .Include(blog => blog.Posts.Where(post => post.BlogId == 1))
-                    .ThenInclude(post => post.Author)
-                    .Include(blog => blog.Posts)
-                    .ThenInclude(post => post.Tags.OrderBy(postTag => postTag.TagId).Skip(3))
-                    .ToList();
-            }
-            #endregion
-
-            #region MultipleLeafIncludesFiltered2
-            using (var context = new BloggingContext())
-            {
-                var filteredBlogs = context.Blogs
-                    .Include(blog => blog.Posts.Where(post => post.BlogId == 1))
-                    .ThenInclude(post => post.Author)
-                    .Include(blog => blog.Posts.Where(post => post.BlogId == 1))
-                    .ThenInclude(post => post.Tags.OrderBy(postTag => postTag.TagId).Skip(3))
-                    .ToList();
-            }
-            #endregion
-
-            #region AutoIncludes
-            using (var context = new BloggingContext())
-            {
-                var themes = context.Themes.ToList();
-            }
-
-            #endregion
-
-            #region IgnoreAutoIncludes
-            using (var context = new BloggingContext())
-            {
-                var themes = context.Themes.IgnoreAutoIncludes().ToList();
-            }
-
-            #endregion
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
         }
+
+        #region SingleInclude
+        using (var context = new BloggingContext())
+        {
+            var blogs = context.Blogs
+                .Include(blog => blog.Posts)
+                .ToList();
+        }
+        #endregion
+
+        #region IgnoredInclude
+        using (var context = new BloggingContext())
+        {
+            var blogs = context.Blogs
+                .Include(blog => blog.Posts)
+                .Select(
+                    blog => new { Id = blog.BlogId, blog.Url })
+                .ToList();
+        }
+        #endregion
+
+        #region MultipleIncludes
+        using (var context = new BloggingContext())
+        {
+            var blogs = context.Blogs
+                .Include(blog => blog.Posts)
+                .Include(blog => blog.Owner)
+                .ToList();
+        }
+        #endregion
+
+        #region SingleThenInclude
+        using (var context = new BloggingContext())
+        {
+            var blogs = context.Blogs
+                .Include(blog => blog.Posts)
+                .ThenInclude(post => post.Author)
+                .ToList();
+        }
+        #endregion
+
+        #region MultipleThenIncludes
+        using (var context = new BloggingContext())
+        {
+            var blogs = context.Blogs
+                .Include(blog => blog.Posts)
+                .ThenInclude(post => post.Author)
+                .ThenInclude(author => author.Photo)
+                .ToList();
+        }
+        #endregion
+
+        #region IncludeTree
+        using (var context = new BloggingContext())
+        {
+            var blogs = context.Blogs
+                .Include(blog => blog.Posts)
+                .ThenInclude(post => post.Author)
+                .ThenInclude(author => author.Photo)
+                .Include(blog => blog.Owner)
+                .ThenInclude(owner => owner.Photo)
+                .ToList();
+        }
+        #endregion
+
+        #region MultipleLeafIncludes
+        using (var context = new BloggingContext())
+        {
+            var blogs = context.Blogs
+                .Include(blog => blog.Posts)
+                .ThenInclude(post => post.Author)
+                .Include(blog => blog.Posts)
+                .ThenInclude(post => post.Tags)
+                .ToList();
+        }
+        #endregion
+
+        #region IncludeMultipleNavigationsWithSingleInclude
+        using (var context = new BloggingContext())
+        {
+            var blogs = context.Blogs
+                .Include(blog => blog.Owner.AuthoredPosts)
+                .ThenInclude(post => post.Blog.Owner.Photo)
+                .ToList();
+        }
+        #endregion
+
+        #region AsSplitQuery
+        using (var context = new BloggingContext())
+        {
+            var blogs = context.Blogs
+                .Include(blog => blog.Posts)
+                .AsSplitQuery()
+                .ToList();
+        }
+        #endregion
+
+        using (var context = new SplitQueriesBloggingContext())
+        {
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+        }
+
+        #region WithSplitQueryAsDefault
+        using (var context = new SplitQueriesBloggingContext())
+        {
+            var blogs = context.Blogs
+                .Include(blog => blog.Posts)
+                .ToList();
+        }
+        #endregion
+
+        #region AsSingleQuery
+        using (var context = new SplitQueriesBloggingContext())
+        {
+            var blogs = context.Blogs
+                .Include(blog => blog.Posts)
+                .AsSingleQuery()
+                .ToList();
+        }
+        #endregion
+
+        #region Explicit
+        using (var context = new BloggingContext())
+        {
+            var blog = context.Blogs
+                .Single(b => b.BlogId == 1);
+
+            context.Entry(blog)
+                .Collection(b => b.Posts)
+                .Load();
+
+            context.Entry(blog)
+                .Reference(b => b.Owner)
+                .Load();
+        }
+        #endregion
+
+        #region NavQueryAggregate
+        using (var context = new BloggingContext())
+        {
+            var blog = context.Blogs
+                .Single(b => b.BlogId == 1);
+
+            var postCount = context.Entry(blog)
+                .Collection(b => b.Posts)
+                .Query()
+                .Count();
+        }
+        #endregion
+
+        #region NavQueryFiltered
+        using (var context = new BloggingContext())
+        {
+            var blog = context.Blogs
+                .Single(b => b.BlogId == 1);
+
+            var goodPosts = context.Entry(blog)
+                .Collection(b => b.Posts)
+                .Query()
+                .Where(p => p.Rating > 3)
+                .ToList();
+        }
+        #endregion
+
+        #region FilteredInclude
+        using (var context = new BloggingContext())
+        {
+            var filteredBlogs = context.Blogs
+                .Include(
+                    blog => blog.Posts
+                        .Where(post => post.BlogId == 1)
+                        .OrderByDescending(post => post.Title)
+                        .Take(5))
+                .ToList();
+        }
+        #endregion
+
+        #region MultipleLeafIncludesFiltered1
+        using (var context = new BloggingContext())
+        {
+            var filteredBlogs = context.Blogs
+                .Include(blog => blog.Posts.Where(post => post.BlogId == 1))
+                .ThenInclude(post => post.Author)
+                .Include(blog => blog.Posts)
+                .ThenInclude(post => post.Tags.OrderBy(postTag => postTag.TagId).Skip(3))
+                .ToList();
+        }
+        #endregion
+
+        #region MultipleLeafIncludesFiltered2
+        using (var context = new BloggingContext())
+        {
+            var filteredBlogs = context.Blogs
+                .Include(blog => blog.Posts.Where(post => post.BlogId == 1))
+                .ThenInclude(post => post.Author)
+                .Include(blog => blog.Posts.Where(post => post.BlogId == 1))
+                .ThenInclude(post => post.Tags.OrderBy(postTag => postTag.TagId).Skip(3))
+                .ToList();
+        }
+        #endregion
+
+        #region AutoIncludes
+        using (var context = new BloggingContext())
+        {
+            var themes = context.Themes.ToList();
+        }
+
+        #endregion
+
+        #region IgnoreAutoIncludes
+        using (var context = new BloggingContext())
+        {
+            var themes = context.Themes.IgnoreAutoIncludes().ToList();
+        }
+
+        #endregion
     }
 }

--- a/samples/core/Querying/RelatedData/SplitQueriesBloggingContext.cs
+++ b/samples/core/Querying/RelatedData/SplitQueriesBloggingContext.cs
@@ -1,17 +1,16 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.RelatedData
+namespace EFQuerying.RelatedData;
+
+public class SplitQueriesBloggingContext : BloggingContext
 {
-    public class SplitQueriesBloggingContext : BloggingContext
+    #region QuerySplittingBehaviorSplitQuery
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        #region QuerySplittingBehaviorSplitQuery
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFQuerying;Trusted_Connection=True",
-                    o => o.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery));
-        }
-        #endregion
+        optionsBuilder
+            .UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying;Trusted_Connection=True",
+                o => o.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery));
     }
+    #endregion
 }

--- a/samples/core/Querying/RelatedData/Tag.cs
+++ b/samples/core/Querying/RelatedData/Tag.cs
@@ -1,11 +1,10 @@
 ﻿using System.Collections.Generic;
 
-namespace EFQuerying.RelatedData
-{
-    public class Tag
-    {
-        public string TagId { get; set; }
+namespace EFQuerying.RelatedData;
 
-        public List<PostTag> Posts { get; set; }
-    }
+public class Tag
+{
+    public string TagId { get; set; }
+
+    public List<PostTag> Posts { get; set; }
 }

--- a/samples/core/Querying/RelatedData/Theme.cs
+++ b/samples/core/Querying/RelatedData/Theme.cs
@@ -1,10 +1,9 @@
-﻿namespace EFQuerying.RelatedData
-{
-    public class Theme
-    {
-        public int Id { get; set; }
+﻿namespace EFQuerying.RelatedData;
 
-        public int ColorSchemeId { get; set; }
-        public ColorScheme ColorScheme { get; set; }
-    }
+public class Theme
+{
+    public int Id { get; set; }
+
+    public int ColorSchemeId { get; set; }
+    public ColorScheme ColorScheme { get; set; }
 }

--- a/samples/core/Querying/Tags/Program.cs
+++ b/samples/core/Querying/Tags/Program.cs
@@ -2,58 +2,57 @@
 using Microsoft.EntityFrameworkCore;
 using NetTopologySuite.Geometries;
 
-namespace EFQuerying.Tags
+namespace EFQuerying.Tags;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
+        using (var context = new SpatialContext())
         {
-            using (var context = new SpatialContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-            }
-
-            using (var context = new SpatialContext())
-            {
-                #region BasicQueryTag
-                var myLocation = new Point(1, 2);
-                var nearestPeople = (from f in context.People.TagWith("This is my spatial query!")
-                                     orderby f.Location.Distance(myLocation) descending
-                                     select f).Take(5).ToList();
-                #endregion
-            }
-
-            using (var context = new SpatialContext())
-            {
-                #region ChainedQueryTags
-                var results = Limit(GetNearestPeople(context, new Point(1, 2)), 25).ToList();
-                #endregion
-            }
-
-            using (var context = new SpatialContext())
-            {
-                #region MultilineQueryTag
-                var results = Limit(GetNearestPeople(context, new Point(1, 2)), 25).TagWith(
-                    @"This is a multi-line
-string").ToList();
-                #endregion
-            }
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
         }
 
-        #region QueryableMethods
-        private static IQueryable<Person> GetNearestPeople(SpatialContext context, Point myLocation)
-            => from f in context.People.TagWith("GetNearestPeople")
-               orderby f.Location.Distance(myLocation) descending
-               select f;
+        using (var context = new SpatialContext())
+        {
+            #region BasicQueryTag
+            var myLocation = new Point(1, 2);
+            var nearestPeople = (from f in context.People.TagWith("This is my spatial query!")
+                                 orderby f.Location.Distance(myLocation) descending
+                                 select f).Take(5).ToList();
+            #endregion
+        }
 
-        private static IQueryable<T> Limit<T>(IQueryable<T> source, int limit) => source.TagWith("Limit").Take(limit);
-        #endregion
+        using (var context = new SpatialContext())
+        {
+            #region ChainedQueryTags
+            var results = Limit(GetNearestPeople(context, new Point(1, 2)), 25).ToList();
+            #endregion
+        }
+
+        using (var context = new SpatialContext())
+        {
+            #region MultilineQueryTag
+            var results = Limit(GetNearestPeople(context, new Point(1, 2)), 25).TagWith(
+                @"This is a multi-line
+string").ToList();
+            #endregion
+        }
     }
 
-    public class Person
-    {
-        public int Id { get; set; }
-        public Point Location { get; set; }
-    }
+    #region QueryableMethods
+    private static IQueryable<Person> GetNearestPeople(SpatialContext context, Point myLocation)
+        => from f in context.People.TagWith("GetNearestPeople")
+           orderby f.Location.Distance(myLocation) descending
+           select f;
+
+    private static IQueryable<T> Limit<T>(IQueryable<T> source, int limit) => source.TagWith("Limit").Take(limit);
+    #endregion
+}
+
+public class Person
+{
+    public int Id { get; set; }
+    public Point Location { get; set; }
 }

--- a/samples/core/Querying/Tags/SpatialContext.cs
+++ b/samples/core/Querying/Tags/SpatialContext.cs
@@ -1,31 +1,30 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using NetTopologySuite.Geometries;
 
-namespace EFQuerying.Tags
+namespace EFQuerying.Tags;
+
+public class SpatialContext : DbContext
 {
-    public class SpatialContext : DbContext
+    public DbSet<Person> People { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Person> People { get; set; }
+        modelBuilder.Entity<Person>(
+            b =>
+            {
+                b.Property(e => e.Location).HasColumnType("geometry");
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Person>(
-                b =>
-                {
-                    b.Property(e => e.Location).HasColumnType("geometry");
+                b.HasData(
+                    new Person { Id = 1, Location = new Point(0, 1) },
+                    new Person { Id = 2, Location = new Point(2, 1) },
+                    new Person { Id = 3, Location = new Point(4, 5) });
+            });
+    }
 
-                    b.HasData(
-                        new Person { Id = 1, Location = new Point(0, 1) },
-                        new Person { Id = 2, Location = new Point(2, 1) },
-                        new Person { Id = 3, Location = new Point(4, 5) });
-                });
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.Tags;Trusted_Connection=True",
-                b => b.UseNetTopologySuite());
-        }
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseSqlServer(
+            @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.Tags;Trusted_Connection=True",
+            b => b.UseNetTopologySuite());
     }
 }

--- a/samples/core/Querying/Tracking/Blog.cs
+++ b/samples/core/Querying/Tracking/Blog.cs
@@ -1,12 +1,11 @@
 ﻿using System.Collections.Generic;
 
-namespace EFQuerying.Tracking
+namespace EFQuerying.Tracking;
+
+public class Blog
 {
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public int? Rating { get; set; }
-        public List<Post> Posts { get; set; }
-    }
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public int? Rating { get; set; }
+    public List<Post> Posts { get; set; }
 }

--- a/samples/core/Querying/Tracking/BloggingContext.cs
+++ b/samples/core/Querying/Tracking/BloggingContext.cs
@@ -1,23 +1,22 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.Tracking
+namespace EFQuerying.Tracking;
+
+public class BloggingContext : DbContext
 {
-    public class BloggingContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
+        modelBuilder.Entity<Blog>()
+            .HasData(
+                new Blog { BlogId = 1, Url = @"https://devblogs.microsoft.com/dotnet", Rating = 5 },
+                new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4 });
+    }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasData(
-                    new Blog { BlogId = 1, Url = @"https://devblogs.microsoft.com/dotnet", Rating = 5 },
-                    new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4 });
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFQuerying.Tracking;Trusted_Connection=True");
-        }
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFQuerying.Tracking;Trusted_Connection=True");
     }
 }

--- a/samples/core/Querying/Tracking/NonTrackingBloggingContext.cs
+++ b/samples/core/Querying/Tracking/NonTrackingBloggingContext.cs
@@ -1,26 +1,25 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.Tracking
+namespace EFQuerying.Tracking;
+
+public class NonTrackingBloggingContext : DbContext
 {
-    public class NonTrackingBloggingContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .HasData(
-                    new Blog { BlogId = 1, Url = @"https://devblogs.microsoft.com/dotnet", Rating = 5 },
-                    new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4 });
-        }
-
-        #region OnConfiguring
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFQuerying.Tracking;Trusted_Connection=True")
-                .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
-        }
-        #endregion
+        modelBuilder.Entity<Blog>()
+            .HasData(
+                new Blog { BlogId = 1, Url = @"https://devblogs.microsoft.com/dotnet", Rating = 5 },
+                new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4 });
     }
+
+    #region OnConfiguring
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=EFQuerying.Tracking;Trusted_Connection=True")
+            .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
+    }
+    #endregion
 }

--- a/samples/core/Querying/Tracking/Post.cs
+++ b/samples/core/Querying/Tracking/Post.cs
@@ -1,13 +1,12 @@
-﻿namespace EFQuerying.Tracking
-{
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-        public int Rating { get; set; }
+﻿namespace EFQuerying.Tracking;
 
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+    public int Rating { get; set; }
+
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
 }

--- a/samples/core/Querying/Tracking/Program.cs
+++ b/samples/core/Querying/Tracking/Program.cs
@@ -1,116 +1,115 @@
 ﻿using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.Tracking
+namespace EFQuerying.Tracking;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
+        using (var context = new BloggingContext())
         {
-            using (var context = new BloggingContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-            }
-
-            using (var context = new BloggingContext())
-            {
-                // seeding database
-                context.Blogs.Add(new Blog { Url = "http://sample.com/blog" });
-                context.Blogs.Add(new Blog { Url = "http://sample.com/another_blog" });
-                context.SaveChanges();
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region Tracking
-                var blog = context.Blogs.SingleOrDefault(b => b.BlogId == 1);
-                blog.Rating = 5;
-                context.SaveChanges();
-                #endregion
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region NoTracking
-                var blogs = context.Blogs
-                    .AsNoTracking()
-                    .ToList();
-                #endregion
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region NoTrackingWithIdentityResolution
-                var blogs = context.Blogs
-                    .AsNoTrackingWithIdentityResolution()
-                    .ToList();
-                #endregion
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region ContextDefaultTrackingBehavior
-                context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
-
-                var blogs = context.Blogs.ToList();
-                #endregion
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region CustomProjection1
-                var blog = context.Blogs
-                    .Select(
-                        b =>
-                            new { Blog = b, PostCount = b.Posts.Count() });
-                #endregion
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region CustomProjection2
-                var blog = context.Blogs
-                    .Select(
-                        b =>
-                            new { Blog = b, Post = b.Posts.OrderBy(p => p.Rating).LastOrDefault() });
-                #endregion
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region CustomProjection3
-                var blog = context.Blogs
-                    .Select(
-                        b =>
-                            new { Id = b.BlogId, b.Url });
-                #endregion
-            }
-
-            using (var context = new BloggingContext())
-            {
-                #region ClientProjection
-                var blogs = context.Blogs
-                    .OrderByDescending(blog => blog.Rating)
-                    .Select(
-                        blog => new { Id = blog.BlogId, Url = StandardizeUrl(blog) })
-                    .ToList();
-                #endregion
-            }
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
         }
 
-        #region ClientMethod
-        public static string StandardizeUrl(Blog blog)
+        using (var context = new BloggingContext())
         {
-            var url = blog.Url.ToLower();
-
-            if (!url.StartsWith("http://"))
-            {
-                url = string.Concat("http://", url);
-            }
-
-            return url;
+            // seeding database
+            context.Blogs.Add(new Blog { Url = "http://sample.com/blog" });
+            context.Blogs.Add(new Blog { Url = "http://sample.com/another_blog" });
+            context.SaveChanges();
         }
-        #endregion
+
+        using (var context = new BloggingContext())
+        {
+            #region Tracking
+            var blog = context.Blogs.SingleOrDefault(b => b.BlogId == 1);
+            blog.Rating = 5;
+            context.SaveChanges();
+            #endregion
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region NoTracking
+            var blogs = context.Blogs
+                .AsNoTracking()
+                .ToList();
+            #endregion
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region NoTrackingWithIdentityResolution
+            var blogs = context.Blogs
+                .AsNoTrackingWithIdentityResolution()
+                .ToList();
+            #endregion
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region ContextDefaultTrackingBehavior
+            context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+
+            var blogs = context.Blogs.ToList();
+            #endregion
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region CustomProjection1
+            var blog = context.Blogs
+                .Select(
+                    b =>
+                        new { Blog = b, PostCount = b.Posts.Count() });
+            #endregion
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region CustomProjection2
+            var blog = context.Blogs
+                .Select(
+                    b =>
+                        new { Blog = b, Post = b.Posts.OrderBy(p => p.Rating).LastOrDefault() });
+            #endregion
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region CustomProjection3
+            var blog = context.Blogs
+                .Select(
+                    b =>
+                        new { Id = b.BlogId, b.Url });
+            #endregion
+        }
+
+        using (var context = new BloggingContext())
+        {
+            #region ClientProjection
+            var blogs = context.Blogs
+                .OrderByDescending(blog => blog.Rating)
+                .Select(
+                    blog => new { Id = blog.BlogId, Url = StandardizeUrl(blog) })
+                .ToList();
+            #endregion
+        }
     }
+
+    #region ClientMethod
+    public static string StandardizeUrl(Blog blog)
+    {
+        var url = blog.Url.ToLower();
+
+        if (!url.StartsWith("http://"))
+        {
+            url = string.Concat("http://", url);
+        }
+
+        return url;
+    }
+    #endregion
 }

--- a/samples/core/Querying/UserDefinedFunctionMapping/Model.cs
+++ b/samples/core/Querying/UserDefinedFunctionMapping/Model.cs
@@ -7,214 +7,213 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
 
-namespace EFQuerying.UserDefinedFunctionMapping
+namespace EFQuerying.UserDefinedFunctionMapping;
+
+#region Entities
+public class Blog
 {
-    #region Entities
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public int? Rating { get; set; }
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public int? Rating { get; set; }
 
-        public List<Post> Posts { get; set; }
-    }
+    public List<Post> Posts { get; set; }
+}
 
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
-        public int Rating { get; set; }
-        public int BlogId { get; set; }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+    public int Rating { get; set; }
+    public int BlogId { get; set; }
 
-        public Blog Blog { get; set; }
-        public List<Comment> Comments { get; set; }
-    }
+    public Blog Blog { get; set; }
+    public List<Comment> Comments { get; set; }
+}
 
-    public class Comment
-    {
-        public int CommentId { get; set; }
-        public string Text { get; set; }
-        public int Likes { get; set; }
-        public int PostId { get; set; }
+public class Comment
+{
+    public int CommentId { get; set; }
+    public string Text { get; set; }
+    public int Likes { get; set; }
+    public int PostId { get; set; }
 
-        public Post Post { get; set; }
-    }
+    public Post Post { get; set; }
+}
+#endregion
+
+public class BloggingContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+    public DbSet<Comment> Comments { get; set; }
+
+    #region BasicFunctionDefinition
+    public int ActivePostCountForBlog(int blogId)
+        => throw new NotSupportedException();
     #endregion
 
-    public class BloggingContext : DbContext
+    #region HasTranslationFunctionDefinition
+    public double PercentageDifference(double first, int second)
+        => throw new NotSupportedException();
+    #endregion
+
+    #region QueryableFunctionDefinition
+    public IQueryable<Post> PostsWithPopularComments(int likeThreshold)
+        => FromExpression(() => PostsWithPopularComments(likeThreshold));
+    #endregion
+
+    #region NullabilityPropagationFunctionDefinition
+    public string ConcatStrings(string prm1, string prm2)
+        => throw new InvalidOperationException();
+
+    public string ConcatStringsOptimized(string prm1, string prm2)
+        => throw new InvalidOperationException();
+    #endregion
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<Comment> Comments { get; set; }
+        #region EntityConfiguration
+        modelBuilder.Entity<Blog>()
+            .HasMany(b => b.Posts)
+            .WithOne(p => p.Blog);
 
-        #region BasicFunctionDefinition
-        public int ActivePostCountForBlog(int blogId)
-            => throw new NotSupportedException();
+        modelBuilder.Entity<Post>()
+            .HasMany(p => p.Comments)
+            .WithOne(c => c.Post);
         #endregion
 
-        #region HasTranslationFunctionDefinition
-        public double PercentageDifference(double first, int second)
-            => throw new NotSupportedException();
+        modelBuilder.Entity<Blog>()
+            .HasData(
+                new Blog { BlogId = 1, Url = @"https://devblogs.microsoft.com/dotnet", Rating = 5 },
+                new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4 });
+
+        modelBuilder.Entity<Post>()
+            .HasData(
+                new Post
+                {
+                    PostId = 1,
+                    BlogId = 1,
+                    Title = "What's new",
+                    Content = "Lorem ipsum dolor sit amet",
+                    Rating = 5
+                },
+                new Post
+                {
+                    PostId = 2,
+                    BlogId = 2,
+                    Title = "Around the World in Eighty Days",
+                    Content = "consectetur adipiscing elit",
+                    Rating = 5
+                },
+                new Post
+                {
+                    PostId = 3,
+                    BlogId = 2,
+                    Title = "Glamping *is* the way",
+                    Content = "sed do eiusmod tempor incididunt",
+                    Rating = 4
+                },
+                new Post
+                {
+                    PostId = 4,
+                    BlogId = 2,
+                    Title = "Travel in the time of pandemic",
+                    Content = "ut labore et dolore magna aliqua",
+                    Rating = 3
+                });
+
+        modelBuilder.Entity<Comment>()
+            .HasData(
+                new Comment { CommentId = 1, PostId = 1, Text = "Exciting!", Likes = 3 },
+                new Comment
+                {
+                    CommentId = 2,
+                    PostId = 1,
+                    Text = "Dotnet is useless - why use C# when you can write super fast assembly code instead?",
+                    Likes = 0
+                },
+                new Comment { CommentId = 3, PostId = 2, Text = "Didn't think you would make it!", Likes = 3 },
+                new Comment { CommentId = 4, PostId = 2, Text = "Are you going to try 70 days next time?", Likes = 5 },
+                new Comment { CommentId = 5, PostId = 2, Text = "Good thing the earth is round :)", Likes = 5 },
+                new Comment { CommentId = 6, PostId = 3, Text = "I couldn't agree with you more", Likes = 2 });
+
+        #region BasicFunctionConfiguration
+        modelBuilder.HasDbFunction(typeof(BloggingContext).GetMethod(nameof(ActivePostCountForBlog), new[] { typeof(int) }))
+            .HasName("CommentedPostCountForBlog");
         #endregion
 
-        #region QueryableFunctionDefinition
-        public IQueryable<Post> PostsWithPopularComments(int likeThreshold)
-            => FromExpression(() => PostsWithPopularComments(likeThreshold));
-        #endregion
-
-        #region NullabilityPropagationFunctionDefinition
-        public string ConcatStrings(string prm1, string prm2)
-            => throw new InvalidOperationException();
-
-        public string ConcatStringsOptimized(string prm1, string prm2)
-            => throw new InvalidOperationException();
-        #endregion
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            #region EntityConfiguration
-            modelBuilder.Entity<Blog>()
-                .HasMany(b => b.Posts)
-                .WithOne(p => p.Blog);
-
-            modelBuilder.Entity<Post>()
-                .HasMany(p => p.Comments)
-                .WithOne(c => c.Post);
-            #endregion
-
-            modelBuilder.Entity<Blog>()
-                .HasData(
-                    new Blog { BlogId = 1, Url = @"https://devblogs.microsoft.com/dotnet", Rating = 5 },
-                    new Blog { BlogId = 2, Url = @"https://mytravelblog.com/", Rating = 4 });
-
-            modelBuilder.Entity<Post>()
-                .HasData(
-                    new Post
-                    {
-                        PostId = 1,
-                        BlogId = 1,
-                        Title = "What's new",
-                        Content = "Lorem ipsum dolor sit amet",
-                        Rating = 5
-                    },
-                    new Post
-                    {
-                        PostId = 2,
-                        BlogId = 2,
-                        Title = "Around the World in Eighty Days",
-                        Content = "consectetur adipiscing elit",
-                        Rating = 5
-                    },
-                    new Post
-                    {
-                        PostId = 3,
-                        BlogId = 2,
-                        Title = "Glamping *is* the way",
-                        Content = "sed do eiusmod tempor incididunt",
-                        Rating = 4
-                    },
-                    new Post
-                    {
-                        PostId = 4,
-                        BlogId = 2,
-                        Title = "Travel in the time of pandemic",
-                        Content = "ut labore et dolore magna aliqua",
-                        Rating = 3
-                    });
-
-            modelBuilder.Entity<Comment>()
-                .HasData(
-                    new Comment { CommentId = 1, PostId = 1, Text = "Exciting!", Likes = 3 },
-                    new Comment
-                    {
-                        CommentId = 2,
-                        PostId = 1,
-                        Text = "Dotnet is useless - why use C# when you can write super fast assembly code instead?",
-                        Likes = 0
-                    },
-                    new Comment { CommentId = 3, PostId = 2, Text = "Didn't think you would make it!", Likes = 3 },
-                    new Comment { CommentId = 4, PostId = 2, Text = "Are you going to try 70 days next time?", Likes = 5 },
-                    new Comment { CommentId = 5, PostId = 2, Text = "Good thing the earth is round :)", Likes = 5 },
-                    new Comment { CommentId = 6, PostId = 3, Text = "I couldn't agree with you more", Likes = 2 });
-
-            #region BasicFunctionConfiguration
-            modelBuilder.HasDbFunction(typeof(BloggingContext).GetMethod(nameof(ActivePostCountForBlog), new[] { typeof(int) }))
-                .HasName("CommentedPostCountForBlog");
-            #endregion
-
-            #region HasTranslationFunctionConfiguration
-            // 100 * ABS(first - second) / ((first + second) / 2)
-            modelBuilder.HasDbFunction(
-                    typeof(BloggingContext).GetMethod(nameof(PercentageDifference), new[] { typeof(double), typeof(int) }))
-                .HasTranslation(
-                    args =>
+        #region HasTranslationFunctionConfiguration
+        // 100 * ABS(first - second) / ((first + second) / 2)
+        modelBuilder.HasDbFunction(
+                typeof(BloggingContext).GetMethod(nameof(PercentageDifference), new[] { typeof(double), typeof(int) }))
+            .HasTranslation(
+                args =>
+                    new SqlBinaryExpression(
+                        ExpressionType.Multiply,
+                        new SqlConstantExpression(
+                            Expression.Constant(100),
+                            new IntTypeMapping("int", DbType.Int32)),
                         new SqlBinaryExpression(
-                            ExpressionType.Multiply,
-                            new SqlConstantExpression(
-                                Expression.Constant(100),
-                                new IntTypeMapping("int", DbType.Int32)),
-                            new SqlBinaryExpression(
-                                ExpressionType.Divide,
-                                new SqlFunctionExpression(
-                                    "ABS",
-                                    new SqlExpression[]
-                                    {
-                                        new SqlBinaryExpression(
-                                            ExpressionType.Subtract,
-                                            args.First(),
-                                            args.Skip(1).First(),
-                                            args.First().Type,
-                                            args.First().TypeMapping)
-                                    },
-                                    nullable: true,
-                                    argumentsPropagateNullability: new[] { true, true },
-                                    type: args.First().Type,
-                                    typeMapping: args.First().TypeMapping),
-                                new SqlBinaryExpression(
-                                    ExpressionType.Divide,
+                            ExpressionType.Divide,
+                            new SqlFunctionExpression(
+                                "ABS",
+                                new SqlExpression[]
+                                {
                                     new SqlBinaryExpression(
-                                        ExpressionType.Add,
+                                        ExpressionType.Subtract,
                                         args.First(),
                                         args.Skip(1).First(),
                                         args.First().Type,
-                                        args.First().TypeMapping),
-                                    new SqlConstantExpression(
-                                        Expression.Constant(2),
-                                        new IntTypeMapping("int", DbType.Int32)),
+                                        args.First().TypeMapping)
+                                },
+                                nullable: true,
+                                argumentsPropagateNullability: new[] { true, true },
+                                type: args.First().Type,
+                                typeMapping: args.First().TypeMapping),
+                            new SqlBinaryExpression(
+                                ExpressionType.Divide,
+                                new SqlBinaryExpression(
+                                    ExpressionType.Add,
+                                    args.First(),
+                                    args.Skip(1).First(),
                                     args.First().Type,
                                     args.First().TypeMapping),
+                                new SqlConstantExpression(
+                                    Expression.Constant(2),
+                                    new IntTypeMapping("int", DbType.Int32)),
                                 args.First().Type,
                                 args.First().TypeMapping),
                             args.First().Type,
-                            args.First().TypeMapping));
-            #endregion
+                            args.First().TypeMapping),
+                        args.First().Type,
+                        args.First().TypeMapping));
+        #endregion
 
-            #region NullabilityPropagationModelConfiguration
-            modelBuilder
-                .HasDbFunction(typeof(BloggingContext).GetMethod(nameof(ConcatStrings), new[] { typeof(string), typeof(string) }))
-                .HasName("ConcatStrings");
+        #region NullabilityPropagationModelConfiguration
+        modelBuilder
+            .HasDbFunction(typeof(BloggingContext).GetMethod(nameof(ConcatStrings), new[] { typeof(string), typeof(string) }))
+            .HasName("ConcatStrings");
 
-            modelBuilder.HasDbFunction(
-                typeof(BloggingContext).GetMethod(nameof(ConcatStringsOptimized), new[] { typeof(string), typeof(string) }),
-                b =>
-                {
-                    b.HasName("ConcatStrings");
-                    b.HasParameter("prm1").PropagatesNullability();
-                    b.HasParameter("prm2").PropagatesNullability();
-                });
-            #endregion
+        modelBuilder.HasDbFunction(
+            typeof(BloggingContext).GetMethod(nameof(ConcatStringsOptimized), new[] { typeof(string), typeof(string) }),
+            b =>
+            {
+                b.HasName("ConcatStrings");
+                b.HasParameter("prm1").PropagatesNullability();
+                b.HasParameter("prm2").PropagatesNullability();
+            });
+        #endregion
 
-            #region QueryableFunctionConfigurationHasDbFunction
-            modelBuilder.Entity<Post>().ToTable("Posts");
-            modelBuilder.HasDbFunction(typeof(BloggingContext).GetMethod(nameof(PostsWithPopularComments), new[] { typeof(int) }));
-            #endregion
-        }
+        #region QueryableFunctionConfigurationHasDbFunction
+        modelBuilder.Entity<Post>().ToTable("Posts");
+        modelBuilder.HasDbFunction(typeof(BloggingContext).GetMethod(nameof(PostsWithPopularComments), new[] { typeof(int) }));
+        #endregion
+    }
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.UserDefinedFunctionMapping;Trusted_Connection=True");
-        }
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseSqlServer(
+            @"Server=(localdb)\mssqllocaldb;Database=EFQuerying.UserDefinedFunctionMapping;Trusted_Connection=True");
     }
 }

--- a/samples/core/Querying/UserDefinedFunctionMapping/Program.cs
+++ b/samples/core/Querying/UserDefinedFunctionMapping/Program.cs
@@ -1,18 +1,18 @@
 ﻿using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFQuerying.UserDefinedFunctionMapping
-{
-    internal class Program
-    {
-        private static void Main(string[] args)
-        {
-            using var context = new BloggingContext();
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
+namespace EFQuerying.UserDefinedFunctionMapping;
 
-            context.Database.ExecuteSqlRaw(
-                @"CREATE FUNCTION dbo.CommentedPostCountForBlog(@id int)
+internal class Program
+{
+    private static void Main(string[] args)
+    {
+        using var context = new BloggingContext();
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+
+        context.Database.ExecuteSqlRaw(
+            @"CREATE FUNCTION dbo.CommentedPostCountForBlog(@id int)
                     RETURNS int
                     AS
                     BEGIN
@@ -24,16 +24,16 @@ namespace EFQuerying.UserDefinedFunctionMapping
                                 WHERE [p].[PostId] = [c].[PostId]) > 0));
                     END");
 
-            context.Database.ExecuteSqlRaw(
-                @"CREATE FUNCTION [dbo].[ConcatStrings] (@prm1 nvarchar(max), @prm2 nvarchar(max))
+        context.Database.ExecuteSqlRaw(
+            @"CREATE FUNCTION [dbo].[ConcatStrings] (@prm1 nvarchar(max), @prm2 nvarchar(max))
                     RETURNS nvarchar(max)
                     AS
                     BEGIN
                         RETURN @prm1 + @prm2;
                     END");
 
-            context.Database.ExecuteSqlRaw(
-                @"CREATE FUNCTION dbo.PostsWithPopularComments(@likeThreshold int)
+        context.Database.ExecuteSqlRaw(
+            @"CREATE FUNCTION dbo.PostsWithPopularComments(@likeThreshold int)
                     RETURNS TABLE
                     AS
                     RETURN
@@ -46,35 +46,34 @@ namespace EFQuerying.UserDefinedFunctionMapping
                             WHERE ([p].[PostId] = [c].[PostId]) AND ([c].[Likes] >= @likeThreshold)) > 0
                     )");
 
-            #region BasicQuery
-            var query1 = from b in context.Blogs
-                         where context.ActivePostCountForBlog(b.BlogId) > 1
-                         select b;
-            #endregion
-            var result1 = query1.ToList();
+        #region BasicQuery
+        var query1 = from b in context.Blogs
+                     where context.ActivePostCountForBlog(b.BlogId) > 1
+                     select b;
+        #endregion
+        var result1 = query1.ToList();
 
-            #region HasTranslationQuery
-            var query2 = from p in context.Posts
-                         select context.PercentageDifference(p.BlogId, 3);
-            #endregion
-            var result2 = query2.ToList();
+        #region HasTranslationQuery
+        var query2 = from p in context.Posts
+                     select context.PercentageDifference(p.BlogId, 3);
+        #endregion
+        var result2 = query2.ToList();
 
-            #region NullabilityPropagationExamples
-            var query3 = context.Blogs.Where(e => context.ConcatStrings(e.Url, e.Rating.ToString()) != "https://mytravelblog.com/4");
-            var query4 = context.Blogs.Where(
-                e => context.ConcatStringsOptimized(e.Url, e.Rating.ToString()) != "https://mytravelblog.com/4");
-            #endregion
+        #region NullabilityPropagationExamples
+        var query3 = context.Blogs.Where(e => context.ConcatStrings(e.Url, e.Rating.ToString()) != "https://mytravelblog.com/4");
+        var query4 = context.Blogs.Where(
+            e => context.ConcatStringsOptimized(e.Url, e.Rating.ToString()) != "https://mytravelblog.com/4");
+        #endregion
 
-            var result3 = query3.ToList();
-            var result4 = query4.ToList();
+        var result3 = query3.ToList();
+        var result4 = query4.ToList();
 
-            #region TableValuedFunctionQuery
-            var likeThreshold = 3;
-            var query5 = from p in context.PostsWithPopularComments(likeThreshold)
-                         orderby p.Rating
-                         select p;
-            #endregion
-            var result5 = query5.ToList();
-        }
+        #region TableValuedFunctionQuery
+        var likeThreshold = 3;
+        var query5 = from p in context.PostsWithPopularComments(likeThreshold)
+                     orderby p.Rating
+                     select p;
+        #endregion
+        var result5 = query5.ToList();
     }
 }

--- a/samples/core/Saving/Basics/Blog.cs
+++ b/samples/core/Saving/Basics/Blog.cs
@@ -1,12 +1,11 @@
 ﻿using System.Collections.Generic;
 
-namespace EFSaving.Basics
-{
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+namespace EFSaving.Basics;
 
-        public List<Post> Posts { get; set; }
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public List<Post> Posts { get; set; }
 }

--- a/samples/core/Saving/Basics/BloggingContext.cs
+++ b/samples/core/Saving/Basics/BloggingContext.cs
@@ -1,16 +1,15 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFSaving.Basics
-{
-    public class BloggingContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+namespace EFSaving.Basics;
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Basics;Trusted_Connection=True");
-        }
+public class BloggingContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseSqlServer(
+            @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Basics;Trusted_Connection=True");
     }
 }

--- a/samples/core/Saving/Basics/Post.cs
+++ b/samples/core/Saving/Basics/Post.cs
@@ -1,12 +1,11 @@
-﻿namespace EFSaving.Basics
-{
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+﻿namespace EFSaving.Basics;
 
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
 }

--- a/samples/core/Saving/Basics/Sample.cs
+++ b/samples/core/Saving/Basics/Sample.cs
@@ -1,70 +1,69 @@
 ﻿using System.Linq;
 
-namespace EFSaving.Basics
+namespace EFSaving.Basics;
+
+public class Sample
 {
-    public class Sample
+    public static void Run()
     {
-        public static void Run()
+        using (var context = new BloggingContext())
         {
-            using (var context = new BloggingContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-            }
-
-            #region Add
-            using (var context = new BloggingContext())
-            {
-                var blog = new Blog { Url = "http://example.com" };
-                context.Blogs.Add(blog);
-                context.SaveChanges();
-            }
-            #endregion
-
-            #region Update
-            using (var context = new BloggingContext())
-            {
-                var blog = context.Blogs.First();
-                blog.Url = "http://example.com/blog";
-                context.SaveChanges();
-            }
-            #endregion
-
-            #region Remove
-            using (var context = new BloggingContext())
-            {
-                var blog = context.Blogs.First();
-                context.Blogs.Remove(blog);
-                context.SaveChanges();
-            }
-            #endregion
-
-            #region MultipleOperations
-            using (var context = new BloggingContext())
-            {
-                // seeding database
-                context.Blogs.Add(new Blog { Url = "http://example.com/blog" });
-                context.Blogs.Add(new Blog { Url = "http://example.com/another_blog" });
-                context.SaveChanges();
-            }
-
-            using (var context = new BloggingContext())
-            {
-                // add
-                context.Blogs.Add(new Blog { Url = "http://example.com/blog_one" });
-                context.Blogs.Add(new Blog { Url = "http://example.com/blog_two" });
-
-                // update
-                var firstBlog = context.Blogs.First();
-                firstBlog.Url = "";
-
-                // remove
-                var lastBlog = context.Blogs.OrderBy(e => e.BlogId).Last();
-                context.Blogs.Remove(lastBlog);
-
-                context.SaveChanges();
-            }
-            #endregion
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
         }
+
+        #region Add
+        using (var context = new BloggingContext())
+        {
+            var blog = new Blog { Url = "http://example.com" };
+            context.Blogs.Add(blog);
+            context.SaveChanges();
+        }
+        #endregion
+
+        #region Update
+        using (var context = new BloggingContext())
+        {
+            var blog = context.Blogs.First();
+            blog.Url = "http://example.com/blog";
+            context.SaveChanges();
+        }
+        #endregion
+
+        #region Remove
+        using (var context = new BloggingContext())
+        {
+            var blog = context.Blogs.First();
+            context.Blogs.Remove(blog);
+            context.SaveChanges();
+        }
+        #endregion
+
+        #region MultipleOperations
+        using (var context = new BloggingContext())
+        {
+            // seeding database
+            context.Blogs.Add(new Blog { Url = "http://example.com/blog" });
+            context.Blogs.Add(new Blog { Url = "http://example.com/another_blog" });
+            context.SaveChanges();
+        }
+
+        using (var context = new BloggingContext())
+        {
+            // add
+            context.Blogs.Add(new Blog { Url = "http://example.com/blog_one" });
+            context.Blogs.Add(new Blog { Url = "http://example.com/blog_two" });
+
+            // update
+            var firstBlog = context.Blogs.First();
+            firstBlog.Url = "";
+
+            // remove
+            var lastBlog = context.Blogs.OrderBy(e => e.BlogId).Last();
+            context.Blogs.Remove(lastBlog);
+
+            context.SaveChanges();
+        }
+        #endregion
     }
 }

--- a/samples/core/Saving/CascadeDelete/Blog.cs
+++ b/samples/core/Saving/CascadeDelete/Blog.cs
@@ -1,12 +1,11 @@
 ﻿using System.Collections.Generic;
 
-namespace EFSaving.CascadeDelete
-{
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+namespace EFSaving.CascadeDelete;
 
-        public List<Post> Posts { get; set; } = new List<Post>();
-    }
+public class Blog
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public List<Post> Posts { get; set; } = new List<Post>();
 }

--- a/samples/core/Saving/CascadeDelete/BloggingContext.cs
+++ b/samples/core/Saving/CascadeDelete/BloggingContext.cs
@@ -5,110 +5,109 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Logging;
 
-namespace EFSaving.CascadeDelete
+namespace EFSaving.CascadeDelete;
+
+public sealed class BloggingContext : DbContext
 {
-    public sealed class BloggingContext : DbContext
+    public BloggingContext(DeleteBehavior deleteBehavior, bool requiredRelationship)
     {
-        public BloggingContext(DeleteBehavior deleteBehavior, bool requiredRelationship)
-        {
-            DeleteBehavior = deleteBehavior;
-            RequiredRelationship = requiredRelationship;
+        DeleteBehavior = deleteBehavior;
+        RequiredRelationship = requiredRelationship;
 
-            if (LogMessages == null)
-            {
-                LogMessages = new List<string>();
-                this.GetService<ILoggerFactory>().AddProvider(new MyLoggerProvider());
-            }
+        if (LogMessages == null)
+        {
+            LogMessages = new List<string>();
+            this.GetService<ILoggerFactory>().AddProvider(new MyLoggerProvider());
+        }
+    }
+
+    public DeleteBehavior DeleteBehavior { get; }
+    public bool RequiredRelationship { get; }
+
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder
+            .ReplaceService<IModelCacheKeyFactory, DeleteBehaviorCacheKeyFactory>()
+            .EnableSensitiveDataLogging()
+            .UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.CascadeDelete;Trusted_Connection=True",
+                b => b.MaxBatchSize(1));
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder
+            .Entity<Blog>()
+            .HasMany(e => e.Posts)
+            .WithOne(e => e.Blog)
+            .OnDelete(DeleteBehavior)
+            .IsRequired(RequiredRelationship);
+
+    public override int SaveChanges()
+    {
+        LogMessages.Clear();
+
+        return base.SaveChanges();
+    }
+
+    public class DeleteBehaviorCacheKeyFactory : IModelCacheKeyFactory
+    {
+        public virtual object Create(DbContext context, bool designTime)
+        {
+            var bloggingContext = (BloggingContext)context;
+
+            return (bloggingContext.DeleteBehavior, bloggingContext.RequiredRelationship, designTime);
+        }
+    }
+
+    public static IList<string> LogMessages;
+
+    private class MyLoggerProvider : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new SampleLogger();
+
+        public void Dispose()
+        {
         }
 
-        public DeleteBehavior DeleteBehavior { get; }
-        public bool RequiredRelationship { get; }
-
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder
-                .ReplaceService<IModelCacheKeyFactory, DeleteBehaviorCacheKeyFactory>()
-                .EnableSensitiveDataLogging()
-                .UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.CascadeDelete;Trusted_Connection=True",
-                    b => b.MaxBatchSize(1));
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-            => modelBuilder
-                .Entity<Blog>()
-                .HasMany(e => e.Posts)
-                .WithOne(e => e.Blog)
-                .OnDelete(DeleteBehavior)
-                .IsRequired(RequiredRelationship);
-
-        public override int SaveChanges()
+        private class SampleLogger : ILogger
         {
-            LogMessages.Clear();
+            public bool IsEnabled(LogLevel logLevel) => true;
 
-            return base.SaveChanges();
-        }
-
-        public class DeleteBehaviorCacheKeyFactory : IModelCacheKeyFactory
-        {
-            public virtual object Create(DbContext context, bool designTime)
+            public void Log<TState>(
+                LogLevel logLevel, EventId eventId, TState state, Exception exception,
+                Func<TState, Exception, string> formatter)
             {
-                var bloggingContext = (BloggingContext)context;
-
-                return (bloggingContext.DeleteBehavior, bloggingContext.RequiredRelationship, designTime);
-            }
-        }
-
-        public static IList<string> LogMessages;
-
-        private class MyLoggerProvider : ILoggerProvider
-        {
-            public ILogger CreateLogger(string categoryName) => new SampleLogger();
-
-            public void Dispose()
-            {
-            }
-
-            private class SampleLogger : ILogger
-            {
-                public bool IsEnabled(LogLevel logLevel) => true;
-
-                public void Log<TState>(
-                    LogLevel logLevel, EventId eventId, TState state, Exception exception,
-                    Func<TState, Exception, string> formatter)
+                if (eventId.Id == RelationalEventId.CommandExecuting.Id)
                 {
-                    if (eventId.Id == RelationalEventId.CommandExecuting.Id)
+                    var message = formatter(state, exception);
+                    var commandIndex = Math.Max(message.IndexOf("UPDATE"), message.IndexOf("DELETE"));
+                    if (commandIndex >= 0)
                     {
-                        var message = formatter(state, exception);
-                        var commandIndex = Math.Max(message.IndexOf("UPDATE"), message.IndexOf("DELETE"));
-                        if (commandIndex >= 0)
+                        var truncatedMessage = message.Substring(commandIndex, message.IndexOf(";", commandIndex) - commandIndex)
+                            .Replace(Environment.NewLine, " ");
+
+                        for (var i = 0; i < 4; i++)
                         {
-                            var truncatedMessage = message.Substring(commandIndex, message.IndexOf(";", commandIndex) - commandIndex)
-                                .Replace(Environment.NewLine, " ");
-
-                            for (var i = 0; i < 4; i++)
+                            var paramIndex = message.IndexOf($"@p{i}='");
+                            if (paramIndex >= 0)
                             {
-                                var paramIndex = message.IndexOf($"@p{i}='");
-                                if (paramIndex >= 0)
+                                var paramValue = message.Substring(paramIndex + 5, 1);
+                                if (paramValue == "'")
                                 {
-                                    var paramValue = message.Substring(paramIndex + 5, 1);
-                                    if (paramValue == "'")
-                                    {
-                                        paramValue = "NULL";
-                                    }
-
-                                    truncatedMessage = truncatedMessage.Replace($"@p{i}", paramValue);
+                                    paramValue = "NULL";
                                 }
-                            }
 
-                            LogMessages.Add(truncatedMessage);
+                                truncatedMessage = truncatedMessage.Replace($"@p{i}", paramValue);
+                            }
                         }
+
+                        LogMessages.Add(truncatedMessage);
                     }
                 }
-
-                public IDisposable BeginScope<TState>(TState state) => null;
             }
+
+            public IDisposable BeginScope<TState>(TState state) => null;
         }
     }
 }

--- a/samples/core/Saving/CascadeDelete/Post.cs
+++ b/samples/core/Saving/CascadeDelete/Post.cs
@@ -1,12 +1,11 @@
-﻿namespace EFSaving.CascadeDelete
-{
-    public class Post
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+﻿namespace EFSaving.CascadeDelete;
 
-        public int? BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
+public class Post
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int? BlogId { get; set; }
+    public Blog Blog { get; set; }
 }

--- a/samples/core/Saving/CascadeDelete/Sample.cs
+++ b/samples/core/Saving/CascadeDelete/Sample.cs
@@ -3,160 +3,159 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFSaving.CascadeDelete
+namespace EFSaving.CascadeDelete;
+
+public class Sample
 {
-    public class Sample
+    public static void Run()
     {
-        public static void Run()
+        DeleteBehaviorSample(DeleteBehavior.Cascade, true);
+        DeleteBehaviorSample(DeleteBehavior.ClientSetNull, true);
+        DeleteBehaviorSample(DeleteBehavior.SetNull, true);
+        DeleteBehaviorSample(DeleteBehavior.Restrict, true);
+
+        DeleteBehaviorSample(DeleteBehavior.Cascade, false);
+        DeleteBehaviorSample(DeleteBehavior.ClientSetNull, false);
+        DeleteBehaviorSample(DeleteBehavior.SetNull, false);
+        DeleteBehaviorSample(DeleteBehavior.Restrict, false);
+
+        DeleteOrphansSample(DeleteBehavior.Cascade, true);
+        DeleteOrphansSample(DeleteBehavior.ClientSetNull, true);
+        DeleteOrphansSample(DeleteBehavior.SetNull, true);
+        DeleteOrphansSample(DeleteBehavior.Restrict, true);
+
+        DeleteOrphansSample(DeleteBehavior.Cascade, false);
+        DeleteOrphansSample(DeleteBehavior.ClientSetNull, false);
+        DeleteOrphansSample(DeleteBehavior.SetNull, false);
+        DeleteOrphansSample(DeleteBehavior.Restrict, false);
+    }
+
+    private static void DeleteBehaviorSample(DeleteBehavior deleteBehavior, bool requiredRelationship)
+    {
+        Console.WriteLine(
+            $"Test using DeleteBehavior.{deleteBehavior} with {(requiredRelationship ? "required" : "optional")} relationship:");
+
+        InitializeDatabase(requiredRelationship);
+
+        using var context = new BloggingContext(deleteBehavior, requiredRelationship);
+
+        #region DeleteBehaviorVariations
+        var blog = context.Blogs.Include(b => b.Posts).First();
+        var posts = blog.Posts.ToList();
+
+        DumpEntities("  After loading entities:", context, blog, posts);
+
+        context.Remove(blog);
+
+        DumpEntities($"  After deleting blog '{blog.BlogId}':", context, blog, posts);
+
+        try
         {
-            DeleteBehaviorSample(DeleteBehavior.Cascade, true);
-            DeleteBehaviorSample(DeleteBehavior.ClientSetNull, true);
-            DeleteBehaviorSample(DeleteBehavior.SetNull, true);
-            DeleteBehaviorSample(DeleteBehavior.Restrict, true);
-
-            DeleteBehaviorSample(DeleteBehavior.Cascade, false);
-            DeleteBehaviorSample(DeleteBehavior.ClientSetNull, false);
-            DeleteBehaviorSample(DeleteBehavior.SetNull, false);
-            DeleteBehaviorSample(DeleteBehavior.Restrict, false);
-
-            DeleteOrphansSample(DeleteBehavior.Cascade, true);
-            DeleteOrphansSample(DeleteBehavior.ClientSetNull, true);
-            DeleteOrphansSample(DeleteBehavior.SetNull, true);
-            DeleteOrphansSample(DeleteBehavior.Restrict, true);
-
-            DeleteOrphansSample(DeleteBehavior.Cascade, false);
-            DeleteOrphansSample(DeleteBehavior.ClientSetNull, false);
-            DeleteOrphansSample(DeleteBehavior.SetNull, false);
-            DeleteOrphansSample(DeleteBehavior.Restrict, false);
-        }
-
-        private static void DeleteBehaviorSample(DeleteBehavior deleteBehavior, bool requiredRelationship)
-        {
-            Console.WriteLine(
-                $"Test using DeleteBehavior.{deleteBehavior} with {(requiredRelationship ? "required" : "optional")} relationship:");
-
-            InitializeDatabase(requiredRelationship);
-
-            using var context = new BloggingContext(deleteBehavior, requiredRelationship);
-
-            #region DeleteBehaviorVariations
-            var blog = context.Blogs.Include(b => b.Posts).First();
-            var posts = blog.Posts.ToList();
-
-            DumpEntities("  After loading entities:", context, blog, posts);
-
-            context.Remove(blog);
-
-            DumpEntities($"  After deleting blog '{blog.BlogId}':", context, blog, posts);
-
-            try
-            {
-                Console.WriteLine();
-                Console.WriteLine("  Saving changes:");
-
-                context.SaveChanges();
-
-                DumpSql();
-
-                DumpEntities("  After SaveChanges:", context, blog, posts);
-            }
-            catch (Exception e)
-            {
-                DumpSql();
-
-                Console.WriteLine();
-                Console.WriteLine(
-                    $"  SaveChanges threw {e.GetType().Name}: {(e is DbUpdateException ? e.InnerException.Message : e.Message)}");
-            }
-            #endregion
-
             Console.WriteLine();
-        }
-
-        private static void DeleteOrphansSample(DeleteBehavior deleteBehavior, bool requiredRelationship)
-        {
-            Console.WriteLine(
-                $"Test deleting orphans with DeleteBehavior.{deleteBehavior} and {(requiredRelationship ? "a required" : "an optional")} relationship:");
-
-            InitializeDatabase(requiredRelationship);
-
-            using var context = new BloggingContext(deleteBehavior, requiredRelationship);
-
-            #region DeleteOrphansVariations
-            var blog = context.Blogs.Include(b => b.Posts).First();
-            var posts = blog.Posts.ToList();
-
-            DumpEntities("  After loading entities:", context, blog, posts);
-
-            blog.Posts.Clear();
-
-            DumpEntities("  After making posts orphans:", context, blog, posts);
-
-            try
-            {
-                Console.WriteLine();
-                Console.WriteLine("  Saving changes:");
-
-                context.SaveChanges();
-
-                DumpSql();
-
-                DumpEntities("  After SaveChanges:", context, blog, posts);
-            }
-            catch (Exception e)
-            {
-                DumpSql();
-
-                Console.WriteLine();
-                Console.WriteLine(
-                    $"  SaveChanges threw {e.GetType().Name}: {(e is DbUpdateException ? e.InnerException.Message : e.Message)}");
-            }
-            #endregion
-
-            Console.WriteLine();
-        }
-
-        private static void InitializeDatabase(bool requiredRelationship)
-        {
-            using var context = new BloggingContext(DeleteBehavior.ClientSetNull, requiredRelationship);
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-
-            context.Blogs.Add(
-                new Blog
-                {
-                    Url = "http://sample.com",
-                    Posts = new List<Post> { new Post { Title = "Saving Data with EF" }, new Post { Title = "Cascade Delete with EF" } }
-                });
+            Console.WriteLine("  Saving changes:");
 
             context.SaveChanges();
-        }
 
-        private static void DumpEntities(string message, BloggingContext context, Blog blog, IList<Post> posts)
+            DumpSql();
+
+            DumpEntities("  After SaveChanges:", context, blog, posts);
+        }
+        catch (Exception e)
+        {
+            DumpSql();
+
+            Console.WriteLine();
+            Console.WriteLine(
+                $"  SaveChanges threw {e.GetType().Name}: {(e is DbUpdateException ? e.InnerException.Message : e.Message)}");
+        }
+        #endregion
+
+        Console.WriteLine();
+    }
+
+    private static void DeleteOrphansSample(DeleteBehavior deleteBehavior, bool requiredRelationship)
+    {
+        Console.WriteLine(
+            $"Test deleting orphans with DeleteBehavior.{deleteBehavior} and {(requiredRelationship ? "a required" : "an optional")} relationship:");
+
+        InitializeDatabase(requiredRelationship);
+
+        using var context = new BloggingContext(deleteBehavior, requiredRelationship);
+
+        #region DeleteOrphansVariations
+        var blog = context.Blogs.Include(b => b.Posts).First();
+        var posts = blog.Posts.ToList();
+
+        DumpEntities("  After loading entities:", context, blog, posts);
+
+        blog.Posts.Clear();
+
+        DumpEntities("  After making posts orphans:", context, blog, posts);
+
+        try
         {
             Console.WriteLine();
-            Console.WriteLine(message);
+            Console.WriteLine("  Saving changes:");
 
-            var blogEntry = context.Entry(blog);
+            context.SaveChanges();
 
-            Console.WriteLine($"    Blog '{blog.BlogId}' is in state {blogEntry.State} with {posts.Count} posts referenced.");
+            DumpSql();
 
-            foreach (var post in posts)
-            {
-                var postEntry = context.Entry(post);
-
-                Console.WriteLine(
-                    $"      Post '{post.PostId}' is in state {postEntry.State} " +
-                    $"with FK '{post.BlogId?.ToString() ?? "null"}' and {(post.Blog == null ? "no reference to a blog." : $"reference to blog '{post.BlogId}'.")}");
-            }
+            DumpEntities("  After SaveChanges:", context, blog, posts);
         }
-
-        private static void DumpSql()
+        catch (Exception e)
         {
-            foreach (var logMessage in BloggingContext.LogMessages)
+            DumpSql();
+
+            Console.WriteLine();
+            Console.WriteLine(
+                $"  SaveChanges threw {e.GetType().Name}: {(e is DbUpdateException ? e.InnerException.Message : e.Message)}");
+        }
+        #endregion
+
+        Console.WriteLine();
+    }
+
+    private static void InitializeDatabase(bool requiredRelationship)
+    {
+        using var context = new BloggingContext(DeleteBehavior.ClientSetNull, requiredRelationship);
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+
+        context.Blogs.Add(
+            new Blog
             {
-                Console.WriteLine("    " + logMessage);
-            }
+                Url = "http://sample.com",
+                Posts = new List<Post> { new Post { Title = "Saving Data with EF" }, new Post { Title = "Cascade Delete with EF" } }
+            });
+
+        context.SaveChanges();
+    }
+
+    private static void DumpEntities(string message, BloggingContext context, Blog blog, IList<Post> posts)
+    {
+        Console.WriteLine();
+        Console.WriteLine(message);
+
+        var blogEntry = context.Entry(blog);
+
+        Console.WriteLine($"    Blog '{blog.BlogId}' is in state {blogEntry.State} with {posts.Count} posts referenced.");
+
+        foreach (var post in posts)
+        {
+            var postEntry = context.Entry(post);
+
+            Console.WriteLine(
+                $"      Post '{post.PostId}' is in state {postEntry.State} " +
+                $"with FK '{post.BlogId?.ToString() ?? "null"}' and {(post.Blog == null ? "no reference to a blog." : $"reference to blog '{post.BlogId}'.")}");
+        }
+    }
+
+    private static void DumpSql()
+    {
+        foreach (var logMessage in BloggingContext.LogMessages)
+        {
+            Console.WriteLine("    " + logMessage);
         }
     }
 }

--- a/samples/core/Saving/Concurrency/Sample.cs
+++ b/samples/core/Saving/Concurrency/Sample.cs
@@ -3,97 +3,96 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFSaving.Concurrency
+namespace EFSaving.Concurrency;
+
+public class Sample
 {
-    public class Sample
+    public static void Run()
     {
-        public static void Run()
+        // Ensure database is created and has a person in it
+        using (var setupContext = new PersonContext())
         {
-            // Ensure database is created and has a person in it
-            using (var setupContext = new PersonContext())
-            {
-                setupContext.Database.EnsureDeleted();
-                setupContext.Database.EnsureCreated();
+            setupContext.Database.EnsureDeleted();
+            setupContext.Database.EnsureCreated();
 
-                setupContext.People.Add(new Person { FirstName = "John", LastName = "Doe" });
-                setupContext.SaveChanges();
+            setupContext.People.Add(new Person { FirstName = "John", LastName = "Doe" });
+            setupContext.SaveChanges();
+        }
+
+        #region ConcurrencyHandlingCode
+        using var context = new PersonContext();
+        // Fetch a person from database and change phone number
+        var person = context.People.Single(p => p.PersonId == 1);
+        person.PhoneNumber = "555-555-5555";
+
+        // Change the person's name in the database to simulate a concurrency conflict
+        context.Database.ExecuteSqlRaw(
+            "UPDATE dbo.People SET FirstName = 'Jane' WHERE PersonId = 1");
+
+        var saved = false;
+        while (!saved)
+        {
+            try
+            {
+                // Attempt to save changes to the database
+                context.SaveChanges();
+                saved = true;
             }
-
-            #region ConcurrencyHandlingCode
-            using var context = new PersonContext();
-            // Fetch a person from database and change phone number
-            var person = context.People.Single(p => p.PersonId == 1);
-            person.PhoneNumber = "555-555-5555";
-
-            // Change the person's name in the database to simulate a concurrency conflict
-            context.Database.ExecuteSqlRaw(
-                "UPDATE dbo.People SET FirstName = 'Jane' WHERE PersonId = 1");
-
-            var saved = false;
-            while (!saved)
+            catch (DbUpdateConcurrencyException ex)
             {
-                try
+                foreach (var entry in ex.Entries)
                 {
-                    // Attempt to save changes to the database
-                    context.SaveChanges();
-                    saved = true;
-                }
-                catch (DbUpdateConcurrencyException ex)
-                {
-                    foreach (var entry in ex.Entries)
+                    if (entry.Entity is Person)
                     {
-                        if (entry.Entity is Person)
+                        var proposedValues = entry.CurrentValues;
+                        var databaseValues = entry.GetDatabaseValues();
+
+                        foreach (var property in proposedValues.Properties)
                         {
-                            var proposedValues = entry.CurrentValues;
-                            var databaseValues = entry.GetDatabaseValues();
+                            var proposedValue = proposedValues[property];
+                            var databaseValue = databaseValues[property];
 
-                            foreach (var property in proposedValues.Properties)
-                            {
-                                var proposedValue = proposedValues[property];
-                                var databaseValue = databaseValues[property];
-
-                                // TODO: decide which value should be written to database
-                                // proposedValues[property] = <value to be saved>;
-                            }
-
-                            // Refresh original values to bypass next concurrency check
-                            entry.OriginalValues.SetValues(databaseValues);
+                            // TODO: decide which value should be written to database
+                            // proposedValues[property] = <value to be saved>;
                         }
-                        else
-                        {
-                            throw new NotSupportedException(
-                                "Don't know how to handle concurrency conflicts for "
-                                + entry.Metadata.Name);
-                        }
+
+                        // Refresh original values to bypass next concurrency check
+                        entry.OriginalValues.SetValues(databaseValues);
+                    }
+                    else
+                    {
+                        throw new NotSupportedException(
+                            "Don't know how to handle concurrency conflicts for "
+                            + entry.Metadata.Name);
                     }
                 }
             }
-            #endregion
         }
+        #endregion
+    }
 
-        public class PersonContext : DbContext
+    public class PersonContext : DbContext
+    {
+        public DbSet<Person> People { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            public DbSet<Person> People { get; set; }
-
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            {
-                // Requires NuGet package Microsoft.EntityFrameworkCore.SqlServer
-                optionsBuilder.UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Concurrency;Trusted_Connection=True");
-            }
+            // Requires NuGet package Microsoft.EntityFrameworkCore.SqlServer
+            optionsBuilder.UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Concurrency;Trusted_Connection=True");
         }
+    }
 
-        public class Person
-        {
-            public int PersonId { get; set; }
+    public class Person
+    {
+        public int PersonId { get; set; }
 
-            [ConcurrencyCheck]
-            public string FirstName { get; set; }
+        [ConcurrencyCheck]
+        public string FirstName { get; set; }
 
-            [ConcurrencyCheck]
-            public string LastName { get; set; }
+        [ConcurrencyCheck]
+        public string LastName { get; set; }
 
-            public string PhoneNumber { get; set; }
-        }
+        public string PhoneNumber { get; set; }
     }
 }

--- a/samples/core/Saving/Disconnected/Blog.cs
+++ b/samples/core/Saving/Disconnected/Blog.cs
@@ -1,12 +1,11 @@
 ﻿using System.Collections.Generic;
 
-namespace EFSaving.Disconnected
-{
-    public class Blog : EntityBase
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
+namespace EFSaving.Disconnected;
 
-        public List<Post> Posts { get; set; }
-    }
+public class Blog : EntityBase
+{
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+
+    public List<Post> Posts { get; set; }
 }

--- a/samples/core/Saving/Disconnected/BloggingContext.cs
+++ b/samples/core/Saving/Disconnected/BloggingContext.cs
@@ -1,16 +1,15 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace EFSaving.Disconnected
-{
-    public class BloggingContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+namespace EFSaving.Disconnected;
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Disconnected;Trusted_Connection=True");
-        }
+public class BloggingContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseSqlServer(
+            @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Disconnected;Trusted_Connection=True");
     }
 }

--- a/samples/core/Saving/Disconnected/EntityBase.cs
+++ b/samples/core/Saving/Disconnected/EntityBase.cs
@@ -1,16 +1,15 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 
-namespace EFSaving.Disconnected
+namespace EFSaving.Disconnected;
+
+public abstract class EntityBase
 {
-    public abstract class EntityBase
-    {
-        [NotMapped]
-        public bool IsNew { get; set; }
+    [NotMapped]
+    public bool IsNew { get; set; }
 
-        [NotMapped]
-        public bool IsDeleted { get; set; }
+    [NotMapped]
+    public bool IsDeleted { get; set; }
 
-        [NotMapped]
-        public bool IsChanged { get; set; }
-    }
+    [NotMapped]
+    public bool IsChanged { get; set; }
 }

--- a/samples/core/Saving/Disconnected/Post.cs
+++ b/samples/core/Saving/Disconnected/Post.cs
@@ -1,12 +1,11 @@
-﻿namespace EFSaving.Disconnected
-{
-    public class Post : EntityBase
-    {
-        public int PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+﻿namespace EFSaving.Disconnected;
 
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-    }
+public class Post : EntityBase
+{
+    public int PostId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
 }

--- a/samples/core/Saving/Disconnected/Sample.cs
+++ b/samples/core/Saving/Disconnected/Sample.cs
@@ -3,556 +3,555 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFSaving.Disconnected
+namespace EFSaving.Disconnected;
+
+public class Sample
 {
-    public class Sample
+    public static void Run()
     {
-        public static void Run()
+        using (var context = new BloggingContext())
         {
-            using (var context = new BloggingContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-            }
-
-            IsItNew();
-            InsertAndUpdateSingleEntity();
-            InsertOrUpdateSingleEntityStoreGenerated();
-            InsertOrUpdateSingleEntityFind();
-            InsertAndUpdateGraph();
-            InsertOrUpdateGraphStoreGenerated();
-            InsertOrUpdateGraphFind();
-            InsertUpdateOrDeleteGraphFind();
-            InsertUpdateOrDeleteTrackGraph();
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
         }
 
-        private static void IsItNew()
-        {
-            Console.WriteLine();
-            Console.WriteLine("Show entity-specific check for key set:");
-            using (var context = new BloggingContext())
-            {
-                var blog = new Blog { Url = "http://sample.com" };
-
-                // Key is not set for a new entity
-                Console.WriteLine($"  Blog entity is {(IsItNew(blog) ? "new" : "existing")}.");
-
-                context.Add(blog);
-                context.SaveChanges();
-
-                // Key is now set
-                Console.WriteLine($"  Blog entity is {(IsItNew(blog) ? "new" : "existing")}.");
-            }
-
-            Console.WriteLine();
-            Console.WriteLine("Show general IsKeySet:");
-            using (var context = new BloggingContext())
-            {
-                var blog = new Blog { Url = "http://sample.com" };
-
-                // Key is not set for a new entity
-                Console.WriteLine($"  Blog entity is {(IsItNew(context, (object)blog) ? "new" : "existing")}.");
-
-                context.Add(blog);
-                context.SaveChanges();
-
-                // Key is now set
-                Console.WriteLine($"  Blog entity is {(IsItNew(context, (object)blog) ? "new" : "existing")}.");
-            }
-
-            Console.WriteLine();
-            Console.WriteLine("Show key set on Add:");
-            using (var context = new BloggingContext())
-            {
-                var blog = new Blog { Url = "http://sample.com" };
-
-                // Key is not set for a new entity
-                Console.WriteLine($"  Blog entity is {(IsItNew(context, (object)blog) ? "new" : "existing")}.");
-
-                context.Add(blog);
-
-                // Key is set as soon as Add assigns a key, even if it is temporary
-                Console.WriteLine($"  Blog entity is {(IsItNew(context, (object)blog) ? "new" : "existing")}.");
-            }
-
-            Console.WriteLine();
-            Console.WriteLine("Show using query to check for new entity:");
-            using (var context = new BloggingContext())
-            {
-                var blog = new Blog { Url = "http://sample.com" };
-
-                Console.WriteLine($"  Blog entity is {(IsItNew(context, blog) ? "new" : "existing")}.");
-
-                context.Add(blog);
-                context.SaveChanges();
-
-                Console.WriteLine($"  Blog entity is {(IsItNew(context, blog) ? "new" : "existing")}.");
-            }
-        }
-
-        private static void InsertAndUpdateSingleEntity()
-        {
-            Console.WriteLine();
-            Console.WriteLine("Save single entity with explicit insert or update:");
-            var blog = new Blog { Url = "http://sample.com" };
-
-            using (var context = new BloggingContext())
-            {
-                Console.WriteLine($"  Inserting with URL {blog.Url}");
-                Insert(context, blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                Console.WriteLine($"  Found with URL {context.Blogs.Single(b => b.BlogId == blog.BlogId).Url}");
-            }
-
-            using (var context = new BloggingContext())
-            {
-                blog.Url = "https://sample.com";
-                Console.WriteLine($"  Updating with URL {blog.Url}");
-                Update(context, blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                Console.WriteLine($"  Found with URL {(context.Blogs.Single(b => b.BlogId == blog.BlogId)).Url}");
-            }
-        }
-
-        private static void InsertOrUpdateSingleEntityStoreGenerated()
-        {
-            Console.WriteLine();
-            Console.WriteLine("Save single entity with auto-generated key:");
-            var blog = new Blog { Url = "http://sample.com" };
-
-            using (var context = new BloggingContext())
-            {
-                Console.WriteLine($"  Inserting with URL {blog.Url}");
-                InsertOrUpdate(context, (object)blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                Console.WriteLine($"  Found with URL {context.Blogs.Single(b => b.BlogId == blog.BlogId).Url}");
-            }
-
-            using (var context = new BloggingContext())
-            {
-                blog.Url = "https://sample.com";
-                Console.WriteLine($"  Updating with URL {blog.Url}");
-                InsertOrUpdate(context, (object)blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                Console.WriteLine($"  Found with URL {(context.Blogs.Single(b => b.BlogId == blog.BlogId)).Url}");
-            }
-        }
-
-        private static void InsertOrUpdateSingleEntityFind()
-        {
-            Console.WriteLine();
-            Console.WriteLine("Save single entity with any kind of key:");
-            var blog = new Blog { Url = "http://sample.com" };
-
-            using (var context = new BloggingContext())
-            {
-                Console.WriteLine($"  Inserting with URL {blog.Url}");
-                InsertOrUpdate(context, blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                Console.WriteLine($"  Found with URL {context.Blogs.Single(b => b.BlogId == blog.BlogId).Url}");
-            }
-
-            using (var context = new BloggingContext())
-            {
-                blog.Url = "https://sample.com";
-                Console.WriteLine($"  Updating with URL {blog.Url}");
-                InsertOrUpdate(context, blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                Console.WriteLine($"  Found with URL {context.Blogs.Single(b => b.BlogId == blog.BlogId).Url}");
-            }
-        }
-
-        private static void InsertAndUpdateGraph()
-        {
-            Console.WriteLine();
-            Console.WriteLine("Save graph with explicit insert or update:");
-            var blog = CreateBlogAndPosts();
-
-            using (var context = new BloggingContext())
-            {
-                Console.WriteLine($"  Inserting with URL {blog.Url} and {blog.Posts[0].Title}, {blog.Posts[1].Title}");
-                InsertGraph(context, blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
-                Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
-            }
-
-            using (var context = new BloggingContext())
-            {
-                blog.Url = "https://sample.com";
-                blog.Posts[0].Title = "Post A";
-                blog.Posts[1].Title = "Post B";
-
-                Console.WriteLine($"  Updating with URL {blog.Url}");
-                UpdateGraph(context, blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
-                Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
-            }
-        }
-
-        private static void InsertOrUpdateGraphStoreGenerated()
-        {
-            Console.WriteLine();
-            Console.WriteLine("Save graph with auto-generated key:");
-            var blog = CreateBlogAndPosts();
-
-            using (var context = new BloggingContext())
-            {
-                Console.WriteLine($"  Inserting with URL {blog.Url} and {blog.Posts[0].Title}, {blog.Posts[1].Title}");
-                InsertOrUpdateGraph(context, (object)blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
-                Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
-            }
-
-            using (var context = new BloggingContext())
-            {
-                blog.Url = "https://sample.com";
-                blog.Posts[0].Title = "Post A";
-                blog.Posts[1].Title = "Post B";
-                blog.Posts.Add(new Post { Title = "New Post" });
-
-                Console.WriteLine($"  Updating with URL {blog.Url}");
-                InsertOrUpdateGraph(context, (object)blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
-                Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}, {read.Posts[2].Title}");
-            }
-        }
-
-        private static void InsertOrUpdateGraphFind()
-        {
-            Console.WriteLine();
-            Console.WriteLine("Save graph with any kind of key:");
-            var blog = CreateBlogAndPosts();
-
-            using (var context = new BloggingContext())
-            {
-                Console.WriteLine($"  Inserting with URL {blog.Url} and {blog.Posts[0].Title}, {blog.Posts[1].Title}");
-                InsertOrUpdateGraph(context, blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
-                Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
-            }
-
-            using (var context = new BloggingContext())
-            {
-                blog.Url = "https://sample.com";
-                blog.Posts[0].Title = "Post A";
-                blog.Posts[1].Title = "Post B";
-                blog.Posts.Add(new Post { Title = "New Post" });
-
-                Console.WriteLine($"  Updating with URL {blog.Url}");
-                InsertOrUpdateGraph(context, blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
-                Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}, {read.Posts[2].Title}");
-            }
-        }
-
-        private static void InsertUpdateOrDeleteGraphFind()
-        {
-            Console.WriteLine();
-            Console.WriteLine("Save graph with deletes and any kind of key:");
-            var blog = CreateBlogAndPosts();
-
-            using (var context = new BloggingContext())
-            {
-                Console.WriteLine($"  Inserting with URL {blog.Url} and {blog.Posts[0].Title}, {blog.Posts[1].Title}");
-                InsertUpdateOrDeleteGraph(context, blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
-                Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
-            }
-
-            using (var context = new BloggingContext())
-            {
-                blog.Url = "https://sample.com";
-                blog.Posts[0].Title = "Post A";
-                blog.Posts.Remove(blog.Posts[1]);
-                blog.Posts.Add(new Post { Title = "New Post" });
-
-                Console.WriteLine($"  Updating with URL {blog.Url}");
-                InsertUpdateOrDeleteGraph(context, blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
-                Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
-            }
-        }
-
-        private static void InsertUpdateOrDeleteTrackGraph()
-        {
-            Console.WriteLine();
-            Console.WriteLine("Save graph using TrackGraph:");
-            var blog = CreateBlogAndPosts();
-            blog.IsNew = true;
-            blog.Posts[0].IsNew = true;
-            blog.Posts[1].IsNew = true;
-
-            using (var context = new BloggingContext())
-            {
-                Console.WriteLine($"  Inserting with URL {blog.Url} and {blog.Posts[0].Title}, {blog.Posts[1].Title}");
-                SaveAnnotatedGraph(context, blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
-                Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
-            }
-
-            blog.IsNew = false;
-            blog.Posts[0].IsNew = false;
-            blog.Posts[1].IsNew = false;
-
-            using (var context = new BloggingContext())
-            {
-                blog.Url = "https://sample.com";
-                blog.IsChanged = true;
-                blog.Posts[0].Title = "Post A";
-                blog.Posts[0].IsDeleted = true;
-                blog.Posts[1].Title = "Post B";
-                blog.Posts.Add(new Post { Title = "New Post", IsNew = true });
-
-                Console.WriteLine($"  Updating with URL {blog.Url}");
-                SaveAnnotatedGraph(context, blog);
-            }
-
-            using (var context = new BloggingContext())
-            {
-                var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
-                Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
-            }
-        }
-
-        #region IsItNewSimple
-        public static bool IsItNew(Blog blog)
-            => blog.BlogId == 0;
-        #endregion
-
-        #region IsItNewGeneral
-        public static bool IsItNew(DbContext context, object entity)
-            => !context.Entry(entity).IsKeySet;
-        #endregion
-
-        #region IsItNewQuery
-        public static bool IsItNew(BloggingContext context, Blog blog)
-            => context.Blogs.Find(blog.BlogId) == null;
-        #endregion
-
-        #region InsertAndUpdateSingleEntity
-        public static void Insert(DbContext context, object entity)
-        {
-            context.Add(entity);
-            context.SaveChanges();
-        }
-
-        public static void Update(DbContext context, object entity)
-        {
-            context.Update(entity);
-            context.SaveChanges();
-        }
-        #endregion
-
-        #region InsertOrUpdateSingleEntity
-        public static void InsertOrUpdate(DbContext context, object entity)
-        {
-            context.Update(entity);
-            context.SaveChanges();
-        }
-        #endregion
-
-        #region InsertOrUpdateSingleEntityWithFind
-        public static void InsertOrUpdate(BloggingContext context, Blog blog)
-        {
-            var existingBlog = context.Blogs.Find(blog.BlogId);
-            if (existingBlog == null)
-            {
-                context.Add(blog);
-            }
-            else
-            {
-                context.Entry(existingBlog).CurrentValues.SetValues(blog);
-            }
-
-            context.SaveChanges();
-        }
-        #endregion
-
-        private static Blog CreateBlogAndPosts()
-        {
-            #region CreateBlogAndPosts
-            var blog = new Blog
-            {
-                Url = "http://sample.com", Posts = new List<Post> { new Post { Title = "Post 1" }, new Post { Title = "Post 2" }, }
-            };
-            #endregion
-
-            return blog;
-        }
-
-        #region InsertGraph
-        public static void InsertGraph(DbContext context, object rootEntity)
-        {
-            context.Add(rootEntity);
-            context.SaveChanges();
-        }
-        #endregion
-
-        #region UpdateGraph
-        public static void UpdateGraph(DbContext context, object rootEntity)
-        {
-            context.Update(rootEntity);
-            context.SaveChanges();
-        }
-        #endregion
-
-        #region InsertOrUpdateGraph
-        public static void InsertOrUpdateGraph(DbContext context, object rootEntity)
-        {
-            context.Update(rootEntity);
-            context.SaveChanges();
-        }
-        #endregion
-
-        #region InsertOrUpdateGraphWithFind
-        public static void InsertOrUpdateGraph(BloggingContext context, Blog blog)
-        {
-            var existingBlog = context.Blogs
-                .Include(b => b.Posts)
-                .FirstOrDefault(b => b.BlogId == blog.BlogId);
-
-            if (existingBlog == null)
-            {
-                context.Add(blog);
-            }
-            else
-            {
-                context.Entry(existingBlog).CurrentValues.SetValues(blog);
-                foreach (var post in blog.Posts)
-                {
-                    var existingPost = existingBlog.Posts
-                        .FirstOrDefault(p => p.PostId == post.PostId);
-
-                    if (existingPost == null)
-                    {
-                        existingBlog.Posts.Add(post);
-                    }
-                    else
-                    {
-                        context.Entry(existingPost).CurrentValues.SetValues(post);
-                    }
-                }
-            }
-
-            context.SaveChanges();
-        }
-        #endregion
-
-        #region InsertUpdateOrDeleteGraphWithFind
-        public static void InsertUpdateOrDeleteGraph(BloggingContext context, Blog blog)
-        {
-            var existingBlog = context.Blogs
-                .Include(b => b.Posts)
-                .FirstOrDefault(b => b.BlogId == blog.BlogId);
-
-            if (existingBlog == null)
-            {
-                context.Add(blog);
-            }
-            else
-            {
-                context.Entry(existingBlog).CurrentValues.SetValues(blog);
-                foreach (var post in blog.Posts)
-                {
-                    var existingPost = existingBlog.Posts
-                        .FirstOrDefault(p => p.PostId == post.PostId);
-
-                    if (existingPost == null)
-                    {
-                        existingBlog.Posts.Add(post);
-                    }
-                    else
-                    {
-                        context.Entry(existingPost).CurrentValues.SetValues(post);
-                    }
-                }
-
-                foreach (var post in existingBlog.Posts)
-                {
-                    if (!blog.Posts.Any(p => p.PostId == post.PostId))
-                    {
-                        context.Remove(post);
-                    }
-                }
-            }
-
-            context.SaveChanges();
-        }
-        #endregion
-
-        #region TrackGraph
-        public static void SaveAnnotatedGraph(DbContext context, object rootEntity)
-        {
-            context.ChangeTracker.TrackGraph(
-                rootEntity,
-                n =>
-                {
-                    var entity = (EntityBase)n.Entry.Entity;
-                    n.Entry.State = entity.IsNew
-                        ? EntityState.Added
-                        : entity.IsChanged
-                            ? EntityState.Modified
-                            : entity.IsDeleted
-                                ? EntityState.Deleted
-                                : EntityState.Unchanged;
-                });
-
-            context.SaveChanges();
-        }
-        #endregion
+        IsItNew();
+        InsertAndUpdateSingleEntity();
+        InsertOrUpdateSingleEntityStoreGenerated();
+        InsertOrUpdateSingleEntityFind();
+        InsertAndUpdateGraph();
+        InsertOrUpdateGraphStoreGenerated();
+        InsertOrUpdateGraphFind();
+        InsertUpdateOrDeleteGraphFind();
+        InsertUpdateOrDeleteTrackGraph();
     }
+
+    private static void IsItNew()
+    {
+        Console.WriteLine();
+        Console.WriteLine("Show entity-specific check for key set:");
+        using (var context = new BloggingContext())
+        {
+            var blog = new Blog { Url = "http://sample.com" };
+
+            // Key is not set for a new entity
+            Console.WriteLine($"  Blog entity is {(IsItNew(blog) ? "new" : "existing")}.");
+
+            context.Add(blog);
+            context.SaveChanges();
+
+            // Key is now set
+            Console.WriteLine($"  Blog entity is {(IsItNew(blog) ? "new" : "existing")}.");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("Show general IsKeySet:");
+        using (var context = new BloggingContext())
+        {
+            var blog = new Blog { Url = "http://sample.com" };
+
+            // Key is not set for a new entity
+            Console.WriteLine($"  Blog entity is {(IsItNew(context, (object)blog) ? "new" : "existing")}.");
+
+            context.Add(blog);
+            context.SaveChanges();
+
+            // Key is now set
+            Console.WriteLine($"  Blog entity is {(IsItNew(context, (object)blog) ? "new" : "existing")}.");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("Show key set on Add:");
+        using (var context = new BloggingContext())
+        {
+            var blog = new Blog { Url = "http://sample.com" };
+
+            // Key is not set for a new entity
+            Console.WriteLine($"  Blog entity is {(IsItNew(context, (object)blog) ? "new" : "existing")}.");
+
+            context.Add(blog);
+
+            // Key is set as soon as Add assigns a key, even if it is temporary
+            Console.WriteLine($"  Blog entity is {(IsItNew(context, (object)blog) ? "new" : "existing")}.");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("Show using query to check for new entity:");
+        using (var context = new BloggingContext())
+        {
+            var blog = new Blog { Url = "http://sample.com" };
+
+            Console.WriteLine($"  Blog entity is {(IsItNew(context, blog) ? "new" : "existing")}.");
+
+            context.Add(blog);
+            context.SaveChanges();
+
+            Console.WriteLine($"  Blog entity is {(IsItNew(context, blog) ? "new" : "existing")}.");
+        }
+    }
+
+    private static void InsertAndUpdateSingleEntity()
+    {
+        Console.WriteLine();
+        Console.WriteLine("Save single entity with explicit insert or update:");
+        var blog = new Blog { Url = "http://sample.com" };
+
+        using (var context = new BloggingContext())
+        {
+            Console.WriteLine($"  Inserting with URL {blog.Url}");
+            Insert(context, blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            Console.WriteLine($"  Found with URL {context.Blogs.Single(b => b.BlogId == blog.BlogId).Url}");
+        }
+
+        using (var context = new BloggingContext())
+        {
+            blog.Url = "https://sample.com";
+            Console.WriteLine($"  Updating with URL {blog.Url}");
+            Update(context, blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            Console.WriteLine($"  Found with URL {(context.Blogs.Single(b => b.BlogId == blog.BlogId)).Url}");
+        }
+    }
+
+    private static void InsertOrUpdateSingleEntityStoreGenerated()
+    {
+        Console.WriteLine();
+        Console.WriteLine("Save single entity with auto-generated key:");
+        var blog = new Blog { Url = "http://sample.com" };
+
+        using (var context = new BloggingContext())
+        {
+            Console.WriteLine($"  Inserting with URL {blog.Url}");
+            InsertOrUpdate(context, (object)blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            Console.WriteLine($"  Found with URL {context.Blogs.Single(b => b.BlogId == blog.BlogId).Url}");
+        }
+
+        using (var context = new BloggingContext())
+        {
+            blog.Url = "https://sample.com";
+            Console.WriteLine($"  Updating with URL {blog.Url}");
+            InsertOrUpdate(context, (object)blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            Console.WriteLine($"  Found with URL {(context.Blogs.Single(b => b.BlogId == blog.BlogId)).Url}");
+        }
+    }
+
+    private static void InsertOrUpdateSingleEntityFind()
+    {
+        Console.WriteLine();
+        Console.WriteLine("Save single entity with any kind of key:");
+        var blog = new Blog { Url = "http://sample.com" };
+
+        using (var context = new BloggingContext())
+        {
+            Console.WriteLine($"  Inserting with URL {blog.Url}");
+            InsertOrUpdate(context, blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            Console.WriteLine($"  Found with URL {context.Blogs.Single(b => b.BlogId == blog.BlogId).Url}");
+        }
+
+        using (var context = new BloggingContext())
+        {
+            blog.Url = "https://sample.com";
+            Console.WriteLine($"  Updating with URL {blog.Url}");
+            InsertOrUpdate(context, blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            Console.WriteLine($"  Found with URL {context.Blogs.Single(b => b.BlogId == blog.BlogId).Url}");
+        }
+    }
+
+    private static void InsertAndUpdateGraph()
+    {
+        Console.WriteLine();
+        Console.WriteLine("Save graph with explicit insert or update:");
+        var blog = CreateBlogAndPosts();
+
+        using (var context = new BloggingContext())
+        {
+            Console.WriteLine($"  Inserting with URL {blog.Url} and {blog.Posts[0].Title}, {blog.Posts[1].Title}");
+            InsertGraph(context, blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
+            Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
+        }
+
+        using (var context = new BloggingContext())
+        {
+            blog.Url = "https://sample.com";
+            blog.Posts[0].Title = "Post A";
+            blog.Posts[1].Title = "Post B";
+
+            Console.WriteLine($"  Updating with URL {blog.Url}");
+            UpdateGraph(context, blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
+            Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
+        }
+    }
+
+    private static void InsertOrUpdateGraphStoreGenerated()
+    {
+        Console.WriteLine();
+        Console.WriteLine("Save graph with auto-generated key:");
+        var blog = CreateBlogAndPosts();
+
+        using (var context = new BloggingContext())
+        {
+            Console.WriteLine($"  Inserting with URL {blog.Url} and {blog.Posts[0].Title}, {blog.Posts[1].Title}");
+            InsertOrUpdateGraph(context, (object)blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
+            Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
+        }
+
+        using (var context = new BloggingContext())
+        {
+            blog.Url = "https://sample.com";
+            blog.Posts[0].Title = "Post A";
+            blog.Posts[1].Title = "Post B";
+            blog.Posts.Add(new Post { Title = "New Post" });
+
+            Console.WriteLine($"  Updating with URL {blog.Url}");
+            InsertOrUpdateGraph(context, (object)blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
+            Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}, {read.Posts[2].Title}");
+        }
+    }
+
+    private static void InsertOrUpdateGraphFind()
+    {
+        Console.WriteLine();
+        Console.WriteLine("Save graph with any kind of key:");
+        var blog = CreateBlogAndPosts();
+
+        using (var context = new BloggingContext())
+        {
+            Console.WriteLine($"  Inserting with URL {blog.Url} and {blog.Posts[0].Title}, {blog.Posts[1].Title}");
+            InsertOrUpdateGraph(context, blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
+            Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
+        }
+
+        using (var context = new BloggingContext())
+        {
+            blog.Url = "https://sample.com";
+            blog.Posts[0].Title = "Post A";
+            blog.Posts[1].Title = "Post B";
+            blog.Posts.Add(new Post { Title = "New Post" });
+
+            Console.WriteLine($"  Updating with URL {blog.Url}");
+            InsertOrUpdateGraph(context, blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
+            Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}, {read.Posts[2].Title}");
+        }
+    }
+
+    private static void InsertUpdateOrDeleteGraphFind()
+    {
+        Console.WriteLine();
+        Console.WriteLine("Save graph with deletes and any kind of key:");
+        var blog = CreateBlogAndPosts();
+
+        using (var context = new BloggingContext())
+        {
+            Console.WriteLine($"  Inserting with URL {blog.Url} and {blog.Posts[0].Title}, {blog.Posts[1].Title}");
+            InsertUpdateOrDeleteGraph(context, blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
+            Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
+        }
+
+        using (var context = new BloggingContext())
+        {
+            blog.Url = "https://sample.com";
+            blog.Posts[0].Title = "Post A";
+            blog.Posts.Remove(blog.Posts[1]);
+            blog.Posts.Add(new Post { Title = "New Post" });
+
+            Console.WriteLine($"  Updating with URL {blog.Url}");
+            InsertUpdateOrDeleteGraph(context, blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
+            Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
+        }
+    }
+
+    private static void InsertUpdateOrDeleteTrackGraph()
+    {
+        Console.WriteLine();
+        Console.WriteLine("Save graph using TrackGraph:");
+        var blog = CreateBlogAndPosts();
+        blog.IsNew = true;
+        blog.Posts[0].IsNew = true;
+        blog.Posts[1].IsNew = true;
+
+        using (var context = new BloggingContext())
+        {
+            Console.WriteLine($"  Inserting with URL {blog.Url} and {blog.Posts[0].Title}, {blog.Posts[1].Title}");
+            SaveAnnotatedGraph(context, blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
+            Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
+        }
+
+        blog.IsNew = false;
+        blog.Posts[0].IsNew = false;
+        blog.Posts[1].IsNew = false;
+
+        using (var context = new BloggingContext())
+        {
+            blog.Url = "https://sample.com";
+            blog.IsChanged = true;
+            blog.Posts[0].Title = "Post A";
+            blog.Posts[0].IsDeleted = true;
+            blog.Posts[1].Title = "Post B";
+            blog.Posts.Add(new Post { Title = "New Post", IsNew = true });
+
+            Console.WriteLine($"  Updating with URL {blog.Url}");
+            SaveAnnotatedGraph(context, blog);
+        }
+
+        using (var context = new BloggingContext())
+        {
+            var read = context.Blogs.Include(b => b.Posts).Single(b => b.BlogId == blog.BlogId);
+            Console.WriteLine($"  Found with URL {read.Url} and {read.Posts[0].Title}, {read.Posts[1].Title}");
+        }
+    }
+
+    #region IsItNewSimple
+    public static bool IsItNew(Blog blog)
+        => blog.BlogId == 0;
+    #endregion
+
+    #region IsItNewGeneral
+    public static bool IsItNew(DbContext context, object entity)
+        => !context.Entry(entity).IsKeySet;
+    #endregion
+
+    #region IsItNewQuery
+    public static bool IsItNew(BloggingContext context, Blog blog)
+        => context.Blogs.Find(blog.BlogId) == null;
+    #endregion
+
+    #region InsertAndUpdateSingleEntity
+    public static void Insert(DbContext context, object entity)
+    {
+        context.Add(entity);
+        context.SaveChanges();
+    }
+
+    public static void Update(DbContext context, object entity)
+    {
+        context.Update(entity);
+        context.SaveChanges();
+    }
+    #endregion
+
+    #region InsertOrUpdateSingleEntity
+    public static void InsertOrUpdate(DbContext context, object entity)
+    {
+        context.Update(entity);
+        context.SaveChanges();
+    }
+    #endregion
+
+    #region InsertOrUpdateSingleEntityWithFind
+    public static void InsertOrUpdate(BloggingContext context, Blog blog)
+    {
+        var existingBlog = context.Blogs.Find(blog.BlogId);
+        if (existingBlog == null)
+        {
+            context.Add(blog);
+        }
+        else
+        {
+            context.Entry(existingBlog).CurrentValues.SetValues(blog);
+        }
+
+        context.SaveChanges();
+    }
+    #endregion
+
+    private static Blog CreateBlogAndPosts()
+    {
+        #region CreateBlogAndPosts
+        var blog = new Blog
+        {
+            Url = "http://sample.com", Posts = new List<Post> { new Post { Title = "Post 1" }, new Post { Title = "Post 2" }, }
+        };
+        #endregion
+
+        return blog;
+    }
+
+    #region InsertGraph
+    public static void InsertGraph(DbContext context, object rootEntity)
+    {
+        context.Add(rootEntity);
+        context.SaveChanges();
+    }
+    #endregion
+
+    #region UpdateGraph
+    public static void UpdateGraph(DbContext context, object rootEntity)
+    {
+        context.Update(rootEntity);
+        context.SaveChanges();
+    }
+    #endregion
+
+    #region InsertOrUpdateGraph
+    public static void InsertOrUpdateGraph(DbContext context, object rootEntity)
+    {
+        context.Update(rootEntity);
+        context.SaveChanges();
+    }
+    #endregion
+
+    #region InsertOrUpdateGraphWithFind
+    public static void InsertOrUpdateGraph(BloggingContext context, Blog blog)
+    {
+        var existingBlog = context.Blogs
+            .Include(b => b.Posts)
+            .FirstOrDefault(b => b.BlogId == blog.BlogId);
+
+        if (existingBlog == null)
+        {
+            context.Add(blog);
+        }
+        else
+        {
+            context.Entry(existingBlog).CurrentValues.SetValues(blog);
+            foreach (var post in blog.Posts)
+            {
+                var existingPost = existingBlog.Posts
+                    .FirstOrDefault(p => p.PostId == post.PostId);
+
+                if (existingPost == null)
+                {
+                    existingBlog.Posts.Add(post);
+                }
+                else
+                {
+                    context.Entry(existingPost).CurrentValues.SetValues(post);
+                }
+            }
+        }
+
+        context.SaveChanges();
+    }
+    #endregion
+
+    #region InsertUpdateOrDeleteGraphWithFind
+    public static void InsertUpdateOrDeleteGraph(BloggingContext context, Blog blog)
+    {
+        var existingBlog = context.Blogs
+            .Include(b => b.Posts)
+            .FirstOrDefault(b => b.BlogId == blog.BlogId);
+
+        if (existingBlog == null)
+        {
+            context.Add(blog);
+        }
+        else
+        {
+            context.Entry(existingBlog).CurrentValues.SetValues(blog);
+            foreach (var post in blog.Posts)
+            {
+                var existingPost = existingBlog.Posts
+                    .FirstOrDefault(p => p.PostId == post.PostId);
+
+                if (existingPost == null)
+                {
+                    existingBlog.Posts.Add(post);
+                }
+                else
+                {
+                    context.Entry(existingPost).CurrentValues.SetValues(post);
+                }
+            }
+
+            foreach (var post in existingBlog.Posts)
+            {
+                if (!blog.Posts.Any(p => p.PostId == post.PostId))
+                {
+                    context.Remove(post);
+                }
+            }
+        }
+
+        context.SaveChanges();
+    }
+    #endregion
+
+    #region TrackGraph
+    public static void SaveAnnotatedGraph(DbContext context, object rootEntity)
+    {
+        context.ChangeTracker.TrackGraph(
+            rootEntity,
+            n =>
+            {
+                var entity = (EntityBase)n.Entry.Entity;
+                n.Entry.State = entity.IsNew
+                    ? EntityState.Added
+                    : entity.IsChanged
+                        ? EntityState.Modified
+                        : entity.IsDeleted
+                            ? EntityState.Deleted
+                            : EntityState.Unchanged;
+            });
+
+        context.SaveChanges();
+    }
+    #endregion
 }

--- a/samples/core/Saving/Program.cs
+++ b/samples/core/Saving/Program.cs
@@ -1,21 +1,20 @@
 ﻿using EFSaving.Basics;
 using EFSaving.Transactions;
 
-namespace EFSaving
+namespace EFSaving;
+
+internal class Program
 {
-    internal class Program
+    private static void Main(string[] args)
     {
-        private static void Main(string[] args)
-        {
-            Sample.Run();
-            RelatedData.Sample.Run();
-            CascadeDelete.Sample.Run();
-            Concurrency.Sample.Run();
-            ControllingTransaction.Run();
-            ManagingSavepoints.Run();
-            SharingTransaction.Run();
-            ExternalDbTransaction.Run();
-            Disconnected.Sample.Run();
-        }
+        Sample.Run();
+        RelatedData.Sample.Run();
+        CascadeDelete.Sample.Run();
+        Concurrency.Sample.Run();
+        ControllingTransaction.Run();
+        ManagingSavepoints.Run();
+        SharingTransaction.Run();
+        ExternalDbTransaction.Run();
+        Disconnected.Sample.Run();
     }
 }

--- a/samples/core/Saving/RelatedData/Sample.cs
+++ b/samples/core/Saving/RelatedData/Sample.cs
@@ -2,99 +2,98 @@
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFSaving.RelatedData
+namespace EFSaving.RelatedData;
+
+public class Sample
 {
-    public class Sample
+    public static void Run()
     {
-        public static void Run()
+        using (var context = new BloggingContext())
         {
-            using (var context = new BloggingContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-            }
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+        }
 
-            #region AddingGraphOfEntities
-            using (var context = new BloggingContext())
+        #region AddingGraphOfEntities
+        using (var context = new BloggingContext())
+        {
+            var blog = new Blog
             {
-                var blog = new Blog
+                Url = "http://blogs.msdn.com/dotnet",
+                Posts = new List<Post>
                 {
-                    Url = "http://blogs.msdn.com/dotnet",
-                    Posts = new List<Post>
-                    {
-                        new Post { Title = "Intro to C#" },
-                        new Post { Title = "Intro to VB.NET" },
-                        new Post { Title = "Intro to F#" }
-                    }
-                };
+                    new Post { Title = "Intro to C#" },
+                    new Post { Title = "Intro to VB.NET" },
+                    new Post { Title = "Intro to F#" }
+                }
+            };
 
-                context.Blogs.Add(blog);
-                context.SaveChanges();
-            }
-            #endregion
-
-            #region AddingRelatedEntity
-            using (var context = new BloggingContext())
-            {
-                var blog = context.Blogs.Include(b => b.Posts).First();
-                var post = new Post { Title = "Intro to EF Core" };
-
-                blog.Posts.Add(post);
-                context.SaveChanges();
-            }
-            #endregion
-
-            #region ChangingRelationships
-            using (var context = new BloggingContext())
-            {
-                var blog = new Blog { Url = "http://blogs.msdn.com/visualstudio" };
-                var post = context.Posts.First();
-
-                post.Blog = blog;
-                context.SaveChanges();
-            }
-            #endregion
-
-            #region RemovingRelationships
-            using (var context = new BloggingContext())
-            {
-                var blog = context.Blogs.Include(b => b.Posts).First();
-                var post = blog.Posts.First();
-
-                blog.Posts.Remove(post);
-                context.SaveChanges();
-            }
-            #endregion
+            context.Blogs.Add(blog);
+            context.SaveChanges();
         }
+        #endregion
 
-        public class BloggingContext : DbContext
+        #region AddingRelatedEntity
+        using (var context = new BloggingContext())
         {
-            public DbSet<Blog> Blogs { get; set; }
-            public DbSet<Post> Posts { get; set; }
+            var blog = context.Blogs.Include(b => b.Posts).First();
+            var post = new Post { Title = "Intro to EF Core" };
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            {
-                optionsBuilder.UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.RelatedData;Trusted_Connection=True");
-            }
+            blog.Posts.Add(post);
+            context.SaveChanges();
         }
+        #endregion
 
-        public class Blog
+        #region ChangingRelationships
+        using (var context = new BloggingContext())
         {
-            public int BlogId { get; set; }
-            public string Url { get; set; }
+            var blog = new Blog { Url = "http://blogs.msdn.com/visualstudio" };
+            var post = context.Posts.First();
 
-            public List<Post> Posts { get; set; }
+            post.Blog = blog;
+            context.SaveChanges();
         }
+        #endregion
 
-        public class Post
+        #region RemovingRelationships
+        using (var context = new BloggingContext())
         {
-            public int PostId { get; set; }
-            public string Title { get; set; }
-            public string Content { get; set; }
+            var blog = context.Blogs.Include(b => b.Posts).First();
+            var post = blog.Posts.First();
 
-            public int BlogId { get; set; }
-            public Blog Blog { get; set; }
+            blog.Posts.Remove(post);
+            context.SaveChanges();
         }
+        #endregion
+    }
+
+    public class BloggingContext : DbContext
+    {
+        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Post> Posts { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.RelatedData;Trusted_Connection=True");
+        }
+    }
+
+    public class Blog
+    {
+        public int BlogId { get; set; }
+        public string Url { get; set; }
+
+        public List<Post> Posts { get; set; }
+    }
+
+    public class Post
+    {
+        public int PostId { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+
+        public int BlogId { get; set; }
+        public Blog Blog { get; set; }
     }
 }

--- a/samples/core/Saving/Transactions/CommitableTransaction.cs
+++ b/samples/core/Saving/Transactions/CommitableTransaction.cs
@@ -3,78 +3,77 @@ using System.Transactions;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFSaving.Transactions
+namespace EFSaving.Transactions;
+
+public class CommitableTransaction
 {
-    public class CommitableTransaction
+    public static void Run()
     {
-        public static void Run()
+        var connectionString =
+            @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True";
+
+        using (var context = new BloggingContext(
+                   new DbContextOptionsBuilder<BloggingContext>()
+                       .UseSqlServer(connectionString)
+                       .Options))
         {
-            var connectionString =
-                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True";
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+        }
 
-            using (var context = new BloggingContext(
-                new DbContextOptionsBuilder<BloggingContext>()
-                    .UseSqlServer(connectionString)
-                    .Options))
+        #region Transaction
+        using (var transaction = new CommittableTransaction(
+                   new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted }))
+        {
+            var connection = new SqlConnection(connectionString);
+
+            try
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-            }
+                var options = new DbContextOptionsBuilder<BloggingContext>()
+                    .UseSqlServer(connection)
+                    .Options;
 
-            #region Transaction
-            using (var transaction = new CommittableTransaction(
-                new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted }))
-            {
-                var connection = new SqlConnection(connectionString);
-
-                try
+                using (var context = new BloggingContext(options))
                 {
-                    var options = new DbContextOptionsBuilder<BloggingContext>()
-                        .UseSqlServer(connection)
-                        .Options;
+                    context.Database.OpenConnection();
+                    context.Database.EnlistTransaction(transaction);
 
-                    using (var context = new BloggingContext(options))
-                    {
-                        context.Database.OpenConnection();
-                        context.Database.EnlistTransaction(transaction);
+                    // Run raw ADO.NET command in the transaction
+                    var command = connection.CreateCommand();
+                    command.CommandText = "DELETE FROM dbo.Blogs";
+                    command.ExecuteNonQuery();
 
-                        // Run raw ADO.NET command in the transaction
-                        var command = connection.CreateCommand();
-                        command.CommandText = "DELETE FROM dbo.Blogs";
-                        command.ExecuteNonQuery();
-
-                        // Run an EF Core command in the transaction
-                        context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
-                        context.SaveChanges();
-                        context.Database.CloseConnection();
-                    }
-
-                    // Commit transaction if all commands succeed, transaction will auto-rollback
-                    // when disposed if either commands fails
-                    transaction.Commit();
+                    // Run an EF Core command in the transaction
+                    context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
+                    context.SaveChanges();
+                    context.Database.CloseConnection();
                 }
-                catch (Exception)
-                {
-                    // TODO: Handle failure
-                }
+
+                // Commit transaction if all commands succeed, transaction will auto-rollback
+                // when disposed if either commands fails
+                transaction.Commit();
             }
-            #endregion
-        }
-
-        public class BloggingContext : DbContext
-        {
-            public BloggingContext(DbContextOptions<BloggingContext> options)
-                : base(options)
+            catch (Exception)
             {
+                // TODO: Handle failure
             }
-
-            public DbSet<Blog> Blogs { get; set; }
         }
+        #endregion
+    }
 
-        public class Blog
+    public class BloggingContext : DbContext
+    {
+        public BloggingContext(DbContextOptions<BloggingContext> options)
+            : base(options)
         {
-            public int BlogId { get; set; }
-            public string Url { get; set; }
         }
+
+        public DbSet<Blog> Blogs { get; set; }
+    }
+
+    public class Blog
+    {
+        public int BlogId { get; set; }
+        public string Url { get; set; }
     }
 }

--- a/samples/core/Saving/Transactions/ControllingTransaction.cs
+++ b/samples/core/Saving/Transactions/ControllingTransaction.cs
@@ -2,60 +2,59 @@ using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFSaving.Transactions
+namespace EFSaving.Transactions;
+
+public class ControllingTransaction
 {
-    public class ControllingTransaction
+    public static void Run()
     {
-        public static void Run()
+        using (var setupContext = new BloggingContext())
         {
-            using (var setupContext = new BloggingContext())
-            {
-                setupContext.Database.EnsureDeleted();
-                setupContext.Database.EnsureCreated();
-            }
-
-            #region Transaction
-            using var context = new BloggingContext();
-            using var transaction = context.Database.BeginTransaction();
-
-            try
-            {
-                context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
-                context.SaveChanges();
-
-                context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/visualstudio" });
-                context.SaveChanges();
-
-                var blogs = context.Blogs
-                    .OrderBy(b => b.Url)
-                    .ToList();
-
-                // Commit transaction if all commands succeed, transaction will auto-rollback
-                // when disposed if either commands fails
-                transaction.Commit();
-            }
-            catch (Exception)
-            {
-                // TODO: Handle failure
-            }
-            #endregion
+            setupContext.Database.EnsureDeleted();
+            setupContext.Database.EnsureCreated();
         }
 
-        public class BloggingContext : DbContext
-        {
-            public DbSet<Blog> Blogs { get; set; }
+        #region Transaction
+        using var context = new BloggingContext();
+        using var transaction = context.Database.BeginTransaction();
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            {
-                optionsBuilder.UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True");
-            }
-        }
-
-        public class Blog
+        try
         {
-            public int BlogId { get; set; }
-            public string Url { get; set; }
+            context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
+            context.SaveChanges();
+
+            context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/visualstudio" });
+            context.SaveChanges();
+
+            var blogs = context.Blogs
+                .OrderBy(b => b.Url)
+                .ToList();
+
+            // Commit transaction if all commands succeed, transaction will auto-rollback
+            // when disposed if either commands fails
+            transaction.Commit();
         }
+        catch (Exception)
+        {
+            // TODO: Handle failure
+        }
+        #endregion
+    }
+
+    public class BloggingContext : DbContext
+    {
+        public DbSet<Blog> Blogs { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True");
+        }
+    }
+
+    public class Blog
+    {
+        public int BlogId { get; set; }
+        public string Url { get; set; }
     }
 }

--- a/samples/core/Saving/Transactions/ExternalDbTransaction.cs
+++ b/samples/core/Saving/Transactions/ExternalDbTransaction.cs
@@ -2,74 +2,73 @@ using System;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFSaving.Transactions
+namespace EFSaving.Transactions;
+
+public class ExternalDbTransaction
 {
-    public class ExternalDbTransaction
+    public static void Run()
     {
-        public static void Run()
+        var connectionString =
+            @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True";
+
+        using (var context = new BloggingContext(
+                   new DbContextOptionsBuilder<BloggingContext>()
+                       .UseSqlServer(connectionString)
+                       .Options))
         {
-            var connectionString =
-                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True";
-
-            using (var context = new BloggingContext(
-                new DbContextOptionsBuilder<BloggingContext>()
-                    .UseSqlServer(connectionString)
-                    .Options))
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-            }
-
-            #region Transaction
-            using var connection = new SqlConnection(connectionString);
-            connection.Open();
-
-            using var transaction = connection.BeginTransaction();
-            try
-            {
-                // Run raw ADO.NET command in the transaction
-                var command = connection.CreateCommand();
-                command.Transaction = transaction;
-                command.CommandText = "DELETE FROM dbo.Blogs";
-                command.ExecuteNonQuery();
-
-                // Run an EF Core command in the transaction
-                var options = new DbContextOptionsBuilder<BloggingContext>()
-                    .UseSqlServer(connection)
-                    .Options;
-
-                using (var context = new BloggingContext(options))
-                {
-                    context.Database.UseTransaction(transaction);
-                    context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
-                    context.SaveChanges();
-                }
-
-                // Commit transaction if all commands succeed, transaction will auto-rollback
-                // when disposed if either commands fails
-                transaction.Commit();
-            }
-            catch (Exception)
-            {
-                // TODO: Handle failure
-            }
-            #endregion
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
         }
 
-        public class BloggingContext : DbContext
+        #region Transaction
+        using var connection = new SqlConnection(connectionString);
+        connection.Open();
+
+        using var transaction = connection.BeginTransaction();
+        try
         {
-            public BloggingContext(DbContextOptions<BloggingContext> options)
-                : base(options)
+            // Run raw ADO.NET command in the transaction
+            var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = "DELETE FROM dbo.Blogs";
+            command.ExecuteNonQuery();
+
+            // Run an EF Core command in the transaction
+            var options = new DbContextOptionsBuilder<BloggingContext>()
+                .UseSqlServer(connection)
+                .Options;
+
+            using (var context = new BloggingContext(options))
             {
+                context.Database.UseTransaction(transaction);
+                context.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
+                context.SaveChanges();
             }
 
-            public DbSet<Blog> Blogs { get; set; }
+            // Commit transaction if all commands succeed, transaction will auto-rollback
+            // when disposed if either commands fails
+            transaction.Commit();
+        }
+        catch (Exception)
+        {
+            // TODO: Handle failure
+        }
+        #endregion
+    }
+
+    public class BloggingContext : DbContext
+    {
+        public BloggingContext(DbContextOptions<BloggingContext> options)
+            : base(options)
+        {
         }
 
-        public class Blog
-        {
-            public int BlogId { get; set; }
-            public string Url { get; set; }
-        }
+        public DbSet<Blog> Blogs { get; set; }
+    }
+
+    public class Blog
+    {
+        public int BlogId { get; set; }
+        public string Url { get; set; }
     }
 }

--- a/samples/core/Saving/Transactions/ManagingSavepoints.cs
+++ b/samples/core/Saving/Transactions/ManagingSavepoints.cs
@@ -1,60 +1,59 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 
-namespace EFSaving.Transactions
+namespace EFSaving.Transactions;
+
+public class ManagingSavepoints
 {
-    public class ManagingSavepoints
+    public static void Run()
     {
-        public static void Run()
+        using (var setupContext = new BloggingContext())
         {
-            using (var setupContext = new BloggingContext())
-            {
-                setupContext.Database.EnsureDeleted();
-                setupContext.Database.EnsureCreated();
-            }
-
-            #region Savepoints
-            using var context = new BloggingContext();
-            using var transaction = context.Database.BeginTransaction();
-
-            try
-            {
-                context.Blogs.Add(new Blog { Url = "https://devblogs.microsoft.com/dotnet/" });
-                context.SaveChanges();
-
-                transaction.CreateSavepoint("BeforeMoreBlogs");
-
-                context.Blogs.Add(new Blog { Url = "https://devblogs.microsoft.com/visualstudio/" });
-                context.Blogs.Add(new Blog { Url = "https://devblogs.microsoft.com/aspnet/" });
-                context.SaveChanges();
-
-                transaction.Commit();
-            }
-            catch (Exception)
-            {
-                // If a failure occurred, we rollback to the savepoint and can continue the transaction
-                transaction.RollbackToSavepoint("BeforeMoreBlogs");
-
-                // TODO: Handle failure, possibly retry inserting blogs
-            }
-            #endregion
+            setupContext.Database.EnsureDeleted();
+            setupContext.Database.EnsureCreated();
         }
 
-        public class BloggingContext : DbContext
-        {
-            public DbSet<Blog> Blogs { get; set; }
+        #region Savepoints
+        using var context = new BloggingContext();
+        using var transaction = context.Database.BeginTransaction();
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            {
-                optionsBuilder.UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True");
-            }
-        }
-
-        public class Blog
+        try
         {
-            public int BlogId { get; set; }
-            public string Url { get; set; }
+            context.Blogs.Add(new Blog { Url = "https://devblogs.microsoft.com/dotnet/" });
+            context.SaveChanges();
+
+            transaction.CreateSavepoint("BeforeMoreBlogs");
+
+            context.Blogs.Add(new Blog { Url = "https://devblogs.microsoft.com/visualstudio/" });
+            context.Blogs.Add(new Blog { Url = "https://devblogs.microsoft.com/aspnet/" });
+            context.SaveChanges();
+
+            transaction.Commit();
         }
+        catch (Exception)
+        {
+            // If a failure occurred, we rollback to the savepoint and can continue the transaction
+            transaction.RollbackToSavepoint("BeforeMoreBlogs");
+
+            // TODO: Handle failure, possibly retry inserting blogs
+        }
+        #endregion
+    }
+
+    public class BloggingContext : DbContext
+    {
+        public DbSet<Blog> Blogs { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True");
+        }
+    }
+
+    public class Blog
+    {
+        public int BlogId { get; set; }
+        public string Url { get; set; }
     }
 }

--- a/samples/core/Saving/Transactions/SharingTransaction.cs
+++ b/samples/core/Saving/Transactions/SharingTransaction.cs
@@ -4,73 +4,72 @@ using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 
-namespace EFSaving.Transactions
+namespace EFSaving.Transactions;
+
+public class SharingTransaction
 {
-    public class SharingTransaction
+    public static void Run()
     {
-        public static void Run()
+        var connectionString =
+            @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True";
+
+        using (var context = new BloggingContext(
+                   new DbContextOptionsBuilder<BloggingContext>()
+                       .UseSqlServer(connectionString)
+                       .Options))
         {
-            var connectionString =
-                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Transactions;Trusted_Connection=True";
-
-            using (var context = new BloggingContext(
-                new DbContextOptionsBuilder<BloggingContext>()
-                    .UseSqlServer(connectionString)
-                    .Options))
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-            }
-
-            #region Transaction
-            using var connection = new SqlConnection(connectionString);
-            var options = new DbContextOptionsBuilder<BloggingContext>()
-                .UseSqlServer(connection)
-                .Options;
-
-            using var context1 = new BloggingContext(options);
-            using var transaction = context1.Database.BeginTransaction();
-            try
-            {
-                context1.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
-                context1.SaveChanges();
-
-                using (var context2 = new BloggingContext(options))
-                {
-                    context2.Database.UseTransaction(transaction.GetDbTransaction());
-
-                    var blogs = context2.Blogs
-                        .OrderBy(b => b.Url)
-                        .ToList();
-                }
-
-                // Commit transaction if all commands succeed, transaction will auto-rollback
-                // when disposed if either commands fails
-                transaction.Commit();
-            }
-            catch (Exception)
-            {
-                // TODO: Handle failure
-            }
-            #endregion
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
         }
 
-        #region Context
-        public class BloggingContext : DbContext
+        #region Transaction
+        using var connection = new SqlConnection(connectionString);
+        var options = new DbContextOptionsBuilder<BloggingContext>()
+            .UseSqlServer(connection)
+            .Options;
+
+        using var context1 = new BloggingContext(options);
+        using var transaction = context1.Database.BeginTransaction();
+        try
         {
-            public BloggingContext(DbContextOptions<BloggingContext> options)
-                : base(options)
+            context1.Blogs.Add(new Blog { Url = "http://blogs.msdn.com/dotnet" });
+            context1.SaveChanges();
+
+            using (var context2 = new BloggingContext(options))
             {
+                context2.Database.UseTransaction(transaction.GetDbTransaction());
+
+                var blogs = context2.Blogs
+                    .OrderBy(b => b.Url)
+                    .ToList();
             }
 
-            public DbSet<Blog> Blogs { get; set; }
+            // Commit transaction if all commands succeed, transaction will auto-rollback
+            // when disposed if either commands fails
+            transaction.Commit();
+        }
+        catch (Exception)
+        {
+            // TODO: Handle failure
         }
         #endregion
+    }
 
-        public class Blog
+    #region Context
+    public class BloggingContext : DbContext
+    {
+        public BloggingContext(DbContextOptions<BloggingContext> options)
+            : base(options)
         {
-            public int BlogId { get; set; }
-            public string Url { get; set; }
         }
+
+        public DbSet<Blog> Blogs { get; set; }
+    }
+    #endregion
+
+    public class Blog
+    {
+        public int BlogId { get; set; }
+        public string Url { get; set; }
     }
 }

--- a/samples/core/Schemas/Migrations/MigrationTableNameContext.cs
+++ b/samples/core/Schemas/Migrations/MigrationTableNameContext.cs
@@ -1,16 +1,15 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace Migrations
-{
-    public class MigrationTableNameContext : DbContext
-    {
-        private readonly string _connectionString = @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=Sample";
+namespace Migrations;
 
-        #region TableNameContext
-        protected override void OnConfiguring(DbContextOptionsBuilder options)
-            => options.UseSqlServer(
-                _connectionString,
-                x => x.MigrationsHistoryTable("__MyMigrationsHistory", "mySchema"));
-        #endregion
-    }
+public class MigrationTableNameContext : DbContext
+{
+    private readonly string _connectionString = @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=Sample";
+
+    #region TableNameContext
+    protected override void OnConfiguring(DbContextOptionsBuilder options)
+        => options.UseSqlServer(
+            _connectionString,
+            x => x.MigrationsHistoryTable("__MyMigrationsHistory", "mySchema"));
+    #endregion
 }

--- a/samples/core/Schemas/Migrations/MyHistoryRepository.cs
+++ b/samples/core/Schemas/Migrations/MyHistoryRepository.cs
@@ -5,34 +5,33 @@ using Microsoft.EntityFrameworkCore.SqlServer.Migrations.Internal;
 
 #pragma warning disable EF1001
 
-namespace Migrations
+namespace Migrations;
+
+public class MyHistoryRepositoryContext : DbContext
 {
-    public class MyHistoryRepositoryContext : DbContext
-    {
-        private readonly string _connectionString = @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=Sample";
+    private readonly string _connectionString = @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=Sample";
 
-        #region HistoryRepositoryContext
-        protected override void OnConfiguring(DbContextOptionsBuilder options)
-            => options
-                .UseSqlServer(_connectionString)
-                .ReplaceService<IHistoryRepository, MyHistoryRepository>();
-        #endregion
-    }
-
-    #region HistoryRepository
-    internal class MyHistoryRepository : SqlServerHistoryRepository
-    {
-        public MyHistoryRepository(HistoryRepositoryDependencies dependencies)
-            : base(dependencies)
-        {
-        }
-
-        protected override void ConfigureTable(EntityTypeBuilder<HistoryRow> history)
-        {
-            base.ConfigureTable(history);
-
-            history.Property(h => h.MigrationId).HasColumnName("Id");
-        }
-    }
+    #region HistoryRepositoryContext
+    protected override void OnConfiguring(DbContextOptionsBuilder options)
+        => options
+            .UseSqlServer(_connectionString)
+            .ReplaceService<IHistoryRepository, MyHistoryRepository>();
     #endregion
 }
+
+#region HistoryRepository
+internal class MyHistoryRepository : SqlServerHistoryRepository
+{
+    public MyHistoryRepository(HistoryRepositoryDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    protected override void ConfigureTable(EntityTypeBuilder<HistoryRow> history)
+    {
+        base.ConfigureTable(history);
+
+        history.Property(h => h.MigrationId).HasColumnName("Id");
+    }
+}
+#endregion

--- a/samples/core/Schemas/ThreeProjectMigrations/WebApplication1.Data/ApplicationDbContext.cs
+++ b/samples/core/Schemas/ThreeProjectMigrations/WebApplication1.Data/ApplicationDbContext.cs
@@ -1,13 +1,12 @@
 ﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
-namespace WebApplication1.Data
+namespace WebApplication1.Data;
+
+public class ApplicationDbContext : IdentityDbContext
 {
-    public class ApplicationDbContext : IdentityDbContext
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
     {
-        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
-            : base(options)
-        {
-        }
     }
 }

--- a/samples/core/Schemas/ThreeProjectMigrations/WebApplication1/Pages/Error.cshtml.cs
+++ b/samples/core/Schemas/ThreeProjectMigrations/WebApplication1/Pages/Error.cshtml.cs
@@ -3,25 +3,24 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 
-namespace WebApplication1.Pages
+namespace WebApplication1.Pages;
+
+[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+public class ErrorModel : PageModel
 {
-    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
-    public class ErrorModel : PageModel
+    public string RequestId { get; set; }
+
+    public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+    private readonly ILogger<ErrorModel> _logger;
+
+    public ErrorModel(ILogger<ErrorModel> logger)
     {
-        public string RequestId { get; set; }
+        _logger = logger;
+    }
 
-        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
-
-        private readonly ILogger<ErrorModel> _logger;
-
-        public ErrorModel(ILogger<ErrorModel> logger)
-        {
-            _logger = logger;
-        }
-
-        public void OnGet()
-        {
-            RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
-        }
+    public void OnGet()
+    {
+        RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
     }
 }

--- a/samples/core/Schemas/ThreeProjectMigrations/WebApplication1/Pages/Index.cshtml.cs
+++ b/samples/core/Schemas/ThreeProjectMigrations/WebApplication1/Pages/Index.cshtml.cs
@@ -1,19 +1,18 @@
 ﻿using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 
-namespace WebApplication1.Pages
+namespace WebApplication1.Pages;
+
+public class IndexModel : PageModel
 {
-    public class IndexModel : PageModel
+    private readonly ILogger<IndexModel> _logger;
+
+    public IndexModel(ILogger<IndexModel> logger)
     {
-        private readonly ILogger<IndexModel> _logger;
+        _logger = logger;
+    }
 
-        public IndexModel(ILogger<IndexModel> logger)
-        {
-            _logger = logger;
-        }
-
-        public void OnGet()
-        {
-        }
+    public void OnGet()
+    {
     }
 }

--- a/samples/core/Schemas/ThreeProjectMigrations/WebApplication1/Pages/Privacy.cshtml.cs
+++ b/samples/core/Schemas/ThreeProjectMigrations/WebApplication1/Pages/Privacy.cshtml.cs
@@ -1,19 +1,18 @@
 ﻿using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 
-namespace WebApplication1.Pages
+namespace WebApplication1.Pages;
+
+public class PrivacyModel : PageModel
 {
-    public class PrivacyModel : PageModel
+    private readonly ILogger<PrivacyModel> _logger;
+
+    public PrivacyModel(ILogger<PrivacyModel> logger)
     {
-        private readonly ILogger<PrivacyModel> _logger;
+        _logger = logger;
+    }
 
-        public PrivacyModel(ILogger<PrivacyModel> logger)
-        {
-            _logger = logger;
-        }
-
-        public void OnGet()
-        {
-        }
+    public void OnGet()
+    {
     }
 }

--- a/samples/core/Schemas/ThreeProjectMigrations/WebApplication1/Program.cs
+++ b/samples/core/Schemas/ThreeProjectMigrations/WebApplication1/Program.cs
@@ -1,17 +1,16 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
-namespace WebApplication1
-{
-    public class Program
-    {
-        public static void Main(string[] args)
-        {
-            CreateHostBuilder(args).Build().Run();
-        }
+namespace WebApplication1;
 
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        CreateHostBuilder(args).Build().Run();
     }
+
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
 }

--- a/samples/core/Schemas/ThreeProjectMigrations/WebApplication1/Startup.cs
+++ b/samples/core/Schemas/ThreeProjectMigrations/WebApplication1/Startup.cs
@@ -7,57 +7,56 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using WebApplication1.Data;
 
-namespace WebApplication1
+namespace WebApplication1;
+
+public class Startup
 {
-    public class Startup
+    public Startup(IConfiguration configuration)
     {
-        public Startup(IConfiguration configuration)
+        Configuration = configuration;
+    }
+
+    public IConfiguration Configuration { get; }
+
+    // This method gets called by the runtime. Use this method to add services to the container.
+    public void ConfigureServices(IServiceCollection services)
+    {
+        #region snippet_MigrationsAssembly
+        services.AddDbContext<ApplicationDbContext>(
+            options =>
+                options.UseSqlServer(
+                    Configuration.GetConnectionString("DefaultConnection"),
+                    x => x.MigrationsAssembly("WebApplication1.Migrations")));
+        #endregion
+        services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
+            .AddEntityFrameworkStores<ApplicationDbContext>();
+        services.AddRazorPages();
+        services.AddDatabaseDeveloperPageExceptionFilter();
+    }
+
+    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        if (env.IsDevelopment())
         {
-            Configuration = configuration;
+            app.UseDeveloperExceptionPage();
+            app.UseMigrationsEndPoint();
+        }
+        else
+        {
+            app.UseExceptionHandler("/Error");
+            // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+            app.UseHsts();
         }
 
-        public IConfiguration Configuration { get; }
+        app.UseHttpsRedirection();
+        app.UseStaticFiles();
 
-        // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services)
-        {
-            #region snippet_MigrationsAssembly
-            services.AddDbContext<ApplicationDbContext>(
-                options =>
-                    options.UseSqlServer(
-                        Configuration.GetConnectionString("DefaultConnection"),
-                        x => x.MigrationsAssembly("WebApplication1.Migrations")));
-            #endregion
-            services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
-                .AddEntityFrameworkStores<ApplicationDbContext>();
-            services.AddRazorPages();
-            services.AddDatabaseDeveloperPageExceptionFilter();
-        }
+        app.UseRouting();
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-        {
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-                app.UseMigrationsEndPoint();
-            }
-            else
-            {
-                app.UseExceptionHandler("/Error");
-                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-                app.UseHsts();
-            }
+        app.UseAuthentication();
+        app.UseAuthorization();
 
-            app.UseHttpsRedirection();
-            app.UseStaticFiles();
-
-            app.UseRouting();
-
-            app.UseAuthentication();
-            app.UseAuthorization();
-
-            app.UseEndpoints(endpoints => { endpoints.MapRazorPages(); });
-        }
+        app.UseEndpoints(endpoints => { endpoints.MapRazorPages(); });
     }
 }

--- a/samples/core/Schemas/TwoProjectMigrations/WorkerService1/Model.cs
+++ b/samples/core/Schemas/TwoProjectMigrations/WorkerService1/Model.cs
@@ -2,65 +2,64 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
-namespace WorkerService1
+namespace WorkerService1;
+
+public class Blog
 {
-    public class Blog
+    public int Id { get; set; }
+
+    public Uri Source { get; set; }
+    public string Title { get; set; }
+
+    public ICollection<Post> Posts { get; } = new HashSet<Post>();
+}
+
+public class Person
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; }
+    public string Email { get; set; }
+
+    public ICollection<Post> AuthoredPosts { get; } = new HashSet<Post>();
+}
+
+public class Post
+{
+    public int Id { get; set; }
+
+    public int BlogId { get; set; }
+    public Blog Blog { get; set; }
+
+    public string Title { get; set; }
+    public string Content { get; set; }
+
+    public int AuthorId { get; set; }
+    public Person Author { get; set; }
+}
+
+public class MediaPost : Post
+{
+    public Uri MediaUrl { get; set; }
+    public string MediaType { get; set; }
+}
+
+public class BlogContext : DbContext
+{
+    public BlogContext(DbContextOptions<BlogContext> options)
+        : base(options)
     {
-        public int Id { get; set; }
-
-        public Uri Source { get; set; }
-        public string Title { get; set; }
-
-        public ICollection<Post> Posts { get; } = new HashSet<Post>();
     }
 
-    public class Person
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Person> People { get; set; }
+    public DbSet<Post> Posts { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        public int Id { get; set; }
+        modelBuilder.Entity<Person>()
+            .HasIndex(p => p.Email).IsUnique();
 
-        public string Name { get; set; }
-        public string Email { get; set; }
-
-        public ICollection<Post> AuthoredPosts { get; } = new HashSet<Post>();
-    }
-
-    public class Post
-    {
-        public int Id { get; set; }
-
-        public int BlogId { get; set; }
-        public Blog Blog { get; set; }
-
-        public string Title { get; set; }
-        public string Content { get; set; }
-
-        public int AuthorId { get; set; }
-        public Person Author { get; set; }
-    }
-
-    public class MediaPost : Post
-    {
-        public Uri MediaUrl { get; set; }
-        public string MediaType { get; set; }
-    }
-
-    public class BlogContext : DbContext
-    {
-        public BlogContext(DbContextOptions<BlogContext> options)
-            : base(options)
-        {
-        }
-
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Person> People { get; set; }
-        public DbSet<Post> Posts { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Person>()
-                .HasIndex(p => p.Email).IsUnique();
-
-            modelBuilder.Entity<MediaPost>();
-        }
+        modelBuilder.Entity<MediaPost>();
     }
 }

--- a/samples/core/Schemas/TwoProjectMigrations/WorkerService1/Program.cs
+++ b/samples/core/Schemas/TwoProjectMigrations/WorkerService1/Program.cs
@@ -4,39 +4,38 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace WorkerService1
+namespace WorkerService1;
+
+internal class Program
 {
-    internal class Program
-    {
-        private static void Main(string[] args)
-            => CreateHostBuilder(args).Build().Run();
+    private static void Main(string[] args)
+        => CreateHostBuilder(args).Build().Run();
 
-        #region snippet_CreateHostBuilder
-        public static IHostBuilder CreateHostBuilder(string[] args)
-            => Host.CreateDefaultBuilder(args)
-                .ConfigureServices(
-                    (hostContext, services) =>
-                    {
-                        services.AddHostedService<Worker>();
+    #region snippet_CreateHostBuilder
+    public static IHostBuilder CreateHostBuilder(string[] args)
+        => Host.CreateDefaultBuilder(args)
+            .ConfigureServices(
+                (hostContext, services) =>
+                {
+                    services.AddHostedService<Worker>();
 
-                        // Set the active provider via configuration
-                        var configuration = hostContext.Configuration;
-                        var provider = configuration.GetValue("Provider", "SqlServer");
+                    // Set the active provider via configuration
+                    var configuration = hostContext.Configuration;
+                    var provider = configuration.GetValue("Provider", "SqlServer");
 
-                        services.AddDbContext<BlogContext>(
-                            options => _ = provider switch
-                            {
-                                "Sqlite" => options.UseSqlite(
-                                    configuration.GetConnectionString("SqliteConnection"),
-                                    x => x.MigrationsAssembly("SqliteMigrations")),
+                    services.AddDbContext<BlogContext>(
+                        options => _ = provider switch
+                        {
+                            "Sqlite" => options.UseSqlite(
+                                configuration.GetConnectionString("SqliteConnection"),
+                                x => x.MigrationsAssembly("SqliteMigrations")),
 
-                                "SqlServer" => options.UseSqlServer(
-                                    configuration.GetConnectionString("SqlServerConnection"),
-                                    x => x.MigrationsAssembly("SqlServerMigrations")),
+                            "SqlServer" => options.UseSqlServer(
+                                configuration.GetConnectionString("SqlServerConnection"),
+                                x => x.MigrationsAssembly("SqlServerMigrations")),
 
-                                _ => throw new Exception($"Unsupported provider: {provider}")
-                            });
-                    });
-        #endregion
-    }
+                            _ => throw new Exception($"Unsupported provider: {provider}")
+                        });
+                });
+    #endregion
 }

--- a/samples/core/Schemas/TwoProjectMigrations/WorkerService1/Worker.cs
+++ b/samples/core/Schemas/TwoProjectMigrations/WorkerService1/Worker.cs
@@ -4,46 +4,45 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace WorkerService1
+namespace WorkerService1;
+
+internal class Worker : IHostedService, IDisposable
 {
-    internal class Worker : IHostedService, IDisposable
+    private readonly IServiceProvider _services;
+
+    private Timer _timer;
+
+    public Worker(IServiceProvider services)
+        => _services = services;
+
+    public Task StartAsync(CancellationToken stoppingToken)
     {
-        private readonly IServiceProvider _services;
+        _timer = new Timer(
+            state => Execute(),
+            state: null,
+            dueTime: TimeSpan.Zero,
+            period: TimeSpan.FromDays(1));
 
-        private Timer _timer;
-
-        public Worker(IServiceProvider services)
-            => _services = services;
-
-        public Task StartAsync(CancellationToken stoppingToken)
-        {
-            _timer = new Timer(
-                state => Execute(),
-                state: null,
-                dueTime: TimeSpan.Zero,
-                period: TimeSpan.FromDays(1));
-
-            return Task.CompletedTask;
-        }
-
-        private void Execute()
-        {
-            using var scope = _services.CreateScope();
-            var services = scope.ServiceProvider;
-
-            var db = services.GetService<BlogContext>();
-
-            // TODO: Something interesting
-        }
-
-        public Task StopAsync(CancellationToken stoppingToken)
-        {
-            _timer?.Change(Timeout.Infinite, 0);
-
-            return Task.CompletedTask;
-        }
-
-        public void Dispose()
-            => _timer?.Dispose();
+        return Task.CompletedTask;
     }
+
+    private void Execute()
+    {
+        using var scope = _services.CreateScope();
+        var services = scope.ServiceProvider;
+
+        var db = services.GetService<BlogContext>();
+
+        // TODO: Something interesting
+    }
+
+    public Task StopAsync(CancellationToken stoppingToken)
+    {
+        _timer?.Change(Timeout.Infinite, 0);
+
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+        => _timer?.Dispose();
 }

--- a/samples/core/Spatial/SqlServer/Models/City.cs
+++ b/samples/core/Spatial/SqlServer/Models/City.cs
@@ -1,17 +1,16 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using NetTopologySuite.Geometries;
 
-namespace SqlServer.Models
+namespace SqlServer.Models;
+
+#region snippet_City
+[Table("Cities", Schema = "Application")]
+public class City
 {
-    #region snippet_City
-    [Table("Cities", Schema = "Application")]
-    public class City
-    {
-        public int CityID { get; set; }
+    public int CityID { get; set; }
 
-        public string CityName { get; set; }
+    public string CityName { get; set; }
 
-        public Point Location { get; set; }
-    }
-    #endregion
+    public Point Location { get; set; }
 }
+#endregion

--- a/samples/core/Spatial/SqlServer/Models/Country.cs
+++ b/samples/core/Spatial/SqlServer/Models/Country.cs
@@ -1,18 +1,17 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using NetTopologySuite.Geometries;
 
-namespace SqlServer.Models
+namespace SqlServer.Models;
+
+#region snippet_Country
+[Table("Countries", Schema = "Application")]
+public class Country
 {
-    #region snippet_Country
-    [Table("Countries", Schema = "Application")]
-    public class Country
-    {
-        public int CountryID { get; set; }
+    public int CountryID { get; set; }
 
-        public string CountryName { get; set; }
+    public string CountryName { get; set; }
 
-        // Database includes both Polygon and MultiPolygon values
-        public Geometry Border { get; set; }
-    }
-    #endregion
+    // Database includes both Polygon and MultiPolygon values
+    public Geometry Border { get; set; }
 }
+#endregion

--- a/samples/core/Spatial/SqlServer/Models/StateProvince.cs
+++ b/samples/core/Spatial/SqlServer/Models/StateProvince.cs
@@ -1,15 +1,14 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using NetTopologySuite.Geometries;
 
-namespace SqlServer.Models
+namespace SqlServer.Models;
+
+[Table("StateProvinces", Schema = "Application")]
+internal class StateProvince
 {
-    [Table("StateProvinces", Schema = "Application")]
-    internal class StateProvince
-    {
-        public int StateProvinceID { get; set; }
+    public int StateProvinceID { get; set; }
 
-        public string StateProvinceName { get; set; }
+    public string StateProvinceName { get; set; }
 
-        public Geometry Border { get; set; }
-    }
+    public Geometry Border { get; set; }
 }

--- a/samples/core/Spatial/SqlServer/Models/WideWorldImportersContext.cs
+++ b/samples/core/Spatial/SqlServer/Models/WideWorldImportersContext.cs
@@ -1,20 +1,19 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace SqlServer.Models
-{
-    // This DbContext maps to the Wide World Importers sample database which can be
-    // found at https://github.com/microsoft/sql-server-samples
-    internal class WideWorldImportersContext : DbContext
-    {
-        public DbSet<City> Cities { get; set; }
-        public DbSet<StateProvince> StateProvinces { get; set; }
-        public DbSet<Country> Countries { get; set; }
+namespace SqlServer.Models;
 
-        protected override void OnConfiguring(DbContextOptionsBuilder options) =>
-            #region snippet_UseNetTopologySuite
-            options.UseSqlServer(
-                @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=WideWorldImporters",
-                x => x.UseNetTopologySuite());
-        #endregion
-    }
+// This DbContext maps to the Wide World Importers sample database which can be
+// found at https://github.com/microsoft/sql-server-samples
+internal class WideWorldImportersContext : DbContext
+{
+    public DbSet<City> Cities { get; set; }
+    public DbSet<StateProvince> StateProvinces { get; set; }
+    public DbSet<Country> Countries { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder options) =>
+        #region snippet_UseNetTopologySuite
+        options.UseSqlServer(
+            @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=WideWorldImporters",
+            x => x.UseNetTopologySuite());
+    #endregion
 }

--- a/samples/core/SqlServer/AzureDatabase/AzureSqlContext.cs
+++ b/samples/core/SqlServer/AzureDatabase/AzureSqlContext.cs
@@ -1,34 +1,33 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace SqlServer.AzureDatabase
+namespace SqlServer.AzureDatabase;
+
+public class AzureSqlContext : DbContext
 {
-    public class AzureSqlContext : DbContext
+    public DbSet<Blog> Blogs { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        public DbSet<Blog> Blogs { get; set; }
+        optionsBuilder.UseSqlServer(
+            "Server=tcp:[serverName].database.windows.net;Database=myDataBase;User ID=[Login]@[serverName];Password=myPassword];Trusted_Connection=False;Encrypt=True;");
+    }
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(
-                "Server=tcp:[serverName].database.windows.net;Database=myDataBase;User ID=[Login]@[serverName];Password=myPassword];Trusted_Connection=False;Encrypt=True;");
-        }
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        #region HasServiceTier
+        modelBuilder.HasServiceTier("BusinessCritical");
+        #endregion
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            #region HasServiceTier
-            modelBuilder.HasServiceTier("BusinessCritical");
-            #endregion
+        #region HasDatabaseMaxSize
+        modelBuilder.HasDatabaseMaxSize("2 GB");
+        #endregion
 
-            #region HasDatabaseMaxSize
-            modelBuilder.HasDatabaseMaxSize("2 GB");
-            #endregion
+        #region HasPerformanceLevelSql
+        modelBuilder.HasPerformanceLevelSql("ELASTIC_POOL ( name = myelasticpool )");
+        #endregion
 
-            #region HasPerformanceLevelSql
-            modelBuilder.HasPerformanceLevelSql("ELASTIC_POOL ( name = myelasticpool )");
-            #endregion
-
-            #region HasPerformanceLevel
-            modelBuilder.HasPerformanceLevel("BC_Gen4_1");
-            #endregion
-        }
+        #region HasPerformanceLevel
+        modelBuilder.HasPerformanceLevel("BC_Gen4_1");
+        #endregion
     }
 }

--- a/samples/core/SqlServer/AzureDatabase/Blog.cs
+++ b/samples/core/SqlServer/AzureDatabase/Blog.cs
@@ -1,8 +1,7 @@
-﻿namespace SqlServer.AzureDatabase
+﻿namespace SqlServer.AzureDatabase;
+
+public class Blog
 {
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-    }
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/SqlServer/Columns/Blog.cs
+++ b/samples/core/SqlServer/Columns/Blog.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 
-namespace SqlServer.Columns
+namespace SqlServer.Columns;
+
+public class Blog
 {
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public DateTime PublishedOn { get; set; }
-    }
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public DateTime PublishedOn { get; set; }
 }

--- a/samples/core/SqlServer/Columns/RareBlog.cs
+++ b/samples/core/SqlServer/Columns/RareBlog.cs
@@ -1,7 +1,6 @@
-namespace SqlServer.Columns
+namespace SqlServer.Columns;
+
+public class RareBlog : Blog
 {
-    public class RareBlog : Blog
-    {
-        public string RareProperty { get; set; }
-    }
+    public string RareProperty { get; set; }
 }

--- a/samples/core/SqlServer/Columns/SparseColumnContext.cs
+++ b/samples/core/SqlServer/Columns/SparseColumnContext.cs
@@ -1,19 +1,18 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace SqlServer.Columns
-{
-    public class SparseColumnContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<RareBlog> RareBlogs { get; set; }
+namespace SqlServer.Columns;
 
-        #region SparseColumn
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<RareBlog>()
-                .Property(b => b.RareProperty)
-                .IsSparse();
-        }
-        #endregion
+public class SparseColumnContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<RareBlog> RareBlogs { get; set; }
+
+    #region SparseColumn
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<RareBlog>()
+            .Property(b => b.RareProperty)
+            .IsSparse();
     }
+    #endregion
 }

--- a/samples/core/SqlServer/InMemory/Blog.cs
+++ b/samples/core/SqlServer/InMemory/Blog.cs
@@ -1,8 +1,7 @@
-﻿namespace SqlServer.InMemory
+﻿namespace SqlServer.InMemory;
+
+public class Blog
 {
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-    }
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/SqlServer/InMemory/InMemoryContext.cs
+++ b/samples/core/SqlServer/InMemory/InMemoryContext.cs
@@ -1,16 +1,15 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace SqlServer.InMemory
-{
-    public class InMemoryContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+namespace SqlServer.InMemory;
 
-        #region IsMemoryOptimized
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>().IsMemoryOptimized();
-        }
-        #endregion
+public class InMemoryContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
+
+    #region IsMemoryOptimized
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Blog>().IsMemoryOptimized();
     }
+    #endregion
 }

--- a/samples/core/SqlServer/InMemory/Sample.cs
+++ b/samples/core/SqlServer/InMemory/Sample.cs
@@ -1,6 +1,5 @@
-﻿namespace SqlServer.InMemory
+﻿namespace SqlServer.InMemory;
+
+public class Sample
 {
-    public class Sample
-    {
-    }
 }

--- a/samples/core/SqlServer/Indexes/Blog.cs
+++ b/samples/core/SqlServer/Indexes/Blog.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 
-namespace SqlServer.Indexes
+namespace SqlServer.Indexes;
+
+public class Blog
 {
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-        public DateTime PublishedOn { get; set; }
-    }
+    public int BlogId { get; set; }
+    public string Url { get; set; }
+    public DateTime PublishedOn { get; set; }
 }

--- a/samples/core/SqlServer/Indexes/ClusteredIndexContext.cs
+++ b/samples/core/SqlServer/Indexes/ClusteredIndexContext.cs
@@ -1,16 +1,15 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace SqlServer.Indexes
-{
-    public class ClusteredIndexContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+namespace SqlServer.Indexes;
 
-        #region ClusteredIndex
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>().HasIndex(b => b.PublishedOn).IsClustered();
-        }
-        #endregion
+public class ClusteredIndexContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
+
+    #region ClusteredIndex
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Blog>().HasIndex(b => b.PublishedOn).IsClustered();
     }
+    #endregion
 }

--- a/samples/core/SqlServer/Indexes/IndexFillFactorContext.cs
+++ b/samples/core/SqlServer/Indexes/IndexFillFactorContext.cs
@@ -1,16 +1,15 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace SqlServer.Indexes
-{
-    public class IndexFillFactorContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+namespace SqlServer.Indexes;
 
-        #region IndexFillFactor
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>().HasIndex(b => b.PublishedOn).HasFillFactor(10);
-        }
-        #endregion
+public class IndexFillFactorContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
+
+    #region IndexFillFactor
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Blog>().HasIndex(b => b.PublishedOn).HasFillFactor(10);
     }
+    #endregion
 }

--- a/samples/core/SqlServer/Indexes/IndexOnlineContext.cs
+++ b/samples/core/SqlServer/Indexes/IndexOnlineContext.cs
@@ -1,16 +1,15 @@
 ﻿using Microsoft.EntityFrameworkCore;
 
-namespace SqlServer.Indexes
-{
-    public class IndexOnlineContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+namespace SqlServer.Indexes;
 
-        #region IndexOnline
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>().HasIndex(b => b.PublishedOn).IsCreatedOnline();
-        }
-        #endregion
+public class IndexOnlineContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
+
+    #region IndexOnline
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Blog>().HasIndex(b => b.PublishedOn).IsCreatedOnline();
     }
+    #endregion
 }

--- a/samples/core/SqlServer/Program.cs
+++ b/samples/core/SqlServer/Program.cs
@@ -1,9 +1,8 @@
-﻿namespace SqlServer
+﻿namespace SqlServer;
+
+public class Program
 {
-    public class Program
+    private static void Main()
     {
-        private static void Main()
-        {
-        }
     }
 }

--- a/samples/core/SqlServer/ValueGeneration/Blog.cs
+++ b/samples/core/SqlServer/ValueGeneration/Blog.cs
@@ -1,8 +1,7 @@
-﻿namespace SqlServer.ValueGeneration
+﻿namespace SqlServer.ValueGeneration;
+
+public class Blog
 {
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Url { get; set; }
-    }
+    public int BlogId { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/SqlServer/ValueGeneration/ExplicitIdentityValues.cs
+++ b/samples/core/SqlServer/ValueGeneration/ExplicitIdentityValues.cs
@@ -1,45 +1,44 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace SqlServer.ValueGeneration
+namespace SqlServer.ValueGeneration;
+
+public class ExplicitIdentityValuesContext : DbContext
 {
-    public class ExplicitIdentityValuesContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; set; }
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.UseSqlServer(
-                @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Basics;Trusted_Connection=True");
-    }
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseSqlServer(
+            @"Server=(localdb)\mssqllocaldb;Database=EFSaving.Basics;Trusted_Connection=True");
+}
 
-    public class ExplicitIdentityValues
+public class ExplicitIdentityValues
+{
+    public static void Run()
     {
-        public static void Run()
+        using (var context = new ExplicitIdentityValuesContext())
         {
-            using (var context = new ExplicitIdentityValuesContext())
-            {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
-            }
-
-            #region ExplicitIdentityValues
-            using (var context = new ExplicitIdentityValuesContext())
-            {
-                context.Blogs.Add(new Blog { BlogId = 100, Url = "http://blog1.somesite.com" });
-                context.Blogs.Add(new Blog { BlogId = 101, Url = "http://blog2.somesite.com" });
-
-                context.Database.OpenConnection();
-                try
-                {
-                    context.Database.ExecuteSqlRaw("SET IDENTITY_INSERT dbo.Blogs ON");
-                    context.SaveChanges();
-                    context.Database.ExecuteSqlRaw("SET IDENTITY_INSERT dbo.Blogs OFF");
-                }
-                finally
-                {
-                    context.Database.CloseConnection();
-                }
-            }
-            #endregion
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
         }
+
+        #region ExplicitIdentityValues
+        using (var context = new ExplicitIdentityValuesContext())
+        {
+            context.Blogs.Add(new Blog { BlogId = 100, Url = "http://blog1.somesite.com" });
+            context.Blogs.Add(new Blog { BlogId = 101, Url = "http://blog2.somesite.com" });
+
+            context.Database.OpenConnection();
+            try
+            {
+                context.Database.ExecuteSqlRaw("SET IDENTITY_INSERT dbo.Blogs ON");
+                context.SaveChanges();
+                context.Database.ExecuteSqlRaw("SET IDENTITY_INSERT dbo.Blogs OFF");
+            }
+            finally
+            {
+                context.Database.CloseConnection();
+            }
+        }
+        #endregion
     }
 }

--- a/samples/core/SqlServer/ValueGeneration/IdentityOptionsContext.cs
+++ b/samples/core/SqlServer/ValueGeneration/IdentityOptionsContext.cs
@@ -1,18 +1,17 @@
 using Microsoft.EntityFrameworkCore;
 
-namespace SqlServer.ValueGeneration
-{
-    public class IdentityOptionsContext : DbContext
-    {
-        public DbSet<Blog> Blogs { get; set; }
+namespace SqlServer.ValueGeneration;
 
-        #region IdentityOptions
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<Blog>()
-                .Property(b => b.BlogId)
-                .UseIdentityColumn(seed: 10, increment: 10);
-        }
-        #endregion
+public class IdentityOptionsContext : DbContext
+{
+    public DbSet<Blog> Blogs { get; set; }
+
+    #region IdentityOptions
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Blog>()
+            .Property(b => b.BlogId)
+            .UseIdentityColumn(seed: 10, increment: 10);
     }
+    #endregion
 }

--- a/samples/core/Testing/BloggingWebApi/Controllers/BloggingController.cs
+++ b/samples/core/Testing/BloggingWebApi/Controllers/BloggingController.cs
@@ -4,60 +4,59 @@ using EF.Testing.BusinessLogic;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
-namespace EF.Testing.BloggingWebApi.Controllers
+namespace EF.Testing.BloggingWebApi.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class BloggingController : ControllerBase
 {
-    [ApiController]
-    [Route("[controller]")]
-    public class BloggingController : ControllerBase
+    private readonly BloggingContext _context;
+
+    public BloggingController(BloggingContext context)
+        => _context = context;
+
+    #region GetBlog
+    [HttpGet]
+    public ActionResult<Blog> GetBlog(string name)
     {
-        private readonly BloggingContext _context;
-
-        public BloggingController(BloggingContext context)
-            => _context = context;
-
-        #region GetBlog
-        [HttpGet]
-        public ActionResult<Blog> GetBlog(string name)
-        {
-            var blog = _context.Blogs.FirstOrDefault(b => b.Name == name);
-            return blog is null ? NotFound() : blog;
-        }
-        #endregion
-
-        [HttpGet]
-        public ActionResult<Blog[]> GetAllBlogs()
-            => _context.Blogs.OrderBy(b => b.Name).ToArray();
-
-        #region AddBlog
-        [HttpPost]
-        public ActionResult AddBlog(string name, string url)
-        {
-            _context.Blogs.Add(new Blog { Name = name, Url = url });
-            _context.SaveChanges();
-
-            return Ok();
-        }
-        #endregion
-
-        #region UpdateBlogUrl
-        [HttpPost]
-        public ActionResult UpdateBlogUrl(string name, string url)
-        {
-            // Note: it isn't usually necessary to start a transaction for updating. This is done here for illustration purposes only.
-            using var transaction = _context.Database.BeginTransaction(IsolationLevel.Serializable);
-
-            var blog = _context.Blogs.FirstOrDefault(b => b.Name == name);
-            if (blog is null)
-            {
-                return NotFound();
-            }
-
-            blog.Url = url;
-            _context.SaveChanges();
-
-            transaction.Commit();
-            return Ok();
-        }
-        #endregion
+        var blog = _context.Blogs.FirstOrDefault(b => b.Name == name);
+        return blog is null ? NotFound() : blog;
     }
+    #endregion
+
+    [HttpGet]
+    public ActionResult<Blog[]> GetAllBlogs()
+        => _context.Blogs.OrderBy(b => b.Name).ToArray();
+
+    #region AddBlog
+    [HttpPost]
+    public ActionResult AddBlog(string name, string url)
+    {
+        _context.Blogs.Add(new Blog { Name = name, Url = url });
+        _context.SaveChanges();
+
+        return Ok();
+    }
+    #endregion
+
+    #region UpdateBlogUrl
+    [HttpPost]
+    public ActionResult UpdateBlogUrl(string name, string url)
+    {
+        // Note: it isn't usually necessary to start a transaction for updating. This is done here for illustration purposes only.
+        using var transaction = _context.Database.BeginTransaction(IsolationLevel.Serializable);
+
+        var blog = _context.Blogs.FirstOrDefault(b => b.Name == name);
+        if (blog is null)
+        {
+            return NotFound();
+        }
+
+        blog.Url = url;
+        _context.SaveChanges();
+
+        transaction.Commit();
+        return Ok();
+    }
+    #endregion
 }

--- a/samples/core/Testing/BloggingWebApi/Controllers/BloggingControllerWithRepository.cs
+++ b/samples/core/Testing/BloggingWebApi/Controllers/BloggingControllerWithRepository.cs
@@ -4,49 +4,48 @@ using System.Linq;
 using EF.Testing.BusinessLogic;
 using Microsoft.AspNetCore.Mvc;
 
-namespace EF.Testing.BloggingWebApi.Controllers
+namespace EF.Testing.BloggingWebApi.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class BloggingControllerWithRepository : ControllerBase
 {
-    [ApiController]
-    [Route("[controller]")]
-    public class BloggingControllerWithRepository : ControllerBase
+    #region BloggingControllerWithRepository
+    private readonly IBloggingRepository _repository;
+
+    public BloggingControllerWithRepository(IBloggingRepository repository)
+        => _repository = repository;
+
+    [HttpGet]
+    public Blog GetBlog(string name)
+        => _repository.GetBlogByName(name);
+    #endregion
+
+    [HttpGet]
+    public ActionResult<Blog[]> GetAllBlogs()
+        => _repository.GetAllBlogs().ToArray();
+
+    [HttpPost]
+    public ActionResult AddBlog(string name, string url)
     {
-        #region BloggingControllerWithRepository
-        private readonly IBloggingRepository _repository;
+        _repository.AddBlog(new Blog { Name = name, Url = url });
+        _repository.SaveChanges();
 
-        public BloggingControllerWithRepository(IBloggingRepository repository)
-            => _repository = repository;
+        return Ok();
+    }
 
-        [HttpGet]
-        public Blog GetBlog(string name)
-            => _repository.GetBlogByName(name);
-        #endregion
-
-        [HttpGet]
-        public ActionResult<Blog[]> GetAllBlogs()
-            => _repository.GetAllBlogs().ToArray();
-
-        [HttpPost]
-        public ActionResult AddBlog(string name, string url)
+    [HttpPost]
+    public ActionResult UpdateBlogUrl(string name, string url)
+    {
+        var blog = _repository.GetBlogByName(name);
+        if (blog is null)
         {
-            _repository.AddBlog(new Blog { Name = name, Url = url });
-            _repository.SaveChanges();
-
-            return Ok();
+            return NotFound();
         }
 
-        [HttpPost]
-        public ActionResult UpdateBlogUrl(string name, string url)
-        {
-            var blog = _repository.GetBlogByName(name);
-            if (blog is null)
-            {
-                return NotFound();
-            }
+        blog.Url = url;
+        _repository.SaveChanges();
 
-            blog.Url = url;
-            _repository.SaveChanges();
-
-            return Ok();
-        }
+        return Ok();
     }
 }

--- a/samples/core/Testing/BloggingWebApi/Program.cs
+++ b/samples/core/Testing/BloggingWebApi/Program.cs
@@ -1,17 +1,16 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
-namespace EF.Testing.BloggingWebApi
-{
-    public class Program
-    {
-        public static void Main(string[] args)
-        {
-            CreateHostBuilder(args).Build().Run();
-        }
+namespace EF.Testing.BloggingWebApi;
 
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        CreateHostBuilder(args).Build().Run();
     }
+
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
 }

--- a/samples/core/Testing/BloggingWebApi/Startup.cs
+++ b/samples/core/Testing/BloggingWebApi/Startup.cs
@@ -6,41 +6,40 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace EF.Testing.BloggingWebApi
+namespace EF.Testing.BloggingWebApi;
+
+public class Startup
 {
-    public class Startup
+    public Startup(IConfiguration configuration)
     {
-        public Startup(IConfiguration configuration)
+        Configuration = configuration;
+    }
+
+    public IConfiguration Configuration { get; }
+
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddControllers();
+
+        services.AddDbContext<BloggingContext>(
+            b => b.UseSqlServer(
+                @"Server=(localdb)\mssqllocaldb;Database=EFTestSample;Trusted_Connection=True"));
+
+        #region RegisterRepositoryInDI
+        services.AddScoped<IBloggingRepository, BloggingRepository>();
+        #endregion
+    }
+
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        if (env.IsDevelopment())
         {
-            Configuration = configuration;
+            app.UseDeveloperExceptionPage();
         }
 
-        public IConfiguration Configuration { get; }
-
-        public void ConfigureServices(IServiceCollection services)
-        {
-            services.AddControllers();
-
-            services.AddDbContext<BloggingContext>(
-                b => b.UseSqlServer(
-                    @"Server=(localdb)\mssqllocaldb;Database=EFTestSample;Trusted_Connection=True"));
-
-            #region RegisterRepositoryInDI
-            services.AddScoped<IBloggingRepository, BloggingRepository>();
-            #endregion
-        }
-
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-        {
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
-
-            app.UseHttpsRedirection();
-            app.UseRouting();
-            app.UseAuthorization();
-            app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
-        }
+        app.UseHttpsRedirection();
+        app.UseRouting();
+        app.UseAuthorization();
+        app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
     }
 }

--- a/samples/core/Testing/BusinessLogic/Blog.cs
+++ b/samples/core/Testing/BusinessLogic/Blog.cs
@@ -1,9 +1,8 @@
-﻿namespace EF.Testing.BusinessLogic
+﻿namespace EF.Testing.BusinessLogic;
+
+public class Blog
 {
-    public class Blog
-    {
-        public int BlogId { get; set; }
-        public string Name { get; set; }
-        public string Url { get; set; }
-    }
+    public int BlogId { get; set; }
+    public string Name { get; set; }
+    public string Url { get; set; }
 }

--- a/samples/core/Testing/BusinessLogic/BloggingRepository.cs
+++ b/samples/core/Testing/BusinessLogic/BloggingRepository.cs
@@ -1,27 +1,26 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace EF.Testing.BusinessLogic
+namespace EF.Testing.BusinessLogic;
+
+#region BloggingRepository
+public class BloggingRepository : IBloggingRepository
 {
-    #region BloggingRepository
-    public class BloggingRepository : IBloggingRepository
-    {
-        private readonly BloggingContext _context;
+    private readonly BloggingContext _context;
 
-        public BloggingRepository(BloggingContext context)
-            => _context = context;
+    public BloggingRepository(BloggingContext context)
+        => _context = context;
 
-        public Blog GetBlogByName(string name)
-            => _context.Blogs.FirstOrDefault(b => b.Name == name);
-        #endregion
+    public Blog GetBlogByName(string name)
+        => _context.Blogs.FirstOrDefault(b => b.Name == name);
+    #endregion
 
-        public IEnumerable<Blog> GetAllBlogs()
-            => _context.Blogs;
+    public IEnumerable<Blog> GetAllBlogs()
+        => _context.Blogs;
 
-        public void AddBlog(Blog blog)
-            => _context.Add(blog);
+    public void AddBlog(Blog blog)
+        => _context.Add(blog);
 
-        public void SaveChanges()
-            => _context.SaveChanges();
-    }
+    public void SaveChanges()
+        => _context.SaveChanges();
 }

--- a/samples/core/Testing/BusinessLogic/IBloggingRepository.cs
+++ b/samples/core/Testing/BusinessLogic/IBloggingRepository.cs
@@ -1,17 +1,16 @@
 using System.Collections.Generic;
 
-namespace EF.Testing.BusinessLogic
+namespace EF.Testing.BusinessLogic;
+
+#region IBloggingRepository
+public interface IBloggingRepository
 {
-    #region IBloggingRepository
-    public interface IBloggingRepository
-    {
-        Blog GetBlogByName(string name);
+    Blog GetBlogByName(string name);
 
-        IEnumerable<Blog> GetAllBlogs();
+    IEnumerable<Blog> GetAllBlogs();
 
-        void AddBlog(Blog blog);
+    void AddBlog(Blog blog);
 
-        void SaveChanges();
-    }
-    #endregion
+    void SaveChanges();
 }
+#endregion

--- a/samples/core/Testing/BusinessLogic/UrlResource.cs
+++ b/samples/core/Testing/BusinessLogic/UrlResource.cs
@@ -1,7 +1,6 @@
-namespace EF.Testing.BusinessLogic
+namespace EF.Testing.BusinessLogic;
+
+public class UrlResource
 {
-    public class UrlResource
-    {
-        public string Url { get; set; }
-    }
+    public string Url { get; set; }
 }

--- a/samples/core/Testing/TestingWithTheDatabase/BloggingControllerTest.cs
+++ b/samples/core/Testing/TestingWithTheDatabase/BloggingControllerTest.cs
@@ -2,62 +2,61 @@ using System.Linq;
 using EF.Testing.BloggingWebApi.Controllers;
 using Xunit;
 
-namespace EF.Testing.IntegrationTests
+namespace EF.Testing.IntegrationTests;
+
+#region UsingTheFixture
+public class BloggingControllerTest : IClassFixture<TestDatabaseFixture>
 {
-    #region UsingTheFixture
-    public class BloggingControllerTest : IClassFixture<TestDatabaseFixture>
+    public BloggingControllerTest(TestDatabaseFixture fixture)
+        => Fixture = fixture;
+
+    public TestDatabaseFixture Fixture { get; }
+    #endregion
+
+    #region GetBlog
+    [Fact]
+    public void GetBlog()
     {
-        public BloggingControllerTest(TestDatabaseFixture fixture)
-            => Fixture = fixture;
+        using var context = Fixture.CreateContext();
+        var controller = new BloggingController(context);
 
-        public TestDatabaseFixture Fixture { get; }
-        #endregion
+        var blog = controller.GetBlog("Blog2").Value;
 
-        #region GetBlog
-        [Fact]
-        public void GetBlog()
-        {
-            using var context = Fixture.CreateContext();
-            var controller = new BloggingController(context);
-
-            var blog = controller.GetBlog("Blog2").Value;
-
-            Assert.Equal("http://blog2.com", blog.Url);
-        }
-        #endregion
-
-        #region GetAllBlogs
-        [Fact]
-        public void GetAllBlogs()
-        {
-            using var context = Fixture.CreateContext();
-            var controller = new BloggingController(context);
-
-            var blogs = controller.GetAllBlogs().Value;
-
-            Assert.Collection(
-                blogs,
-                b => Assert.Equal("Blog1", b.Name),
-                b => Assert.Equal("Blog2", b.Name));
-        }
-        #endregion
-
-        #region AddBlog
-        [Fact]
-        public void AddBlog()
-        {
-            using var context = Fixture.CreateContext();
-            context.Database.BeginTransaction();
-
-            var controller = new BloggingController(context);
-            controller.AddBlog("Blog3", "http://blog3.com");
-
-            context.ChangeTracker.Clear();
-
-            var blog = context.Blogs.Single(b => b.Name == "Blog3");
-            Assert.Equal("http://blog3.com", blog.Url);
-
-        }
-        #endregion
+        Assert.Equal("http://blog2.com", blog.Url);
     }
+    #endregion
+
+    #region GetAllBlogs
+    [Fact]
+    public void GetAllBlogs()
+    {
+        using var context = Fixture.CreateContext();
+        var controller = new BloggingController(context);
+
+        var blogs = controller.GetAllBlogs().Value;
+
+        Assert.Collection(
+            blogs,
+            b => Assert.Equal("Blog1", b.Name),
+            b => Assert.Equal("Blog2", b.Name));
+    }
+    #endregion
+
+    #region AddBlog
+    [Fact]
+    public void AddBlog()
+    {
+        using var context = Fixture.CreateContext();
+        context.Database.BeginTransaction();
+
+        var controller = new BloggingController(context);
+        controller.AddBlog("Blog3", "http://blog3.com");
+
+        context.ChangeTracker.Clear();
+
+        var blog = context.Blogs.Single(b => b.Name == "Blog3");
+        Assert.Equal("http://blog3.com", blog.Url);
+
+    }
+    #endregion
 }

--- a/samples/core/Testing/TestingWithTheDatabase/TestDatabaseFixture.cs
+++ b/samples/core/Testing/TestingWithTheDatabase/TestDatabaseFixture.cs
@@ -1,43 +1,42 @@
 using EF.Testing.BusinessLogic;
 using Microsoft.EntityFrameworkCore;
 
-namespace EF.Testing.IntegrationTests
+namespace EF.Testing.IntegrationTests;
+
+#region TestDatabaseFixture
+public class TestDatabaseFixture
 {
-    #region TestDatabaseFixture
-    public class TestDatabaseFixture
+    private const string ConnectionString = @"Server=(localdb)\mssqllocaldb;Database=EFTestSample;Trusted_Connection=True";
+
+    private static readonly object _lock = new();
+    private static bool _databaseInitialized;
+
+    public TestDatabaseFixture()
     {
-        private const string ConnectionString = @"Server=(localdb)\mssqllocaldb;Database=EFTestSample;Trusted_Connection=True";
-
-        private static readonly object _lock = new();
-        private static bool _databaseInitialized;
-
-        public TestDatabaseFixture()
+        lock (_lock)
         {
-            lock (_lock)
+            if (!_databaseInitialized)
             {
-                if (!_databaseInitialized)
+                using (var context = CreateContext())
                 {
-                    using (var context = CreateContext())
-                    {
-                        context.Database.EnsureDeleted();
-                        context.Database.EnsureCreated();
+                    context.Database.EnsureDeleted();
+                    context.Database.EnsureCreated();
 
-                        context.AddRange(
-                            new Blog { Name = "Blog1", Url = "http://blog1.com" },
-                            new Blog { Name = "Blog2", Url = "http://blog2.com" });
-                        context.SaveChanges();
-                    }
-
-                    _databaseInitialized = true;
+                    context.AddRange(
+                        new Blog { Name = "Blog1", Url = "http://blog1.com" },
+                        new Blog { Name = "Blog2", Url = "http://blog2.com" });
+                    context.SaveChanges();
                 }
+
+                _databaseInitialized = true;
             }
         }
-
-        public BloggingContext CreateContext()
-            => new BloggingContext(
-                new DbContextOptionsBuilder<BloggingContext>()
-                    .UseSqlServer(ConnectionString)
-                    .Options);
     }
-    #endregion
+
+    public BloggingContext CreateContext()
+        => new BloggingContext(
+            new DbContextOptionsBuilder<BloggingContext>()
+                .UseSqlServer(ConnectionString)
+                .Options);
 }
+#endregion

--- a/samples/core/Testing/TestingWithTheDatabase/TransactionalBloggingControllerTest.cs
+++ b/samples/core/Testing/TestingWithTheDatabase/TransactionalBloggingControllerTest.cs
@@ -3,39 +3,38 @@ using System.Linq;
 using EF.Testing.BloggingWebApi.Controllers;
 using Xunit;
 
-namespace EF.Testing.IntegrationTests
+namespace EF.Testing.IntegrationTests;
+
+#region UsingTheFixture
+[Collection("TransactionalTests")]
+public class TransactionalBloggingControllerTest : IDisposable
 {
-    #region UsingTheFixture
-    [Collection("TransactionalTests")]
-    public class TransactionalBloggingControllerTest : IDisposable
+    public TransactionalBloggingControllerTest(TransactionalTestDatabaseFixture fixture)
+        => Fixture = fixture;
+
+    public TransactionalTestDatabaseFixture Fixture { get; }
+    #endregion
+
+    #region UpdateBlogUrl
+    [Fact]
+    public void UpdateBlogUrl()
     {
-        public TransactionalBloggingControllerTest(TransactionalTestDatabaseFixture fixture)
-            => Fixture = fixture;
-
-        public TransactionalTestDatabaseFixture Fixture { get; }
-        #endregion
-
-        #region UpdateBlogUrl
-        [Fact]
-        public void UpdateBlogUrl()
+        using (var context = Fixture.CreateContext())
         {
-            using (var context = Fixture.CreateContext())
-            {
-                var controller = new BloggingController(context);
-                controller.UpdateBlogUrl("Blog2", "http://blog2_updated.com");
-            }
-
-            using (var context = Fixture.CreateContext())
-            {
-                var blog = context.Blogs.Single(b => b.Name == "Blog2");
-                Assert.Equal("http://blog2_updated.com", blog.Url);
-            }
+            var controller = new BloggingController(context);
+            controller.UpdateBlogUrl("Blog2", "http://blog2_updated.com");
         }
-        #endregion
 
-        #region Dispose
-        public void Dispose()
-            => Fixture.Cleanup();
-        #endregion
+        using (var context = Fixture.CreateContext())
+        {
+            var blog = context.Blogs.Single(b => b.Name == "Blog2");
+            Assert.Equal("http://blog2_updated.com", blog.Url);
+        }
     }
+    #endregion
+
+    #region Dispose
+    public void Dispose()
+        => Fixture.Cleanup();
+    #endregion
 }

--- a/samples/core/Testing/TestingWithTheDatabase/TransactionalTestDatabaseFixture.cs
+++ b/samples/core/Testing/TestingWithTheDatabase/TransactionalTestDatabaseFixture.cs
@@ -2,48 +2,47 @@ using EF.Testing.BusinessLogic;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
-namespace EF.Testing.IntegrationTests
+namespace EF.Testing.IntegrationTests;
+
+#region TransactionalTestDatabaseFixture
+public class TransactionalTestDatabaseFixture
 {
-    #region TransactionalTestDatabaseFixture
-    public class TransactionalTestDatabaseFixture
+    private const string ConnectionString = @"Server=(localdb)\mssqllocaldb;Database=EFTransactionalTestSample;Trusted_Connection=True";
+
+    public BloggingContext CreateContext()
+        => new BloggingContext(
+            new DbContextOptionsBuilder<BloggingContext>()
+                .UseSqlServer(ConnectionString)
+                .Options);
+
+    public TransactionalTestDatabaseFixture()
     {
-        private const string ConnectionString = @"Server=(localdb)\mssqllocaldb;Database=EFTransactionalTestSample;Trusted_Connection=True";
+        using var context = CreateContext();
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
 
-        public BloggingContext CreateContext()
-            => new BloggingContext(
-                new DbContextOptionsBuilder<BloggingContext>()
-                    .UseSqlServer(ConnectionString)
-                    .Options);
-
-        public TransactionalTestDatabaseFixture()
-        {
-            using var context = CreateContext();
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-
-            Cleanup();
-        }
-
-        public void Cleanup()
-        {
-            #region Cleanup
-            using var context = CreateContext();
-
-            context.Blogs.RemoveRange(context.Blogs);
-
-            context.AddRange(
-                new Blog { Name = "Blog1", Url = "http://blog1.com" },
-                new Blog { Name = "Blog2", Url = "http://blog2.com" });
-            context.SaveChanges();
-            #endregion
-        }
+        Cleanup();
     }
-    #endregion
 
-    #region CollectionDefinition
-    [CollectionDefinition("TransactionalTests")]
-    public class TransactionalTestsCollection : ICollectionFixture<TransactionalTestDatabaseFixture>
+    public void Cleanup()
     {
+        #region Cleanup
+        using var context = CreateContext();
+
+        context.Blogs.RemoveRange(context.Blogs);
+
+        context.AddRange(
+            new Blog { Name = "Blog1", Url = "http://blog1.com" },
+            new Blog { Name = "Blog2", Url = "http://blog2.com" });
+        context.SaveChanges();
+        #endregion
     }
-    #endregion
 }
+#endregion
+
+#region CollectionDefinition
+[CollectionDefinition("TransactionalTests")]
+public class TransactionalTestsCollection : ICollectionFixture<TransactionalTestDatabaseFixture>
+{
+}
+#endregion

--- a/samples/core/Testing/TestingWithoutTheDatabase/InMemoryBloggingControllerTest.cs
+++ b/samples/core/Testing/TestingWithoutTheDatabase/InMemoryBloggingControllerTest.cs
@@ -5,90 +5,89 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Xunit;
 
-namespace EF.Testing.UnitTests
+namespace EF.Testing.UnitTests;
+
+public class InMemoryBloggingControllerTest
 {
-    public class InMemoryBloggingControllerTest
+    private readonly DbContextOptions<BloggingContext> _contextOptions;
+
+    #region Constructor
+    public InMemoryBloggingControllerTest()
     {
-        private readonly DbContextOptions<BloggingContext> _contextOptions;
+        _contextOptions = new DbContextOptionsBuilder<BloggingContext>()
+            .UseInMemoryDatabase("BloggingControllerTest")
+            .ConfigureWarnings(b => b.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
 
-        #region Constructor
-        public InMemoryBloggingControllerTest()
-        {
-            _contextOptions = new DbContextOptionsBuilder<BloggingContext>()
-                .UseInMemoryDatabase("BloggingControllerTest")
-                .ConfigureWarnings(b => b.Ignore(InMemoryEventId.TransactionIgnoredWarning))
-                .Options;
+        using var context = new BloggingContext(_contextOptions);
 
-            using var context = new BloggingContext(_contextOptions);
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
 
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
+        context.AddRange(
+            new Blog { Name = "Blog1", Url = "http://blog1.com" },
+            new Blog { Name = "Blog2", Url = "http://blog2.com" });
 
-            context.AddRange(
-                new Blog { Name = "Blog1", Url = "http://blog1.com" },
-                new Blog { Name = "Blog2", Url = "http://blog2.com" });
-
-            context.SaveChanges();
-        }
-        #endregion
-
-        #region GetBlog
-        [Fact]
-        public void GetBlog()
-        {
-            using var context = CreateContext();
-            var controller = new BloggingController(context);
-
-            var blog = controller.GetBlog("Blog2").Value;
-
-            Assert.Equal("http://blog2.com", blog.Url);
-        }
-        #endregion
-
-        [Fact]
-        public void GetAllBlogs()
-        {
-            using var context = CreateContext();
-            var controller = new BloggingController(context);
-
-            var blogs = controller.GetAllBlogs().Value;
-
-            Assert.Collection(
-                blogs,
-                b => Assert.Equal("Blog1", b.Name),
-                b => Assert.Equal("Blog2", b.Name));
-        }
-
-        [Fact]
-        public void AddBlog()
-        {
-            using var context = CreateContext();
-            var controller = new BloggingController(context);
-
-            controller.AddBlog("Blog3", "http://blog3.com");
-
-            var blog = context.Blogs.Single(b => b.Name == "Blog3");
-            Assert.Equal("http://blog3.com", blog.Url);
-        }
-
-        [Fact]
-        public void UpdateBlogUrl()
-        {
-            using var context = CreateContext();
-            var controller = new BloggingController(context);
-
-            controller.UpdateBlogUrl("Blog2", "http://blog2_updated.com");
-
-            var blog = context.Blogs.Single(b => b.Name == "Blog2");
-            Assert.Equal("http://blog2_updated.com", blog.Url);
-        }
-
-        BloggingContext CreateContext() => new BloggingContext(_contextOptions, (context, modelBuilder) =>
-        {
-            #region ToInMemoryQuery
-            modelBuilder.Entity<UrlResource>()
-                .ToInMemoryQuery(() => context.Blogs.Select(b => new UrlResource { Url = b.Url }));
-            #endregion
-        });
+        context.SaveChanges();
     }
+    #endregion
+
+    #region GetBlog
+    [Fact]
+    public void GetBlog()
+    {
+        using var context = CreateContext();
+        var controller = new BloggingController(context);
+
+        var blog = controller.GetBlog("Blog2").Value;
+
+        Assert.Equal("http://blog2.com", blog.Url);
+    }
+    #endregion
+
+    [Fact]
+    public void GetAllBlogs()
+    {
+        using var context = CreateContext();
+        var controller = new BloggingController(context);
+
+        var blogs = controller.GetAllBlogs().Value;
+
+        Assert.Collection(
+            blogs,
+            b => Assert.Equal("Blog1", b.Name),
+            b => Assert.Equal("Blog2", b.Name));
+    }
+
+    [Fact]
+    public void AddBlog()
+    {
+        using var context = CreateContext();
+        var controller = new BloggingController(context);
+
+        controller.AddBlog("Blog3", "http://blog3.com");
+
+        var blog = context.Blogs.Single(b => b.Name == "Blog3");
+        Assert.Equal("http://blog3.com", blog.Url);
+    }
+
+    [Fact]
+    public void UpdateBlogUrl()
+    {
+        using var context = CreateContext();
+        var controller = new BloggingController(context);
+
+        controller.UpdateBlogUrl("Blog2", "http://blog2_updated.com");
+
+        var blog = context.Blogs.Single(b => b.Name == "Blog2");
+        Assert.Equal("http://blog2_updated.com", blog.Url);
+    }
+
+    BloggingContext CreateContext() => new BloggingContext(_contextOptions, (context, modelBuilder) =>
+    {
+        #region ToInMemoryQuery
+        modelBuilder.Entity<UrlResource>()
+            .ToInMemoryQuery(() => context.Blogs.Select(b => new UrlResource { Url = b.Url }));
+        #endregion
+    });
 }

--- a/samples/core/Testing/TestingWithoutTheDatabase/RepositoryBloggingControllerTest.cs
+++ b/samples/core/Testing/TestingWithoutTheDatabase/RepositoryBloggingControllerTest.cs
@@ -3,90 +3,89 @@ using EF.Testing.BusinessLogic;
 using Moq;
 using Xunit;
 
-namespace EF.Testing.UnitTests
+namespace EF.Testing.UnitTests;
+
+public class RepositoryBloggingControllerTest
 {
-    public class RepositoryBloggingControllerTest
+    #region GetBlog
+    [Fact]
+    public void GetBlog()
     {
-        #region GetBlog
-        [Fact]
-        public void GetBlog()
-        {
-            // Arrange
-            var repositoryMock = new Mock<IBloggingRepository>();
-            repositoryMock
-                .Setup(r => r.GetBlogByName("Blog2"))
-                .Returns(new Blog { Name = "Blog2", Url = "http://blog2.com" });
+        // Arrange
+        var repositoryMock = new Mock<IBloggingRepository>();
+        repositoryMock
+            .Setup(r => r.GetBlogByName("Blog2"))
+            .Returns(new Blog { Name = "Blog2", Url = "http://blog2.com" });
 
-            var controller = new BloggingControllerWithRepository(repositoryMock.Object);
+        var controller = new BloggingControllerWithRepository(repositoryMock.Object);
 
-            // Act
-            var blog = controller.GetBlog("Blog2");
+        // Act
+        var blog = controller.GetBlog("Blog2");
 
-            // Assert
-            repositoryMock.Verify(r => r.GetBlogByName("Blog2"));
-            Assert.Equal("http://blog2.com", blog.Url);
-        }
-        #endregion
+        // Assert
+        repositoryMock.Verify(r => r.GetBlogByName("Blog2"));
+        Assert.Equal("http://blog2.com", blog.Url);
+    }
+    #endregion
 
-        [Fact]
-        public void GetAllBlogs()
-        {
-            // Arrange
-            var repositoryMock = new Mock<IBloggingRepository>();
-            repositoryMock
-                .Setup(r => r.GetAllBlogs())
-                .Returns(new[]
-                {
-                    new Blog { Name = "Blog1", Url = "http://blog1.com" },
-                    new Blog { Name = "Blog2", Url = "http://blog2.com" }
-                });
+    [Fact]
+    public void GetAllBlogs()
+    {
+        // Arrange
+        var repositoryMock = new Mock<IBloggingRepository>();
+        repositoryMock
+            .Setup(r => r.GetAllBlogs())
+            .Returns(new[]
+            {
+                new Blog { Name = "Blog1", Url = "http://blog1.com" },
+                new Blog { Name = "Blog2", Url = "http://blog2.com" }
+            });
 
-            var controller = new BloggingControllerWithRepository(repositoryMock.Object);
+        var controller = new BloggingControllerWithRepository(repositoryMock.Object);
 
-            // Act
-            var blogs = controller.GetAllBlogs().Value;
+        // Act
+        var blogs = controller.GetAllBlogs().Value;
 
-            // Assert
-            repositoryMock.Verify(r => r.GetAllBlogs());
-            Assert.Equal("http://blog1.com", blogs[0].Url);
-            Assert.Equal("http://blog2.com", blogs[1].Url);
-        }
+        // Assert
+        repositoryMock.Verify(r => r.GetAllBlogs());
+        Assert.Equal("http://blog1.com", blogs[0].Url);
+        Assert.Equal("http://blog2.com", blogs[1].Url);
+    }
 
-        [Fact]
-        public void AddBlog()
-        {
-            // Arrange
-            var repositoryMock = new Mock<IBloggingRepository>();
-            var controller = new BloggingControllerWithRepository(repositoryMock.Object);
+    [Fact]
+    public void AddBlog()
+    {
+        // Arrange
+        var repositoryMock = new Mock<IBloggingRepository>();
+        var controller = new BloggingControllerWithRepository(repositoryMock.Object);
 
-            // Act
-            controller.AddBlog("Blog2", "http://blog2.com");
+        // Act
+        controller.AddBlog("Blog2", "http://blog2.com");
 
-            // Assert
-            repositoryMock.Verify(r => r.AddBlog(It.IsAny<Blog>()));
-            repositoryMock.Verify(r => r.SaveChanges());
-        }
+        // Assert
+        repositoryMock.Verify(r => r.AddBlog(It.IsAny<Blog>()));
+        repositoryMock.Verify(r => r.SaveChanges());
+    }
 
-        [Fact]
-        public void UpdateBlogUrl()
-        {
-            var blog = new Blog { Name = "Blog2", Url = "http://blog2.com" };
+    [Fact]
+    public void UpdateBlogUrl()
+    {
+        var blog = new Blog { Name = "Blog2", Url = "http://blog2.com" };
 
-            // Arrange
-            var repositoryMock = new Mock<IBloggingRepository>();
-            repositoryMock
-                .Setup(r => r.GetBlogByName("Blog2"))
-                .Returns(blog);
+        // Arrange
+        var repositoryMock = new Mock<IBloggingRepository>();
+        repositoryMock
+            .Setup(r => r.GetBlogByName("Blog2"))
+            .Returns(blog);
 
-            var controller = new BloggingControllerWithRepository(repositoryMock.Object);
+        var controller = new BloggingControllerWithRepository(repositoryMock.Object);
 
-            // Act
-            controller.UpdateBlogUrl("Blog2", "http://blog2_updated.com");
+        // Act
+        controller.UpdateBlogUrl("Blog2", "http://blog2_updated.com");
 
-            // Assert
-            repositoryMock.Verify(r => r.GetBlogByName("Blog2"));
-            repositoryMock.Verify(r => r.SaveChanges());
-            Assert.Equal("http://blog2_updated.com", blog.Url);
-        }
+        // Assert
+        repositoryMock.Verify(r => r.GetBlogByName("Blog2"));
+        repositoryMock.Verify(r => r.SaveChanges());
+        Assert.Equal("http://blog2_updated.com", blog.Url);
     }
 }

--- a/samples/core/Testing/TestingWithoutTheDatabase/SqliteInMemoryBloggingControllerTest.cs
+++ b/samples/core/Testing/TestingWithoutTheDatabase/SqliteInMemoryBloggingControllerTest.cs
@@ -7,99 +7,98 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
-namespace EF.Testing.UnitTests
+namespace EF.Testing.UnitTests;
+
+public class SqliteInMemoryBloggingControllerTest : IDisposable
 {
-    public class SqliteInMemoryBloggingControllerTest : IDisposable
+    private readonly DbConnection _connection;
+    private readonly DbContextOptions<BloggingContext> _contextOptions;
+
+    #region ConstructorAndDispose
+    public SqliteInMemoryBloggingControllerTest()
     {
-        private readonly DbConnection _connection;
-        private readonly DbContextOptions<BloggingContext> _contextOptions;
+        // Create and open a connection. This creates the SQLite in-memory database, which will persist until the connection is closed
+        // at the end of the test (see Dispose below).
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
 
-        #region ConstructorAndDispose
-        public SqliteInMemoryBloggingControllerTest()
+        // These options will be used by the context instances in this test suite, including the connection opened above.
+        _contextOptions = new DbContextOptionsBuilder<BloggingContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        // Create the schema and seed some data
+        using var context = new BloggingContext(_contextOptions);
+
+        if (context.Database.EnsureCreated())
         {
-            // Create and open a connection. This creates the SQLite in-memory database, which will persist until the connection is closed
-            // at the end of the test (see Dispose below).
-            _connection = new SqliteConnection("Filename=:memory:");
-            _connection.Open();
-
-            // These options will be used by the context instances in this test suite, including the connection opened above.
-            _contextOptions = new DbContextOptionsBuilder<BloggingContext>()
-                .UseSqlite(_connection)
-                .Options;
-
-            // Create the schema and seed some data
-            using var context = new BloggingContext(_contextOptions);
-
-            if (context.Database.EnsureCreated())
-            {
-                using var viewCommand = context.Database.GetDbConnection().CreateCommand();
-                viewCommand.CommandText = @"
+            using var viewCommand = context.Database.GetDbConnection().CreateCommand();
+            viewCommand.CommandText = @"
 CREATE VIEW AllResources AS
 SELECT Url
 FROM Blogs;";
-                viewCommand.ExecuteNonQuery();
-            }
-
-            context.AddRange(
-                new Blog { Name = "Blog1", Url = "http://blog1.com" },
-                new Blog { Name = "Blog2", Url = "http://blog2.com" });
-            context.SaveChanges();
+            viewCommand.ExecuteNonQuery();
         }
 
-        BloggingContext CreateContext() => new BloggingContext(_contextOptions);
+        context.AddRange(
+            new Blog { Name = "Blog1", Url = "http://blog1.com" },
+            new Blog { Name = "Blog2", Url = "http://blog2.com" });
+        context.SaveChanges();
+    }
 
-        public void Dispose() => _connection.Dispose();
-        #endregion
+    BloggingContext CreateContext() => new BloggingContext(_contextOptions);
 
-        #region GetBlog
-        [Fact]
-        public void GetBlog()
-        {
-            using var context = CreateContext();
-            var controller = new BloggingController(context);
+    public void Dispose() => _connection.Dispose();
+    #endregion
 
-            var blog = controller.GetBlog("Blog2").Value;
+    #region GetBlog
+    [Fact]
+    public void GetBlog()
+    {
+        using var context = CreateContext();
+        var controller = new BloggingController(context);
 
-            Assert.Equal("http://blog2.com", blog.Url);
-        }
-        #endregion
+        var blog = controller.GetBlog("Blog2").Value;
 
-        [Fact]
-        public void GetAllBlogs()
-        {
-            using var context = CreateContext();
-            var controller = new BloggingController(context);
+        Assert.Equal("http://blog2.com", blog.Url);
+    }
+    #endregion
 
-            var blogs = controller.GetAllBlogs().Value;
+    [Fact]
+    public void GetAllBlogs()
+    {
+        using var context = CreateContext();
+        var controller = new BloggingController(context);
 
-            Assert.Collection(
-                blogs,
-                b => Assert.Equal("Blog1", b.Name),
-                b => Assert.Equal("Blog2", b.Name));
-        }
+        var blogs = controller.GetAllBlogs().Value;
 
-        [Fact]
-        public void AddBlog()
-        {
-            using var context = CreateContext();
-            var controller = new BloggingController(context);
+        Assert.Collection(
+            blogs,
+            b => Assert.Equal("Blog1", b.Name),
+            b => Assert.Equal("Blog2", b.Name));
+    }
 
-            controller.AddBlog("Blog3", "http://blog3.com");
+    [Fact]
+    public void AddBlog()
+    {
+        using var context = CreateContext();
+        var controller = new BloggingController(context);
 
-            var blog = context.Blogs.Single(b => b.Name == "Blog3");
-            Assert.Equal("http://blog3.com", blog.Url);
-        }
+        controller.AddBlog("Blog3", "http://blog3.com");
 
-        [Fact]
-        public void UpdateBlogUrl()
-        {
-            using var context = CreateContext();
-            var controller = new BloggingController(context);
+        var blog = context.Blogs.Single(b => b.Name == "Blog3");
+        Assert.Equal("http://blog3.com", blog.Url);
+    }
 
-            controller.UpdateBlogUrl("Blog2", "http://blog2_updated.com");
+    [Fact]
+    public void UpdateBlogUrl()
+    {
+        using var context = CreateContext();
+        var controller = new BloggingController(context);
 
-            var blog = context.Blogs.Single(b => b.Name == "Blog2");
-            Assert.Equal("http://blog2_updated.com", blog.Url);
-        }
+        controller.UpdateBlogUrl("Blog2", "http://blog2_updated.com");
+
+        var blog = context.Blogs.Single(b => b.Name == "Blog2");
+        Assert.Equal("http://blog2_updated.com", blog.Url);
     }
 }


### PR DESCRIPTION
Done automatically with Rider (and manually removed changes to migration files).

Note that if we have any code snippets in the conceptual pages which don't reference a region, this would break them (since line numbers will now shift). However, we almost always use regions which wouldn't be affected (since line numbers are relative).