### PR TITLE
Rename identifier in ThenInclude method (Cartesian explosion section)

### DIFF
--- a/entity-framework/core/querying/single-split-queries.md
+++ b/entity-framework/core/querying/single-split-queries.md
@@ -17,8 +17,8 @@ Let's examine the following LINQ query and its translated SQL equivalent:
 
 ```c#
 var blogs = ctx.Blogs
-    .Include(blog => blog.Posts)
-    .Include(blog => blog.Contributors)
+    .Include(b => b.Posts)
+    .Include(b => b.Contributors)
     .ToList();
 ```
 
@@ -36,8 +36,8 @@ Note that cartesian explosion does not occur when the two JOINs aren't at the sa
 
 ```c#
 var blogs = ctx.Blogs
-    .Include(blog => blog.Posts)
-    .ThenInclude(post => post.Comments)
+    .Include(b => b.Posts)
+    .ThenInclude(p => p.Comments)
     .ToList();
 ```
 
@@ -57,7 +57,7 @@ JOINs can have create another type of performance issue. Let's examine the follo
 
 ```c#
 var blogs = ctx.Blogs
-    .Include(blog => blog.Posts)
+    .Include(b => b.Posts)
     .ToList();
 ```
 
@@ -74,11 +74,11 @@ If you don't actually need the huge column, it's easy to simply not query for it
 
 ```c#
 var blogs = ctx.Blogs
-    .Select(blog => new
+    .Select(b => new
     {
-        blog.Id,
-        blog.Name,
-        blog.Posts
+        b.Id,
+        b.Name,
+        b.Posts
     })
     .ToList();
 ```

--- a/entity-framework/core/querying/single-split-queries.md
+++ b/entity-framework/core/querying/single-split-queries.md
@@ -17,8 +17,8 @@ Let's examine the following LINQ query and its translated SQL equivalent:
 
 ```c#
 var blogs = ctx.Blogs
-    .Include(b => b.Posts)
-    .Include(b => b.Contributors)
+    .Include(blog => blog.Posts)
+    .Include(blog => blog.Contributors)
     .ToList();
 ```
 
@@ -36,8 +36,8 @@ Note that cartesian explosion does not occur when the two JOINs aren't at the sa
 
 ```c#
 var blogs = ctx.Blogs
-    .Include(b => b.Posts)
-    .ThenInclude(b => b.Comments)
+    .Include(blog => blog.Posts)
+    .ThenInclude(post => post.Comments)
     .ToList();
 ```
 
@@ -57,7 +57,7 @@ JOINs can have create another type of performance issue. Let's examine the follo
 
 ```c#
 var blogs = ctx.Blogs
-    .Include(b => b.Posts)
+    .Include(blog => blog.Posts)
     .ToList();
 ```
 
@@ -74,11 +74,11 @@ If you don't actually need the huge column, it's easy to simply not query for it
 
 ```c#
 var blogs = ctx.Blogs
-    .Select(b => new
+    .Select(blog => new
     {
-        b.Id,
-        b.Name,
-        b.Posts
+        blog.Id,
+        blog.Name,
+        blog.Posts
     })
     .ToList();
 ```


### PR DESCRIPTION
Hi team,

This is my first contribution to such a big project. I hope that these changes will clarify and supplement the article.

1. Propose to rename variables from one letter style to the whole word. 'blog' and 'post' are not as long as they could be. By the way, another sections contain the whole word naming.
2. The main change is in the ThenInclude method. For some people, the letter "b" here can be confusing, so this modification should clarify that Comments is a collection navigation of Post type, not of Blog type.

Thank you in advance 😃