### PR TITLE
Add efmig to Tools section

### DIFF
--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -58,6 +58,12 @@ IWAPI (Instant Web API) is a scaffolding engine for .NET Core that can automate 
 
 [Website](https://instantwebapi.com/)
 
+### efmig
+
+efmig is a multi-platform GUI application that speeds up daily development when working with Entity Framework Core. It covers the most popular use cases such as migration code and script generation with simple, one-click interface.
+
+[GitHub repository](https://github.com/stil/efmig)
+
 ## Extensions
 
 ### Microsoft.EntityFrameworkCore.AutoHistory

--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -60,7 +60,7 @@ IWAPI (Instant Web API) is a scaffolding engine for .NET Core that can automate 
 
 ### efmig
 
-efmig is a multi-platform GUI application that speeds up daily development when working with Entity Framework Core. It covers the most popular use cases such as migration code and script generation with simple, one-click interface.
+efmig is a multi-platform GUI application that speeds up daily development when working with Entity Framework Core. It covers the most popular use cases such as migration code and script generation with simple, one-click interface. For EF Core: 2-8.
 
 [GitHub repository](https://github.com/stil/efmig)
 


### PR DESCRIPTION
My proposal is to add [efmig](https://github.com/stil/efmig) to Tools section. 

I've been using it for my daily professional and personal work for more than 2 years now.
I've covered the most popular use cases such as creation of migrations code or generation of scripts as well as support for rollbacking.

It also plays well when working with different dotnet-ef/.NET Runtime/EF Core versions as it uses local versions for everything.
The additional advantage is that it allows to drop dependency on `Microsoft.EntityFrameworkCore.Design` in the project itself, it also works well with multiple DbContexts in the single .csproj

I believe the community would like to try out alternatives to the dotnet-ef CLI interface.