### PR TITLE
Fix missing Simple Logging region

### DIFF
--- a/samples/core/Performance/Other/BloggingContext.cs
+++ b/samples/core/Performance/Other/BloggingContext.cs
@@ -10,12 +10,14 @@ public class BloggingContext : DbContext
     public DbSet<Blog> Blogs { get; set; }
     public DbSet<Post> Posts { get; set; }
 
+    #region SimpleLogging
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         optionsBuilder
             .UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Blogging;Trusted_Connection=True")
             .LogTo(Console.WriteLine, LogLevel.Information);
     }
+    #endregion
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {


### PR DESCRIPTION
Fixes Simple logging region for https://github.com/dotnet/EntityFramework.Docs/edit/main/entity-framework/core/performance/performance-diagnosis.md

(https://docs.microsoft.com/en-us/ef/core/performance/performance-diagnosis?tabs=simple-logging%2Ccalculate-in-database)