### PR TITLE
Clarify that both filtered include examples are valid

### DIFF
--- a/entity-framework/core/querying/related-data/eager.md
+++ b/entity-framework/core/querying/related-data/eager.md
@@ -60,7 +60,7 @@ Each included navigation allows only one unique set of filter operations. In cas
 
 [!code-csharp[Main](../../../../samples/core/Querying/RelatedData/Program.cs#MultipleLeafIncludesFiltered1)]
 
-Instead, identical operations can be applied for each navigation that is included multiple times:
+Alternatively, identical operations can be applied for each navigation that is included multiple times:
 
 [!code-csharp[Main](../../../../samples/core/Querying/RelatedData/Program.cs#MultipleLeafIncludesFiltered2)]
 


### PR DESCRIPTION
Previous wording made it sound like only the second example was the correct way to do things.