### PR TITLE
Complete the sample with the typed discriminator mapping

### DIFF
--- a/samples/core/Modeling/Inheritance/FluentAPI/NonShadowDiscriminator.cs
+++ b/samples/core/Modeling/Inheritance/FluentAPI/NonShadowDiscriminator.cs
@@ -12,8 +12,6 @@ public class MyContext : DbContext
         modelBuilder.Entity<Blog>()
             .HasDiscriminator(b => b.BlogType);
 
-        modelBuilder.Entity<Blog>()
-            .Property(e => e.BlogType)
 
         modelBuilder.Entity<RssBlog>()
             .HasMaxLength(200)

--- a/samples/core/Modeling/Inheritance/FluentAPI/NonShadowDiscriminator.cs
+++ b/samples/core/Modeling/Inheritance/FluentAPI/NonShadowDiscriminator.cs
@@ -12,10 +12,12 @@ public class MyContext : DbContext
         modelBuilder.Entity<Blog>()
             .HasDiscriminator(b => b.BlogType);
 
-
-        modelBuilder.Entity<RssBlog>()
+        modelBuilder.Entity<Blog>()
+            .Property(e => e.BlogType)
             .HasMaxLength(200)
             .HasColumnName("blog_type");
+            
+        modelBuilder.Entity<RssBlog>();
     }
     #endregion
 }

--- a/samples/core/Modeling/Inheritance/FluentAPI/NonShadowDiscriminator.cs
+++ b/samples/core/Modeling/Inheritance/FluentAPI/NonShadowDiscriminator.cs
@@ -10,8 +10,7 @@ public class MyContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<Blog>()
-            .HasDiscriminator(b => b.BlogType)
-            .HasValue<RssBlog>(BlogTypes.Rss);
+            .HasDiscriminator(b => b.BlogType);
 
         modelBuilder.Entity<Blog>()
             .Property(e => e.BlogType)

--- a/samples/core/Modeling/Inheritance/FluentAPI/NonShadowDiscriminator.cs
+++ b/samples/core/Modeling/Inheritance/FluentAPI/NonShadowDiscriminator.cs
@@ -10,7 +10,8 @@ public class MyContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<Blog>()
-            .HasDiscriminator(b => b.BlogType);
+            .HasDiscriminator(b => b.BlogType)
+            .HasValue<RssBlog>(BlogTypes.Rss);
 
         modelBuilder.Entity<Blog>()
             .Property(e => e.BlogType)

--- a/samples/core/Modeling/Inheritance/FluentAPI/NonShadowDiscriminator.cs
+++ b/samples/core/Modeling/Inheritance/FluentAPI/NonShadowDiscriminator.cs
@@ -15,6 +15,8 @@ public class MyContext : DbContext
 
         modelBuilder.Entity<Blog>()
             .Property(e => e.BlogType)
+
+        modelBuilder.Entity<RssBlog>();
             .HasMaxLength(200)
             .HasColumnName("blog_type");
     }

--- a/samples/core/Modeling/Inheritance/FluentAPI/NonShadowDiscriminator.cs
+++ b/samples/core/Modeling/Inheritance/FluentAPI/NonShadowDiscriminator.cs
@@ -15,7 +15,7 @@ public class MyContext : DbContext
         modelBuilder.Entity<Blog>()
             .Property(e => e.BlogType)
 
-        modelBuilder.Entity<RssBlog>();
+        modelBuilder.Entity<RssBlog>()
             .HasMaxLength(200)
             .HasColumnName("blog_type");
     }


### PR DESCRIPTION
The sample is missing a `HasValue` statement, which actually does the mapping. The `HasValue` statement is available for the sample with shadow mappings.

These docs will be changed by this PR: [Inheritance - Table per Hierarchy And Discriminator Configuration](https://learn.microsoft.com/en-us/ef/core/modeling/inheritance#table-per-hierarchy-and-discriminator-configuration)

This other sample using untyped mappings for the discriminator is using the `HasValue` statement correctly: [Sample with shadow mappings](https://github.com/dotnet/EntityFramework.Docs/blob/main/samples/core/Modeling/Inheritance/FluentAPI/DiscriminatorConfiguration.cs)