### PR TITLE
Fix InvalidOperationException

### DIFF
--- a/entity-framework/core/miscellaneous/connection-resiliency.md
+++ b/entity-framework/core/miscellaneous/connection-resiliency.md
@@ -51,7 +51,7 @@ An execution strategy that automatically retries on failures needs to be able to
 
 However, if your code initiates a transaction using `BeginTransaction()` you are defining your own group of operations that need to be treated as a unit, and everything inside the transaction would need to be played back shall a failure occur. You will receive an exception like the following if you attempt to do this when using an execution strategy:
 
-> InvalidOperationException: The configured execution strategy 'SqlServerRetryingExecutionStrategy' does not support user initiated transactions. Use the execution strategy returned by 'DbContext.Database.CreateExecutionStrategy()' to execute all the operations in the transaction as a retriable unit.
+> InvalidOperationException: The configured execution strategy 'SqlServerRetryingExecutionStrategy' does not support user-initiated transactions. Use the execution strategy returned by 'DbContext.Database.CreateExecutionStrategy()' to execute all the operations in the transaction as a retriable unit.
 
 The solution is to manually invoke the execution strategy with a delegate representing everything that needs to be executed. If a transient failure occurs, the execution strategy will invoke the delegate again.
 


### PR DESCRIPTION
There was a small mismatch between the thrown exception message and the mentioned exception message. This leads to no results on searches by exact phrasing. 