### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ You'll need a basic understanding of [Git and GitHub.com](https://guides.github.
 
 ## Markdown syntax
 
-Articles are written in [DocFx-flavored Markdown (DFM)](http://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html), a superset of [GitHub-flavored Markdown (GFM)](https://guides.github.com/features/mastering-markdown/). For examples of DFM syntax and metadata for UI features commonly used in the EF documentation, see [Metadata and Markdown Template](https://docs.microsoft.com/contribute/dotnet/dotnet-style-guide).
+Articles are written in [DocFx-flavored Markdown (DFM)](http://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html), a superset of [GitHub-flavored Markdown (GFM)](https://guides.github.com/features/mastering-markdown/). For examples of DFM syntax and metadata for UI features commonly used in the EF documentation, see [Metadata and Markdown Template](https://learn.microsoft.com/contribute/dotnet/dotnet-style-guide).
 
 ## Folder structure conventions
 
@@ -96,4 +96,4 @@ DocFX requires the .NET Framework on Windows, or Mono for Linux or macOS.
 
 ## Voice and tone
 
-Our goal is to write documentation that is easily understandable by the widest possible audience. To that end we have established guidelines for writing style that we ask our contributors to follow. For more information, see [Voice and tone guidelines](https://docs.microsoft.com/contribute/dotnet/dotnet-voice-tone).
+Our goal is to write documentation that is easily understandable by the widest possible audience. To that end we have established guidelines for writing style that we ask our contributors to follow. For more information, see [Voice and tone guidelines](https://learn.microsoft.com/contribute/dotnet/dotnet-voice-tone).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Entity Framework Docs
 
-This project contains the source for EF Core and EF6 documentation published at [Entity Framework documentation](https://docs.microsoft.com/ef/).
+This project contains the source for EF Core and EF6 documentation published at [Entity Framework documentation](https://learn.microsoft.com/ef/).
 
 Documentation issues for both EF Core and EF6 should be filed in this repo. Product issues (bugs) should be filed in the [EF Core repo](https://github.com/dotnet/efcore) or the [EF6 repo](https://github.com/dotnet/ef6) as appropriate.
 

--- a/entity-framework/dotnet-data/index.yml
+++ b/entity-framework/dotnet-data/index.yml
@@ -41,7 +41,7 @@ highlightedContent:
     # Card
     - title: "Entity Framework Core (Tutorial)"
       itemType: learn
-      url: /learn/modules/persist-data-ef-core/
+      url: /training/modules/persist-data-ef-core/
       
     # Card
     - title: "SQLite overview"
@@ -133,7 +133,7 @@ additionalContent:
               text: "Overview"
             - url: /ef/core/get-started/overview/first-app
               text: "Create your first EF Core app"
-            - url: /learn/modules/persist-data-ef-core/
+            - url: /training/modules/persist-data-ef-core/
               text: "Learn: Persist and retrieve relational data with EF Core"
             - url: /ef/core/providers/
               text: "Supported databases"

--- a/entity-framework/ef6/fundamentals/performance/perf-whitepaper.md
+++ b/entity-framework/ef6/fundamentals/performance/perf-whitepaper.md
@@ -99,7 +99,7 @@ If you manually make edits to the schema files for the model, you will need to r
 
 You can also use EDMGen to generate views for an EDMX file - the previously referenced MSDN topic describes how to add a pre-build event to do this - but this is complicated and there are some cases where it isn't possible. It's generally easier to use a T4 template to generate the views when your model is in an edmx file.
 
-The ADO.NET team blog has a post that describes how to use a T4 template for view generation ( \<https://docs.microsoft.com/archive/blogs/adonet/how-to-use-a-t4-template-for-view-generation>). This post includes a template that can be downloaded and added to your project. The template was written for the first version of Entity Framework, so they aren’t guaranteed to work with the latest versions of Entity Framework. However, you can download a more up-to-date set of view generation templates for Entity Framework 4 and 5from the Visual Studio Gallery:
+The ADO.NET team blog has a post that describes how to use a T4 template for view generation ( \<https://learn.microsoft.com/archive/blogs/adonet/how-to-use-a-t4-template-for-view-generation>). This post includes a template that can be downloaded and added to your project. The template was written for the first version of Entity Framework, so they aren’t guaranteed to work with the latest versions of Entity Framework. However, you can download a more up-to-date set of view generation templates for Entity Framework 4 and 5from the Visual Studio Gallery:
 
 -   VB.NET: \<http://visualstudiogallery.msdn.microsoft.com/118b44f2-1b91-4de2-a584-7a680418941d>
 -   C\#: \<http://visualstudiogallery.msdn.microsoft.com/ae7730ce-ddab-470f-8456-1b313cd2c44d>
@@ -132,7 +132,7 @@ If you have a large Code First model, using Independent Associations will have t
 
 | When using      | Do this                                                                                                                                                                                                                                                                                                                              |
 |:----------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Entity Designer | After adding an association between two entities, make sure you have a referential constraint. Referential constraints tell Entity Framework to use Foreign Keys instead of Independent Associations. For additional details visit \<https://docs.microsoft.com/archive/blogs/efdesign/foreign-keys-in-the-entity-framework>. |
+| Entity Designer | After adding an association between two entities, make sure you have a referential constraint. Referential constraints tell Entity Framework to use Foreign Keys instead of Independent Associations. For additional details visit \<https://learn.microsoft.com/archive/blogs/efdesign/foreign-keys-in-the-entity-framework>. |
 | EDMGen          | When using EDMGen to generate your files from the database, your Foreign Keys will be respected and added to the model as such. For more information on the different options exposed by EDMGen visit [http://msdn.microsoft.com/library/bb387165.aspx](https://msdn.microsoft.com/library/bb387165.aspx).                           |
 | Code First      | See the "Relationship Convention" section of the [Code First Conventions](xref:ef6/modeling/code-first/conventions/built-in) topic for information on how to include foreign key properties on dependent objects when using Code First.                                                                                              |
 
@@ -391,7 +391,7 @@ The Entity Framework also supports Metadata caching. This is essentially caching
 4.  The ItemCollection is periodically checked for use. If it is determined that a workspace has not been accessed recently, it will be marked for cleanup on the next cache sweep.
 5.  Merely creating an EntityConnection will cause a metadata cache to be created (though the item collections in it will not be initialized until the connection is opened). This workspace will remain in-memory until the caching algorithm determines it is not “in use”.
 
-The Customer Advisory Team has written a blog post that describes holding a reference to an ItemCollection in order to avoid "deprecation" when using large models: \<https://docs.microsoft.com/archive/blogs/appfabriccat/holding-a-reference-to-the-ef-metadataworkspace-for-wcf-services>.
+The Customer Advisory Team has written a blog post that describes holding a reference to an ItemCollection in order to avoid "deprecation" when using large models: \<https://learn.microsoft.com/archive/blogs/appfabriccat/holding-a-reference-to-the-ef-metadataworkspace-for-wcf-services>.
 
 #### 3.4.2 The relationship between Metadata Caching and Query Plan Caching
 
@@ -406,7 +406,7 @@ This implementation of second-level caching is an injected functionality that ta
 #### 3.5.1 Additional references for results caching with the wrapping provider
 
 -   Julie Lerman has written a "Second-Level Caching in Entity Framework and Windows Azure" MSDN article that includes how to update the sample wrapping provider to use Windows Server AppFabric caching: [https://msdn.microsoft.com/magazine/hh394143.aspx](https://msdn.microsoft.com/magazine/hh394143.aspx)
--   If you are working with Entity Framework 5, the team blog has a post that describes how to get things running with the caching provider for Entity Framework 5: \<https://docs.microsoft.com/archive/blogs/adonet/ef-caching-with-jarek-kowalskis-provider>. It also includes a T4 template to help automate adding the 2nd-level caching to your project.
+-   If you are working with Entity Framework 5, the team blog has a post that describes how to get things running with the caching provider for Entity Framework 5: \<https://learn.microsoft.com/archive/blogs/adonet/ef-caching-with-jarek-kowalskis-provider>. It also includes a T4 template to help automate adding the 2nd-level caching to your project.
 
 ## 4 Autocompiled Queries
 
@@ -866,7 +866,7 @@ Another performance consideration when using Entity Framework is the inheritance
 
 If your model uses TPT inheritance, the queries which are generated will be more complex than those that are generated with the other inheritance strategies, which may result on longer execution times on the store.  It will generally take longer to generate queries over a TPT model, and to materialize the resulting objects.
 
-See the "Performance Considerations when using TPT (Table per Type) Inheritance in the Entity Framework" MSDN blog post: \<https://docs.microsoft.com/archive/blogs/adonet/performance-considerations-when-using-tpt-table-per-type-inheritance-in-the-entity-framework>.
+See the "Performance Considerations when using TPT (Table per Type) Inheritance in the Entity Framework" MSDN blog post: \<https://learn.microsoft.com/archive/blogs/adonet/performance-considerations-when-using-tpt-table-per-type-inheritance-in-the-entity-framework>.
 
 #### 7.1.1       Avoiding TPT in Model First or Code First applications
 
@@ -894,7 +894,7 @@ It's worth noting that when generating the SSDL, the load is almost entirely spe
 
 ### 7.3       Splitting Large Models with Database First and Model First
 
-As model size increases, the designer surface becomes cluttered and difficult to use. We typically consider a model with more than 300 entities to be too large to effectively use the designer. The following blog post describes several options for splitting large models: \<https://docs.microsoft.com/archive/blogs/adonet/working-with-large-models-in-entity-framework-part-2>.
+As model size increases, the designer surface becomes cluttered and difficult to use. We typically consider a model with more than 300 entities to be too large to effectively use the designer. The following blog post describes several options for splitting large models: \<https://learn.microsoft.com/archive/blogs/adonet/working-with-large-models-in-entity-framework-part-2>.
 
 The post was written for the first version of Entity Framework, but the steps still apply.
 
@@ -1241,9 +1241,9 @@ When choosing to use EDMX versus Code First, it’s important to know that the f
 
 ### 10.1 Using the Visual Studio Profiler
 
-If you are having performance issues with the Entity Framework, you can use a profiler like the one built into Visual Studio to see where your application is spending its time. This is the tool we used to generate the pie charts in the “Exploring the Performance of the ADO.NET Entity Framework - Part 1” blog post ( \<https://docs.microsoft.com/archive/blogs/adonet/exploring-the-performance-of-the-ado-net-entity-framework-part-1>) that show where Entity Framework spends its time during cold and warm queries.
+If you are having performance issues with the Entity Framework, you can use a profiler like the one built into Visual Studio to see where your application is spending its time. This is the tool we used to generate the pie charts in the “Exploring the Performance of the ADO.NET Entity Framework - Part 1” blog post ( \<https://learn.microsoft.com/archive/blogs/adonet/exploring-the-performance-of-the-ado-net-entity-framework-part-1>) that show where Entity Framework spends its time during cold and warm queries.
 
-The "Profiling Entity Framework using the Visual Studio 2010 Profiler" blog post written by the Data and Modeling Customer Advisory Team shows a real-world example of how they used the profiler to investigate a performance problem.  \<https://docs.microsoft.com/archive/blogs/dmcat/profiling-entity-framework-using-the-visual-studio-2010-profiler>. This post was written for a windows application. If you need to profile a web application the Windows Performance Recorder (WPR) and Windows Performance Analyzer (WPA) tools may work better than working from Visual Studio. WPR and WPA are part of the Windows Performance Toolkit which is included with the Windows Assessment and Deployment Kit.
+The "Profiling Entity Framework using the Visual Studio 2010 Profiler" blog post written by the Data and Modeling Customer Advisory Team shows a real-world example of how they used the profiler to investigate a performance problem.  \<https://learn.microsoft.com/archive/blogs/dmcat/profiling-entity-framework-using-the-visual-studio-2010-profiler>. This post was written for a windows application. If you need to profile a web application the Windows Performance Recorder (WPR) and Windows Performance Analyzer (WPA) tools may work better than working from Visual Studio. WPR and WPA are part of the Windows Performance Toolkit which is included with the Windows Assessment and Deployment Kit.
 
 ### 10.2 Application/Database profiling
 

--- a/entity-framework/index.yml
+++ b/entity-framework/index.yml
@@ -25,7 +25,7 @@ highlightedContent:
     # Card
     - title: "Persist and retrieve relational data with Entity Framework Core"
       itemType: learn
-      url: /learn/modules/persist-data-ef-core/
+      url: /training/modules/persist-data-ef-core/
     # Card
     - title: "Releases and platforms"
       itemType: whats-new

--- a/samples/end2end/PlanetaryDocs/README.md
+++ b/samples/end2end/PlanetaryDocs/README.md
@@ -35,10 +35,10 @@ git clone https://github.com/dotnet/EntityFramework.Docs
 
 ### Create an Azure Cosmos DB instance
 
-To run this demo, you will need to either run the [Azure Cosmos DB emulator](https://docs.microsoft.com/azure/cosmos-db/local-emulator)
+To run this demo, you will need to either run the [Azure Cosmos DB emulator](https://learn.microsoft.com/azure/cosmos-db/local-emulator)
 or create an Azure Cosmos DB account. You can read
-[Create an Azure Cosmos DB account](https://docs.microsoft.com/azure/cosmos-db/create-cosmosdb-resources-portal#create-an-azure-cosmos-db-account) to learn how. Be sure to check out the option
-for a [free account](https://docs.microsoft.com/azure/cosmos-db/optimize-dev-test#azure-cosmos-db-free-tier)!
+[Create an Azure Cosmos DB account](https://learn.microsoft.com/azure/cosmos-db/create-cosmosdb-resources-portal#create-an-azure-cosmos-db-account) to learn how. Be sure to check out the option
+for a [free account](https://learn.microsoft.com/azure/cosmos-db/optimize-dev-test#azure-cosmos-db-free-tier)!
 
 Choose the SQL API.
 


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

**DO NOT MERGE THIS PULL REQUEST WHILE IN DRAFT STATUS!** Some of the changes to links and other content are not valid until after go-live.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
