### PR TITLE
Fix breadcrumbs

### DIFF
--- a/entity-framework/breadcrumb/toc.yml
+++ b/entity-framework/breadcrumb/toc.yml
@@ -1,7 +1,14 @@
-- name: Docs
-  tocHref: /
-  topicHref: /
+- name: .NET
+  tocHref: /ef/
+  topicHref: /dotnet/index
   items:
   - name: Entity Framework
     tocHref: /ef/
-    topicHref: /ef/
+    topicHref: /ef/index
+    items:
+    - name: Entity Framework Core
+      tocHref: /ef/core/
+      topicHref: /ef/core/index
+    - name: Entity Framework 6
+      tocHref: /ef/ef6/
+      topicHref: /ef/ef6/index

--- a/entity-framework/docfx.json
+++ b/entity-framework/docfx.json
@@ -64,7 +64,6 @@
     ],
     "globalMetadata": {
       "breadcrumb_path": "/ef/breadcrumb/toc.json",
-      "extendBreadcrumb": true,
       "searchScope": [
         "Entity Framework"
       ],


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation.