### PR TITLE
no more HashSet<T> in ctor

### DIFF
--- a/entity-framework/core/managing-schemas/scaffolding/index.md
+++ b/entity-framework/core/managing-schemas/scaffolding/index.md
@@ -230,6 +230,7 @@ public partial class Post
     public DateTime? _2DeletedOn { get; set; }
     public int BlogId { get; set; }
     public virtual Blog Blog { get; set; } = null!;
+    public virtual ICollection<Tag> Tags { get; set; } = new List<Tag>();
 }
 ```
 
@@ -400,7 +401,7 @@ public partial class Post
 
     public virtual Blog Blog { get; set; } = null!;
 
-    public virtual ICollection<Tag> Tags { get; set; }
+    public virtual ICollection<Tag> Tags { get; set; } = new List<Tag>();
 }
 -->
 [!code-csharp[Post](../../../../samples/core/Miscellaneous/NewInEFCore6/ScaffoldingSample.cs?name=Post)]
@@ -446,7 +447,7 @@ public partial class Post
 
     public virtual Blog Blog { get; set; } = null!;
 
-    public virtual ICollection<Tag> Tags { get; set; }
+    public virtual ICollection<Tag> Tags { get; set; } = new List<Tag>();
 }
 -->
 [!code-csharp[Post](../../../../samples/core/Miscellaneous/NewInEFCore6/ScaffoldingSample.cs?name=Post)]
@@ -460,7 +461,7 @@ And a class for Tag:
         public string Name { get; set; } = null!;
         public string? Description { get; set; }
 
-        public virtual ICollection<Post> Posts { get; set; }
+        public virtual ICollection<Post> Posts { get; set; } = new List<Post>();
     }
 -->
 [!code-csharp[Tag](../../../../samples/core/Miscellaneous/NewInEFCore6/ScaffoldingSample.cs?name=Tag)]


### PR DESCRIPTION
the collection is now initialised in the nav member as List<T> and not as HashSet<T> in the ctor

IMHO the ICollection<T> abstraction is also pointless as you lose out on specifics like Count property [having to invoke the expensive Count() method instead]. Yes I agree there is T4 sophistication for experts but novices should fall into the pit of success.