### PR TITLE
Add EF7 to releases page

### DIFF
--- a/entity-framework/core/what-is-new/index.md
+++ b/entity-framework/core/what-is-new/index.md
@@ -2,7 +2,7 @@
 title: EF Core releases and planning
 description: Current EF Core releases and schedule/planning details for future releases
 author: ajcvickers
-ms.date: 05/26/2022
+ms.date: 11/9/2022
 uid: core/what-is-new/index
 ---
 
@@ -10,17 +10,18 @@ uid: core/what-is-new/index
 
 ## Stable releases
 
-| Release                                                                                | Target framework  | Supported until           | Links |
-|:---------------------------------------------------------------------------------------|-------------------|---------------------------|-------|
-| [EF Core 6.0](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore)            | .NET 6            | November 8, 2024 (LTS)    | [What's new](xref:core/what-is-new/ef-core-6.0/whatsnew) / [Breaking changes](xref:core/what-is-new/ef-core-6.0/breaking-changes) |
-| ~~[EF Core 5.0](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/5.0.12)~~ | .NET Standard 2.1 | Expired May 10, 2022      | [Announcement](https://devblogs.microsoft.com/dotnet/announcing-the-release-of-ef-core-5-0/) / [Breaking changes](xref:core/what-is-new/ef-core-5.0/breaking-changes) |
-| [EF Core 3.1](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/3.1.21)     | .NET Standard 2.0 | December 3, 2022 (LTS)    | [Announcement](https://devblogs.microsoft.com/dotnet/announcing-entity-framework-core-3-1-and-entity-framework-6-4/) |
+| Release                                                                                | Target framework  | Supported until           | Links                                                                                                                                                                                  |
+|:---------------------------------------------------------------------------------------|-------------------|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [EF Core 7.0](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore)            | .NET 6            | May 14, 2024              | [What's new](xref:core/what-is-new/ef-core-7.0/whatsnew) / [Breaking changes](xref:core/what-is-new/ef-core-7.0/breaking-changes)                                                      |
+| [EF Core 6.0](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/6.0.11)     | .NET 6            | November 12, 2024 (LTS)   | [What's new](xref:core/what-is-new/ef-core-6.0/whatsnew) / [Breaking changes](xref:core/what-is-new/ef-core-6.0/breaking-changes)                                                      |
+| ~~[EF Core 5.0](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/5.0.17)~~ | .NET Standard 2.1 | Expired May 10, 2022      | [Announcement](https://devblogs.microsoft.com/dotnet/announcing-the-release-of-ef-core-5-0/) / [Breaking changes](xref:core/what-is-new/ef-core-5.0/breaking-changes)                  |
+| [EF Core 3.1](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/3.1.31)     | .NET Standard 2.0 | December 13, 2022 (LTS)   | [Announcement](https://devblogs.microsoft.com/dotnet/announcing-entity-framework-core-3-1-and-entity-framework-6-4/)                                                                   |
 | ~~[EF Core 3.0](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/3.0.3)~~  | .NET Standard 2.1 | Expired March 3, 2020     | [Announcement](https://devblogs.microsoft.com/dotnet/announcing-ef-core-3-0-and-ef-6-3-general-availability/) / [Breaking changes](xref:core/what-is-new/ef-core-3.x/breaking-changes) |
-| ~~[EF Core 2.2](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/2.2.6)~~  | .NET Standard 2.0 | Expired December 23, 2019 | [Announcement](https://devblogs.microsoft.com/dotnet/announcing-entity-framework-core-2-2/) |
-| ~~[EF Core 2.1](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/2.1.14)~~ | .NET Standard 2.0 | Expired August 21, 2021*  | [Announcement](https://devblogs.microsoft.com/dotnet/announcing-entity-framework-core-2-1/) |
-| ~~[EF Core 2.0](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/2.0.3)~~  | .NET Standard 2.0 | Expired October 1, 2018   | [Announcement](https://devblogs.microsoft.com/dotnet/announcing-entity-framework-core-2-0/) |
-| ~~[EF Core 1.1](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/1.1.6)~~  | .NET Standard 1.3 | Expired June 27 2019      | [Announcement](https://devblogs.microsoft.com/dotnet/announcing-entity-framework-core-1-1/) |
-| ~~[EF Core 1.0](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/1.0.6)~~  | .NET Standard 1.3 | Expired June 27 2019      | [Announcement](https://devblogs.microsoft.com/dotnet/entity-framework-core-1-0-0-available/) |
+| ~~[EF Core 2.2](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/2.2.6)~~  | .NET Standard 2.0 | Expired December 23, 2019 | [Announcement](https://devblogs.microsoft.com/dotnet/announcing-entity-framework-core-2-2/)                                                                                            |
+| ~~[EF Core 2.1](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/2.1.14)~~ | .NET Standard 2.0 | Expired August 21, 2021*  | [Announcement](https://devblogs.microsoft.com/dotnet/announcing-entity-framework-core-2-1/)                                                                                            |
+| ~~[EF Core 2.0](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/2.0.3)~~  | .NET Standard 2.0 | Expired October 1, 2018   | [Announcement](https://devblogs.microsoft.com/dotnet/announcing-entity-framework-core-2-0/)                                                                                            |
+| ~~[EF Core 1.1](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/1.1.6)~~  | .NET Standard 1.3 | Expired June 27 2019      | [Announcement](https://devblogs.microsoft.com/dotnet/announcing-entity-framework-core-1-1/)                                                                                            |
+| ~~[EF Core 1.0](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/1.0.6)~~  | .NET Standard 1.3 | Expired June 27 2019      | [Announcement](https://devblogs.microsoft.com/dotnet/entity-framework-core-1-0-0-available/)                                                                                           |
 
 See [supported platforms](xref:core/miscellaneous/platforms) for information about the specific platforms supported by each EF Core release.
 
@@ -42,8 +43,8 @@ Patch releases usually ship monthly, but have a long lead time. We are working t
 
 See the [release planning process](xref:core/what-is-new/release-planning) for more information on how we decide what to ship in each release. We typically don't do detailed planning for further out than the next major or minor release.
 
-## EF Core 7.0
+## EF Core 8.0
 
-The next planned stable release is **EF Core 7.0**, or just **EF7**, scheduled for **November 2022**.
+The next planned stable release is **EF Core 8.0**, or just **EF8**, scheduled for **November 2023**.
 
-See the [high-level plan for EF7](xref:core/what-is-new/ef-core-7.0/plan) for more information.
+[//]: # (See the [high-level plan for EF7]&#40;xref:core/what-is-new/ef-core-7.0/plan&#41; for more information.)


### PR DESCRIPTION
Also update supported dates to match latest dates on the .NET releases page.