### PR TITLE
Update `samples/core/Saving/Transactions/SharingTransaction.cs`

### DIFF
--- a/samples/core/Saving/Transactions/SharingTransaction.cs
+++ b/samples/core/Saving/Transactions/SharingTransaction.cs
@@ -42,6 +42,7 @@ public class SharingTransaction
                 var blogs = context2.Blogs
                     .OrderBy(b => b.Url)
                     .ToList();
+                context2.SaveChanges();
             }
 
             // Commit transaction if all commands succeed, transaction will auto-rollback

--- a/samples/core/Saving/Transactions/SharingTransaction.cs
+++ b/samples/core/Saving/Transactions/SharingTransaction.cs
@@ -43,7 +43,7 @@ public class SharingTransaction
                     .OrderBy(b => b.Url)
                     .ToList();
                     
-                context1.Blogs.Add(new Blog { Url = "http://dot.net" });
+                context2.Blogs.Add(new Blog { Url = "http://dot.net" });
                 context2.SaveChanges();
             }
 

--- a/samples/core/Saving/Transactions/SharingTransaction.cs
+++ b/samples/core/Saving/Transactions/SharingTransaction.cs
@@ -42,6 +42,8 @@ public class SharingTransaction
                 var blogs = context2.Blogs
                     .OrderBy(b => b.Url)
                     .ToList();
+                    
+                context1.Blogs.Add(new Blog { Url = "http://dot.net" });
                 context2.SaveChanges();
             }
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/ef/core/saving/transactions#share-connection-and-transaction

User might forget to invoke `DbContext.SaveChanges()` on the derived contexts, like https://stackoverflow.com/questions/41020221/transaction-between-contexts/41020690#41020690