### PR TITLE
Update generated-properties.md

### DIFF
--- a/entity-framework/core/modeling/generated-properties.md
+++ b/entity-framework/core/modeling/generated-properties.md
@@ -97,14 +97,11 @@ BEGIN
 
     IF ((SELECT TRIGGER_NESTLEVEL()) > 1) RETURN;
 
-    DECLARE @Id INT
-
-    SELECT @Id = INSERTED.BlogId
-    FROM INSERTED
-
-    UPDATE dbo.Blogs
+    UPDATE B
     SET LastUpdated = GETDATE()
-    WHERE BlogId = @Id
+    FROM dbo.Blogs AS B
+    INNER JOIN INSERTED AS I
+        ON B.BlogId = I.BlogId
 END
 ```
 


### PR DESCRIPTION
The previous trigger example had a major flaw in it as it assumes the update can only work on a single row, where as in the real world, SQL Server triggers are statement-based, not row-based, meaning that the inserted (or deleted) auto-generated table can contain multiple rows.

I've changed the trigger example to a trigger that will not break in multiple-rows update statements.

Related Issue: [SQL Trigger example is wrong #4604](https://github.com/dotnet/EntityFramework.Docs/issues/4604) 
