### PR TITLE
Fix a link to Including & Excluding Properties in Backing Fields|Basic configuration section

### DIFF
--- a/entity-framework/core/modeling/backing-field.md
+++ b/entity-framework/core/modeling/backing-field.md
@@ -22,7 +22,7 @@ In the following sample, the `Url` property is configured to have `_url` as its 
 
 [!code-csharp[Main](../../../samples/core/Modeling/BackingFields/BackingField.cs#Sample)]
 
-Note that backing fields are only discovered for properties that are included in the model. For more information on which properties are included in the model, see [Including & Excluding Properties](xref:core/modeling/entity-properties).
+Note that backing fields are only discovered for properties that are included in the model. For more information on which properties are included in the model, see [Including & Excluding Properties](xref:core/modeling/entity-properties#included-and-excluded-properties).
 
 You can also configure backing fields by using a Data Annotation (available in EFCore 5.0) or the Fluent API, e.g. if the field name doesn't correspond to the above conventions:
 


### PR DESCRIPTION
Since Including & Excluding Properties is a first section in Entity Properties page, so it's not big problem. But I think it'll be better to use concrete link to the section.

Fixes https://github.com/dotnet/EntityFramework.Docs/issues/3385