### PR TITLE
Update Extensions Version

### DIFF
--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -17,19 +17,19 @@ These tools and extensions provide additional functionality for Entity Framework
 
 ### EF Core Power Tools
 
-EF Core Power Tools is a Visual Studio extension that exposes various EF Core design-time tasks in a simple user interface. It includes reverse engineering of DbContext and entity classes from existing databases and [SQL Server DACPACs](/sql/relational-databases/data-tier-applications/data-tier-applications), management of database migrations, and model visualizations. For EF Core: 6, 7, 8.
+EF Core Power Tools is a Visual Studio extension that exposes various EF Core design-time tasks in a simple user interface. It includes reverse engineering of DbContext and entity classes from existing databases and [SQL Server DACPACs](/sql/relational-databases/data-tier-applications/data-tier-applications), management of database migrations, and model visualizations. For EF Core: 6-8.
 
 [GitHub wiki](https://github.com/ErikEJ/EFCorePowerTools/wiki)
 
 ### EF Core Power Tools CLI
 
-EF Core Power Tools CLI is a .NET global command line tool. It enables advanced reverse engineering of DbContext and entity classes from existing databases and [SQL Server DACPACs](/sql/relational-databases/data-tier-applications/data-tier-applications). For EF Core: 6, 7, 8.
+EF Core Power Tools CLI is a .NET global command line tool. It enables advanced reverse engineering of DbContext and entity classes from existing databases and [SQL Server DACPACs](/sql/relational-databases/data-tier-applications/data-tier-applications). For EF Core: 6-8.
 
 [GitHub readme](https://github.com/ErikEJ/EFCorePowerTools/blob/master/src/GUI/efcpt/readme.md)
 
 ### LLBLGen Pro
 
-LLBLGen Pro is an entity modeling solution with support for Entity Framework and Entity Framework Core. It lets you easily define your entity model and map it to your database, using database first or model first, so you can get started writing queries right away. For EF Core: 2-7.
+LLBLGen Pro is an entity modeling solution with support for Entity Framework and Entity Framework Core. It lets you easily define your entity model and map it to your database, using database first or model first, so you can get started writing queries right away. For EF Core: 2-8.
 
 [Website](https://www.llblgen.com/)
 
@@ -41,7 +41,7 @@ Entity Developer is a powerful O/RM designer for ADO.NET Entity Framework, NHibe
 
 ### DevMagic EF Core Sidekick
 
-EF Core Sidekick is a Visual Studio extension that enhances the power of auto code generation in Visual Studio. It provides a set of tools and templates for generating EF Core entities and derived DbContext from existing database, and then generating services and APIs from the entities. For EF Core: 6, 7.
+EF Core Sidekick is a Visual Studio extension that enhances the power of auto code generation in Visual Studio. It provides a set of tools and templates for generating EF Core entities and derived DbContext from existing database, and then generating services and APIs from the entities. For EF Core: 6-7.
 
 [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=devmagic.efsidekick) |
 [Website](https://www.devmagic.com/)
@@ -74,13 +74,13 @@ A plugin library that enables automatically recording the data changes performed
 
 ### EFCoreSecondLevelCacheInterceptor
 
-Second level caching is a query cache. The results of EF commands will be stored in the cache, so that the same EF commands will retrieve their data from the cache rather than executing them against the database again. For EF Core: 3-7.
+Second level caching is a query cache. The results of EF commands will be stored in the cache, so that the same EF commands will retrieve their data from the cache rather than executing them against the database again. For EF Core: 3-8.
 
 [GitHub repository](https://github.com/VahidN/EFCoreSecondLevelCacheInterceptor) | [NuGet](https://www.nuget.org/packages/EFCoreSecondLevelCacheInterceptor)
 
 ### EntityFrameworkCore.Scaffolding.Handlebars
 
-Allows customization of classes reverse engineered from an existing database using the Entity Framework Core tool chain with Handlebars templates. For EF Core: 2-7.
+Allows customization of classes reverse engineered from an existing database using the Entity Framework Core tool chain with Handlebars templates. For EF Core: 2-8.
 
 [GitHub repository](https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars) | [NuGet](https://www.nuget.org/packages/EntityFrameworkCore.Scaffolding.Handlebars)
 
@@ -92,7 +92,7 @@ NeinLinq extends LINQ providers such as Entity Framework to enable reusing funct
 
 ### EFCore.BulkExtensions
 
-EF Core extensions for Bulk operations (Insert, Update, Delete). For EF Core: 2-7.
+EF Core extensions for Bulk operations (Insert, Update, Delete). For EF Core: 2-8.
 
 [GitHub repository](https://github.com/borisdj/EFCore.BulkExtensions) | [NuGet](https://www.nuget.org/packages/EFCore.BulkExtensions)
 
@@ -104,25 +104,25 @@ Adds design-time pluralization. For EF Core: 2-8.
 
 ### Verify.EntityFramework
 
-Extends [Verify](https://github.com/VerifyTests/Verify) to allow snapshot testing with Entity Framework. For EF Core: 3-7.
+Extends [Verify](https://github.com/VerifyTests/Verify) to allow snapshot testing with Entity Framework. For EF Core: 3-8.
 
 [GitHub repository](https://github.com/VerifyTests/Verify.EntityFramework) | [NuGet](https://www.nuget.org/packages/Verify.EntityFramework)
 
 ### LocalDb
 
-Provides a wrapper around [SQL Server Express LocalDB](/sql/database-engine/configure-windows/sql-server-express-localdb) to simplify running tests against Entity Framework. For EF Core: 3-7.
+Provides a wrapper around [SQL Server Express LocalDB](/sql/database-engine/configure-windows/sql-server-express-localdb) to simplify running tests against Entity Framework. For EF Core: 3-8.
 
 [GitHub repository](https://github.com/SimonCropp/LocalDb) | [NuGet](https://www.nuget.org/packages/EfLocalDb)
 
 ### EntityFrameworkCore.Projectables
 
-Flexible projection magic for EF Core. Use properties, methods, and extension methods in your query without client evaluation. For EF Core: 3, 5, 6.
+Flexible projection magic for EF Core. Use properties, methods, and extension methods in your query without client evaluation. For EF Core: 3-6.
 
 [GitHub repository](https://github.com/koenbeuk/EntityFrameworkCore.Projectables) | [NuGet](https://www.nuget.org/packages/EntityFrameworkCore.Projectables)
 
 ### EntityFrameworkCore.Triggered
 
-Triggers for EF Core. Respond to changes in your DbContext before and after they are committed to the database. Triggers are fully asynchronous and support dependency injection, inheritance, cascading and more. For EF Core: 3, 5, 6.
+Triggers for EF Core. Respond to changes in your DbContext before and after they are committed to the database. Triggers are fully asynchronous and support dependency injection, inheritance, cascading and more. For EF Core: 3-6.
 
 [GitHub repository](https://github.com/koenbeuk/EntityFrameworkCore.Triggered) | [NuGet](https://www.nuget.org/packages/EntityFrameworkCore.Triggered)
 
@@ -140,13 +140,13 @@ Extends your DbContext with high-performance bulk operations: BulkSaveChanges, B
 
 ### Expressionify
 
-Add support for calling extension methods in LINQ lambdas. For EF Core: 3, 5, 6.
+Add support for calling extension methods in LINQ lambdas. For EF Core: 3-6.
 
 [GitHub repository](https://github.com/ClaveConsulting/Expressionify) | [NuGet](https://www.nuget.org/packages/Clave.Expressionify)
 
 ### EntityLinq
 
-Alternative (not MS based) Language Integrated Query (LINQ) technology for relational databases. It allows you to use C# to write strongly typed SQL queries. For EF Core: 3, 5, 6.
+Alternative (not MS based) Language Integrated Query (LINQ) technology for relational databases. It allows you to use C# to write strongly typed SQL queries. For EF Core: 3-6.
 
 - Full C# support for query creation: multiple statements inside lambda, variables, functions, etc.
 - No semantic gap with SQL. EntityLinq declares SQL statements (like `SELECT`, `FROM`, `WHERE`) as first class C# methods, combining familiar syntax with intellisense, type safety and refactoring.
@@ -169,7 +169,7 @@ This plugin allows you to opt into some check constraints - just activate it and
 
 ### SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime
 
-Adds native support to EntityFrameworkCore for SQL Server for the NodaTime types. For EF Core: 3-7.
+Adds native support to EntityFrameworkCore for SQL Server for the NodaTime types. For EF Core: 3-8.
 
 [GitHub repository](https://github.com/StevenRasmussen/EFCore.SqlServer.NodaTime) | [NuGet](https://www.nuget.org/packages/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime)
 
@@ -181,7 +181,7 @@ Adds hierarchyid support to the SQL Server EF Core provider. For EF Core: 3-7.
 
 ### linq2db.EntityFrameworkCore
 
-Alternative translator of LINQ queries to SQL expressions. For EF Core: 2-7.
+Alternative translator of LINQ queries to SQL expressions. For EF Core: 2-8.
 
 Includes support for advanced SQL features such as CTEs, bulk copy, table hints, windowed functions, temporary tables, and database-side create/update/delete operations.
 
@@ -189,7 +189,7 @@ Includes support for advanced SQL features such as CTEs, bulk copy, table hints,
 
 ### EFCore.SoftDelete
 
-An implementation for soft deleting entities. For EF Core: 3, 5, 6.
+An implementation for soft deleting entities. For EF Core: 3-6.
 
 [GitHub repository](https://github.com/AshkanAbd/efCoreSoftDeletes) | [NuGet](https://www.nuget.org/packages/EFCore.SoftDelete)
 
@@ -201,37 +201,37 @@ Extends EF Core to resolve connection strings from App.config. For EF Core: 3-8.
 
 ### Detached Mapper
 
-A DTO-Entity mapper with composition/aggregation handling (similar to GraphDiff). For EF Core: 3, 5, 6.
+A DTO-Entity mapper with composition/aggregation handling (similar to GraphDiff). For EF Core: 3-7.
 
 [GitHub repository](https://github.com/leonardoporro/Detached-Mapper) | [NuGet](https://www.nuget.org/packages/Detached.Mappers.EntityFramework)
 
 ### EntityFrameworkCore.Sqlite.NodaTime
 
-Adds support for [NodaTime](https://nodatime.org) types when using [SQLite](https://sqlite.org). For EF Core: 5, 6, 7.
+Adds support for [NodaTime](https://nodatime.org) types when using [SQLite](https://sqlite.org). For EF Core: 5-8.
 
 [GitHub repository](https://github.com/khellang/EFCore.Sqlite.NodaTime) | [NuGet](https://www.nuget.org/packages/EntityFrameworkCore.Sqlite.NodaTime)
 
 ### ErikEJ.EntityFrameworkCore.SqlServer.Dacpac
 
-Enables reverse engineering an EF Core model from a SQL Server data-tier application package (.dacpac). For EF Core: 6, 7.
+Enables reverse engineering an EF Core model from a SQL Server data-tier application package (.dacpac). For EF Core: 6-8.
 
 [GitHub repository](https://github.com/ErikEJ/EFCorePowerTools/tree/master/src/GUI/ErikEJ.EntityFrameworkCore.SqlServer.Dacpac) | [NuGet](https://www.nuget.org/packages/ErikEJ.EntityFrameworkCore.SqlServer.Dacpac)
 
 ### ErikEJ.EntityFrameworkCore.DgmlBuilder
 
-Generate DGML (Graph) content that visualizes your DbContext. Adds the AsDgml() extension method to the DbContext class. For EF Core: 6, 7.
+Generate DGML (Graph) content that visualizes your DbContext. Adds the AsDgml() extension method to the DbContext class. For EF Core: 6-7.
 
 [GitHub repository](https://github.com/ErikEJ/EFCorePowerTools/tree/master/src/GUI/ErikEJ.EntityFrameworkCore.DgmlBuilder) | [NuGet](https://www.nuget.org/packages/ErikEJ.EntityFrameworkCore.DgmlBuilder)
 
 ### ErikEJ.EntityFrameworkCore.SqlServer.SqlQuery
 
-Provides the `SqlQueryAsync<T>` and `SqlQueryValueAsync<T>` methods to help you populate arbitrary classes or a list of primitive types from a raw SQL query. For EF Core: 6, 7.
+Provides the `SqlQueryAsync<T>` and `SqlQueryValueAsync<T>` methods to help you populate arbitrary classes or a list of primitive types from a raw SQL query. For EF Core: 6-7.
 
 [GitHub repository](https://github.com/ErikEJ/EFCorePowerTools/tree/master/src/GUI/ErikEJ.EntityFrameworkCore.6.SqlServer.SqlQuery) | [NuGet](https://www.nuget.org/packages/ErikEJ.EntityFrameworkCore.SqlServer.SqlQuery)
 
 ### ErikEJ.EntityFrameworkCore.SqlServer.DateOnlyTimeOnly
 
-Use the `DateOnly` and `TimeOnly` .NET types with the EF Core SQL Server provider. For EF Core: 6, 7.
+Use the `DateOnly` and `TimeOnly` .NET types with the EF Core SQL Server provider. For EF Core: 6-7.
 
 [GitHub repository](https://github.com/ErikEJ/EFCore.SqlServer.DateOnlyTimeOnly) | [NuGet](https://www.nuget.org/packages/ErikEJ.EntityFrameworkCore.SqlServer.DateOnlyTimeOnly)
 
@@ -239,25 +239,25 @@ Use the `DateOnly` and `TimeOnly` .NET types with the EF Core SQL Server provide
 
 When using Entity Framework Core all database exceptions are wrapped in DbUpdateException. EntityFramework.Exceptions handles all the database-specific details to find which constraint was violated and allows you to use typed exceptions such as `UniqueConstraintException`, `CannotInsertNullException`, `MaxLengthExceededException`, `NumericOverflowException`, `ReferenceConstraintException` when your query violates database constraints.
 
-Supports SQL Server, Postgres, MySql, SQLite and Oracle. For EF Core: 3, 5, 6.
+Supports SQL Server, Postgres, MySql, SQLite and Oracle. For EF Core: 3-6.
 
 [GitHub Repository](https://github.com/Giorgi/EntityFramework.Exceptions)
 
 ### EntityFrameworkCore.FSharp
 
-Adds F# design-time support to EF Core. For EF Core: 5, 6.
+Adds F# design-time support to EF Core. For EF Core: 5-6.
 
 [GitHub repository](https://github.com/efcore/EFCore.FSharp) | [NuGet](https://www.nuget.org/packages/EntityFrameworkCore.FSharp)
 
 ### EntityFrameworkCore.VisualBasic
 
-Adds VB design-time support to EF Core. For EF Core: 5, 6, 7.
+Adds VB design-time support to EF Core. For EF Core: 5-7.
 
 [GitHub repository](https://github.com/efcore/EFCore.VisualBasic) | [NuGet](https://www.nuget.org/packages/EntityFrameworkCore.VisualBasic)
 
 ### Krzysztofz01.EFCore.QueryFilterBuilder
 
-Extension for Entity Framework that allows you to create and manage multiple query filters. For EF Core: 5, 6, 7.
+Extension for Entity Framework that allows you to create and manage multiple query filters. For EF Core: 5-7.
 
 [GitHub repository](https://github.com/Krzysztofz01/EFCore.QueryFilterBuilder)
 
@@ -270,19 +270,19 @@ It also has many useful features commonly used especially on web development. Fo
 
 ### Laraue.EfCoreTriggers
 
-Fluent API to declare triggers in `Context.OnModelCreating` which are later built into migrations. Providers to Postgres, MySQL, SQL Server and SQLite. For EF Core: 5, 6, 7.
+Fluent API to declare triggers in `Context.OnModelCreating` which are later built into migrations. Providers to Postgres, MySQL, SQL Server and SQLite. For EF Core: 5-8.
 
 [GitHub repository](https://github.com/win7user10/Laraue.EfCoreTriggers) | [NuGet](https://www.nuget.org/packages/Laraue.EfCoreTriggers.Common)
 
 ### EntityCloner.Microsoft.EntityFrameworkCore
 
-Cloning entities using EF Core configuration. You can use the `Include` method to specify related data to be cloned. For EF Core: 5, 6, 7.
+Cloning entities using EF Core configuration. You can use the `Include` method to specify related data to be cloned. For EF Core: 5-7.
 
 [GitHub repository](https://github.com/HenkKin/EntityCloner.Microsoft.EntityFrameworkCore) | [NuGet](https://www.nuget.org/packages/EntityCloner.Microsoft.EntityFrameworkCore)
 
 ### Zomp EF Core Extensions
 
-Provides window (analytics) functions and binary functions for EF Core. Providers: SQL Server, SQLite, PostgreSQL. For EF Core: 6, 7.
+Provides window (analytics) functions and binary functions for EF Core. Providers: SQL Server, SQLite, PostgreSQL. For EF Core: 6-8.
 
 [GitHub repository](https://github.com/zompinc/efcore-extensions) | [NuGet](https://www.nuget.org/packages/Zomp.EFCore.WindowFunctions.SqlServer)
 
@@ -293,7 +293,7 @@ Extension for EF Core that provides alternative `Include` syntax in order to bet
 - Loading multiple entities on the same level (siblings).
 - Writing extension methods that are independent of nesting level.
 
-For EF Core: 6, 7.
+For EF Core: 6-7.
 
 [GitHub repository](https://github.com/AinoraZ/EFCore.IncludeBuilder) | [NuGet](https://www.nuget.org/packages/Ainoraz.EFCore.IncludeBuilder/)
 
@@ -306,7 +306,7 @@ Adds design-time customization of the reverse engineered model including:
 - Overriding property types, especially for enums.
 - EF6 EDMX support, providing a smooth 3-step upgrade path from EF6 to EF Core.
 
-For EF Core: 6, 7.
+For EF Core: 6-8.
 
 [GitHub repository](https://github.com/R4ND3LL/EntityFrameworkRuler/) | [CLI Tool NuGet](https://www.nuget.org/packages/EntityFrameworkRuler/) | [Design NuGet](https://www.nuget.org/packages/EntityFrameworkRuler.Design/)
 
@@ -334,13 +334,13 @@ Build your own GraphQL endpoint on top of any resource.
 
 ### GraphQL.EntityFramework
 
-Add Entity Framework `IQueryable` support to GraphQL. For EF Core: 6, 7.
+Add Entity Framework `IQueryable` support to GraphQL. For EF Core: 6-8.
 
 [GitHub repository](https://github.com/SimonCropp/GraphQL.EntityFramework) | [NuGet](https://www.nuget.org/packages/GraphQL.EntityFramework/)
 
 ### EntityGraphQL
 
-GraphQL server with tight EntityFramework integration. For EF Core: 5, 6, 7.
+GraphQL server with tight EntityFramework integration. For EF Core: 5-7.
 
 [GitHub repository](https://github.com/EntityGraphQL/EntityGraphQL) | [NuGet](https://www.nuget.org/packages/EntityGraphQL)
 
@@ -360,13 +360,13 @@ An O/RM that creates strongly-typed, extendable classes for Entity Framework. Th
 
 ### Microsoft.EntityFrameworkCore.UnitOfWork
 
-A plugin for Microsoft.EntityFrameworkCore to support repository, unit of work patterns, and multiple databases with distributed transaction supported. For EF Core: 2, 3.
+A plugin for Microsoft.EntityFrameworkCore to support repository, unit of work patterns, and multiple databases with distributed transaction supported. For EF Core: 2-3.
 
 [GitHub repository](https://github.com/Arch/UnitOfWork)
 
 ### Toolbelt.EntityFrameworkCore.IndexAttribute
 
-Revival of [Index] attribute (with extension for model building). For EF Core: 2, 3, 5.
+Revival of [Index] attribute (with extension for model building). For EF Core: 2-5.
 
 [GitHub repository](https://github.com/jsakamoto/EntityFrameworkCore.IndexAttribute) | [NuGet](https://www.nuget.org/packages/Toolbelt.EntityFrameworkCore.IndexAttribute)
 
@@ -375,7 +375,7 @@ Revival of [Index] attribute (with extension for model building). For EF Core: 2
 > [!NOTE]
 > SQL Server temporal tables are supported directly within EF Core as of [EF Core 6](/ef/core/what-is-new/ef-core-6.0/whatsnew#sql-server-temporal-tables).
 
-Easily perform temporal queries on your favorite database using introduced extension methods: `AsTemporalAll()`, `AsTemporalAsOf(date)`, `AsTemporalFrom(startDate, endDate)`, `AsTemporalBetween(startDate, endDate)`, `AsTemporalContained(startDate, endDate)`. For EF Core: 3, 5.
+Easily perform temporal queries on your favorite database using introduced extension methods: `AsTemporalAll()`, `AsTemporalAsOf(date)`, `AsTemporalFrom(startDate, endDate)`, `AsTemporalBetween(startDate, endDate)`, `AsTemporalContained(startDate, endDate)`. For EF Core: 3-5.
 
 [GitHub repository](https://github.com/glautrou/EfCoreTemporalTable) | [NuGet](https://www.nuget.org/packages/EfCoreTemporalTable)
 
@@ -384,7 +384,7 @@ Easily perform temporal queries on your favorite database using introduced exten
 > [!NOTE]
 > SQL Server temporal tables are supported directly within EF Core as of [EF Core 6](/ef/core/what-is-new/ef-core-6.0/whatsnew#sql-server-temporal-tables).
 
-Extension library for Entity Framework Core which allows developers who use SQL Server to easily use temporal tables. For EF Core: 2, 3, 5.
+Extension library for Entity Framework Core which allows developers who use SQL Server to easily use temporal tables. For EF Core: 2-5.
 
 [GitHub repository](https://github.com/findulov/EntityFrameworkCore.TemporalTables) | [NuGet](https://www.nuget.org/packages/EntityFrameworkCore.TemporalTables)
 
@@ -399,12 +399,12 @@ LINQ extensions to Entity Framework Core 3.1 to support Microsoft SQL Server Tem
 
 ### EntityFrameworkCore.NCache
 
-NCache Entity Framework Core Provider is a distributed second level cache provider for caching query results. The distributed architecture of NCache makes it more scalable and highly available. For EF Core: 2, 3.
+NCache Entity Framework Core Provider is a distributed second level cache provider for caching query results. The distributed architecture of NCache makes it more scalable and highly available. For EF Core: 2-3.
 
 [Website](https://www.alachisoft.com/ncache/ef-core-cache.html) | [NuGet](https://www.nuget.org/packages/EntityFrameworkCore.NCache)
 
 ### Ramses
 
-Life cycle hooks (for SaveChanges). For EF Core: 2, 3.
+Life cycle hooks (for SaveChanges). For EF Core: 2-3.
 
 [GitHub repository](https://github.com/JValck/Ramses) | [NuGet](https://www.nuget.org/packages/Ramses)

--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -201,7 +201,7 @@ Extends EF Core to resolve connection strings from App.config. For EF Core: 3-8.
 
 ### Detached Mapper
 
-A DTO-Entity mapper with composition/aggregation handling (similar to GraphDiff). For EF Core: 3-7.
+A DTO-Entity mapper with composition/aggregation handling (similar to GraphDiff). For EF Core: 3-6.
 
 [GitHub repository](https://github.com/leonardoporro/Detached-Mapper) | [NuGet](https://www.nuget.org/packages/Detached.Mappers.EntityFramework)
 


### PR DESCRIPTION
In this pull:

- Updated all versions to use "For EF Core: [minVersion]-[maxVersion]" whenever there is more than 1 version
   - NOTE: I didn't touch on version for 
- Updated all [maxVersion] that I could find if EF Core 8 is supported or not (Some other packages probably support it, but if there was not a clear dependency, I didn't touch them)