### PR TITLE
Remove dotnet-core metadata

### DIFF
--- a/samples/end2end/PlanetaryDocs/README.md
+++ b/samples/end2end/PlanetaryDocs/README.md
@@ -1,10 +1,9 @@
 ---
 page_type: sample
-description: "This repository is intended to showcase a full application that supports Create, Read, Update, and Delete operations (CRUD) using Blazor (Server), Entity Framework Core and Azure Cosmos DB."
+description: "This repository is intended to showcase a full application that supports Create, Read, Update, and Delete operations (CRUD) using Blazor (Server), Entity Framework Core, and Azure Cosmos DB."
 languages:
 - csharp
 products:
-- dotnet-core
 - ef-core
 - blazor
 - azure-cosmos-db


### PR DESCRIPTION
Since .NET Core is not the main technology focus for this sample, I removed it. Also, we're trying to retire the .NET Core label from the site experience.

Contributes to https://github.com/dotnet/docs/issues/35970