### PR TITLE
Update execute-insert-update-delete.md

### DIFF
--- a/entity-framework/core/saving/execute-insert-update-delete.md
+++ b/entity-framework/core/saving/execute-insert-update-delete.md
@@ -210,6 +210,7 @@ In this code, we use a LINQ `Where` operator to apply an update to a specific Bl
 * While the SQL UPDATE and DELETE statements allow retrieving original column values for the rows affected, this isn't currently supported by `ExecuteUpdate` and `ExecuteDelete`.
 * Multiple invocations of these methods cannot be batched. Each invocation performs its own roundtrip to the database.
 * Databases typically allow only a single table to be modified with UPDATE or DELETE.
+* These methods can only be executed with relational database providers.
 
 ## Additional resources
 


### PR DESCRIPTION
Add limitation describing ExecuteUpdate and ExecuteDelete not working with non-relational database providers.

Based on answer here: https://stackoverflow.com/questions/74907256/ef-7-new-executedelete-and-executeupdate-methods-not-working-on-an-in-memory-d