### PR TITLE
Update generated-properties.md

### DIFF
--- a/entity-framework/core/modeling/generated-properties.md
+++ b/entity-framework/core/modeling/generated-properties.md
@@ -95,16 +95,11 @@ AS
 BEGIN
     SET NOCOUNT ON;
 
-    IF ((SELECT TRIGGER_NESTLEVEL()) > 1) RETURN;
-
-    DECLARE @Id INT
-
-    SELECT @Id = INSERTED.BlogId
-    FROM INSERTED
-
-    UPDATE dbo.Blogs
+    UPDATE B
     SET LastUpdated = GETDATE()
-    WHERE BlogId = @Id
+    FROM dbo.Blogs AS B
+    INNER JOIN INSERTED AS I
+        ON B.BlogId = I.BlogId
 END
 ```
 


### PR DESCRIPTION
The previous trigger example  had a major flaw in it as it assumes the update can only work on a single row, where as in the real world, SQL Server triggers are statemet-based, not row-based, meaning that the inserted (or deleted) auto-generated table can contain multiple rows.

I've changed the trigger example to a trigger that will not break in multiple-rows update statements.