### PR TITLE
Remove "minor releases" from the release planning page

### DIFF
--- a/entity-framework/core/what-is-new/release-planning.md
+++ b/entity-framework/core/what-is-new/release-planning.md
@@ -46,18 +46,6 @@ This bar gradually rises through the lifetime of a [long-term support (LTS)](htt
 
 The final decision about whether or not to patch an issue is made by the .NET Directors at Microsoft.
 
-### Minor releases
-
-Minor releases change only the "minor" part of the version.
-For example, EF Core 3.**1**.0 is a release that improves on EF Core 3.**0**.0.
-
-Minor releases:
-
-* Are intended to improve the quality and features of the previous release
-* Typically contain bug fixes and new features
-* Do not include intentional breaking changes
-* Have a few prerelease previews pushed to NuGet
-
 ### Major releases
 
 Major releases change the EF "major" version number.


### PR DESCRIPTION
We could also leave the section, saying that we don't do these, but it seems kinda useless.