### PR TITLE
Fixed GetEnumerator() method on mock

### DIFF
--- a/entity-framework/ef6/fundamentals/testing/mocking.md
+++ b/entity-framework/ef6/fundamentals/testing/mocking.md
@@ -207,7 +207,7 @@ namespace TestingDemo
             mockSet.As<IQueryable<Blog>>().Setup(m => m.Provider).Returns(data.Provider);
             mockSet.As<IQueryable<Blog>>().Setup(m => m.Expression).Returns(data.Expression);
             mockSet.As<IQueryable<Blog>>().Setup(m => m.ElementType).Returns(data.ElementType);
-            mockSet.As<IQueryable<Blog>>().Setup(m => m.GetEnumerator()).Returns(data.GetEnumerator());
+            mockSet.As<IQueryable<Blog>>().Setup(m => m.GetEnumerator()).Returns(() => data.GetEnumerator());
 
             var mockContext = new Mock<BloggingContext>();
             mockContext.Setup(c => c.Blogs).Returns(mockSet.Object);
@@ -382,7 +382,7 @@ namespace TestingDemo
 
             mockSet.As<IQueryable<Blog>>().Setup(m => m.Expression).Returns(data.Expression);
             mockSet.As<IQueryable<Blog>>().Setup(m => m.ElementType).Returns(data.ElementType);
-            mockSet.As<IQueryable<Blog>>().Setup(m => m.GetEnumerator()).Returns(data.GetEnumerator());
+            mockSet.As<IQueryable<Blog>>().Setup(m => m.GetEnumerator()).Returns(() => data.GetEnumerator());
 
             var mockContext = new Mock<BloggingContext>();
             mockContext.Setup(c => c.Blogs).Returns(mockSet.Object);


### PR DESCRIPTION
Currently the underlying data collection's `GetEnumerator()` is only invoked once, and the resulting value is used every time the mocked `DbSet`'s `GetEnumerator()` method is invoked. The mocked `DbSet` needs to be configured to retrieve a new enumerator each time the method is called by invoking the underlying data collection's `GetEnumerator()` method. Otherwise the enumerator returned by the method will become invalid if the contents of the mocked `DbSet` change. 

Since the example sets up the underlying data before configuring the mock, and doesn't make any subsiquent changes after that point, this doesn't cause any issues in the example. But if the same setup code is used in a unit test that involves modifying the contents of the DbSet, the code will throw `InvalidOperationException`s anytime the `DbSet` is iterated through or `ToList()` is called.