### PR TITLE
Add the introduction to LessCode.EFCore.StronglyTypedId

### DIFF
--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -342,6 +342,14 @@ For EF Core: 6, 7.
 
 [GitHub repository](https://github.com/R4ND3LL/EntityFrameworkRuler/) | [CLI Tool NuGet](https://www.nuget.org/packages/EntityFrameworkRuler/) | [Design NuGet](https://www.nuget.org/packages/EntityFrameworkRuler.Design/)
 
+### LessCode.EFCore.StronglyTypedId
+
+A source generator that can generate strongly-typed-id classes automatically for entities.
+
+For EF Core: 7.
+
+[GitHub repository](https://github.com/yangzhongke/LessCode.EFCore.StronglyTypedId)
+
 ## API Integrations
 
 These packages are designed to integrate directly with EF Core to expose various APIs.

--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -344,9 +344,7 @@ For EF Core: 6, 7.
 
 ### LessCode.EFCore.StronglyTypedId
 
-A source generator that can generate strongly-typed-id classes automatically for entities.
-
-For EF Core: 7.
+A source generator that can generate strongly-typed-id classes automatically for entities. For EF Core: 7.
 
 [GitHub repository](https://github.com/yangzhongke/LessCode.EFCore.StronglyTypedId)
 


### PR DESCRIPTION
Add the introduction to LessCode.EFCore.StronglyTypedId

As proposed on [https://github.com/dotnet/EntityFramework.Docs/issues/4160#issuecomment-1327216363](https://github.com/dotnet/EntityFramework.Docs/issues/4160#issuecomment-1327216363)