### PR TITLE
Added .NET product header metadata

### DIFF
--- a/entity-framework/docfx.json
+++ b/entity-framework/docfx.json
@@ -77,7 +77,7 @@
       "feedback_system": "GitHub",
       "feedback_github_repo": "dotnet/EntityFramework.Docs",
       "feedback_product_url": "https://github.com/dotnet/efcore/issues/new/choose",
-      "uhfHeaderId": []
+      "uhfHeaderId": "MSDocsHeader-DotNet"
     },
     "fileMetadata": {
       "feedback_product_url": {


### PR DESCRIPTION
Hello, this content needs to use the Microsoft 365 product-level header. Please let me know if you have any questions. If you're wondering "What is a product-level header?" please see:  https://review.docs.microsoft.com/en-us/help/onboard/admin/navigation-product-level-header?branch=main#what-is-product-level-navigation-for