### PR TITLE
Replaced new() with []

### DIFF
--- a/samples/core/Modeling/Relationships/ManyToMany.cs
+++ b/samples/core/Modeling/Relationships/ManyToMany.cs
@@ -34,13 +34,13 @@ public class ManyToMany
         public class Post
         {
             public int Id { get; set; }
-            public List<Tag> Tags { get; } = new();
+            public List<Tag> Tags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
-            public List<Post> Posts { get; } = new();
+            public List<Post> Posts { get; } = [];
         }
         #endregion
 
@@ -105,7 +105,7 @@ public class ManyToMany
         public class Post
         {
             public int Id { get; set; }
-            public List<Tag> Tags { get; } = new();
+            public List<Tag> Tags { get; } = [];
         }
 
         public class Tag
@@ -172,13 +172,13 @@ public class ManyToMany
         public class Post
         {
             public int Id { get; set; }
-            public List<Tag> Tags { get; } = new();
+            public List<Tag> Tags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
-            public List<Post> Posts { get; } = new();
+            public List<Post> Posts { get; } = [];
         }
         #endregion
 
@@ -244,13 +244,13 @@ public class ManyToMany
         public class Post
         {
             public int Id { get; set; }
-            public List<Tag> Tags { get; } = new();
+            public List<Tag> Tags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
-            public List<Post> Posts { get; } = new();
+            public List<Post> Posts { get; } = [];
         }
         #endregion
 
@@ -336,13 +336,13 @@ public class ManyToMany
         public class Post
         {
             public int Id { get; set; }
-            public List<Tag> Tags { get; } = new();
+            public List<Tag> Tags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
-            public List<Post> Posts { get; } = new();
+            public List<Post> Posts { get; } = [];
         }
 
         public class PostTag
@@ -429,15 +429,15 @@ public class ManyToMany
         public class Post
         {
             public int Id { get; set; }
-            public List<Tag> Tags { get; } = new();
-            public List<PostTag> PostTags { get; } = new();
+            public List<Tag> Tags { get; } = [];
+            public List<PostTag> PostTags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
-            public List<Post> Posts { get; } = new();
-            public List<PostTag> PostTags { get; } = new();
+            public List<Post> Posts { get; } = [];
+            public List<PostTag> PostTags { get; } = [];
         }
 
         public class PostTag
@@ -524,15 +524,15 @@ public class ManyToMany
         public class Post
         {
             public int Id { get; set; }
-            public List<Tag> Tags { get; } = new();
-            public List<PostTag> PostTags { get; } = new();
+            public List<Tag> Tags { get; } = [];
+            public List<PostTag> PostTags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
-            public List<Post> Posts { get; } = new();
-            public List<PostTag> PostTags { get; } = new();
+            public List<Post> Posts { get; } = [];
+            public List<PostTag> PostTags { get; } = [];
         }
 
         public class PostTag
@@ -618,15 +618,15 @@ public class ManyToMany
         public class Post
         {
             public int Id { get; set; }
-            public List<Tag> Tags { get; } = new();
-            public List<PostTag> PostTags { get; } = new();
+            public List<Tag> Tags { get; } = [];
+            public List<PostTag> PostTags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
-            public List<Post> Posts { get; } = new();
-            public List<PostTag> PostTags { get; } = new();
+            public List<Post> Posts { get; } = [];
+            public List<PostTag> PostTags { get; } = [];
         }
 
         public class PostTag
@@ -700,14 +700,14 @@ public class ManyToMany
         {
             public int Id { get; set; }
             public int AlternateKey { get; set; }
-            public List<Tag> Tags { get; } = new();
+            public List<Tag> Tags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
             public int AlternateKey { get; set; }
-            public List<Post> Posts { get; } = new();
+            public List<Post> Posts { get; } = [];
         }
         #endregion
 
@@ -773,16 +773,16 @@ public class ManyToMany
         {
             public int Id { get; set; }
             public int AlternateKey { get; set; }
-            public List<Tag> Tags { get; } = new();
-            public List<PostTag> PostTags { get; } = new();
+            public List<Tag> Tags { get; } = [];
+            public List<PostTag> PostTags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
             public int AlternateKey { get; set; }
-            public List<Post> Posts { get; } = new();
-            public List<PostTag> PostTags { get; } = new();
+            public List<Post> Posts { get; } = [];
+            public List<PostTag> PostTags { get; } = [];
         }
 
         public class PostTag
@@ -855,13 +855,13 @@ public class ManyToMany
         public class Post
         {
             public int Id { get; set; }
-            public List<Tag> Tags { get; } = new();
+            public List<Tag> Tags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
-            public List<Post> Posts { get; } = new();
+            public List<Post> Posts { get; } = [];
         }
 
         public class PostTag
@@ -931,13 +931,13 @@ public class ManyToMany
         public class Post
         {
             public int Id { get; set; }
-            public List<Tag> Tags { get; } = new();
+            public List<Tag> Tags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
-            public List<Post> Posts { get; } = new();
+            public List<Post> Posts { get; } = [];
         }
         #endregion
 
@@ -1009,15 +1009,15 @@ public class ManyToMany
         public class Post
         {
             public int Id { get; set; }
-            public List<Tag> Tags { get; } = new();
-            public List<PostTag> PostTags { get; } = new();
+            public List<Tag> Tags { get; } = [];
+            public List<PostTag> PostTags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
-            public List<Post> Posts { get; } = new();
-            public List<PostTag> PostTags { get; } = new();
+            public List<Post> Posts { get; } = [];
+            public List<PostTag> PostTags { get; } = [];
         }
 
         public class PostTag
@@ -1092,13 +1092,13 @@ public class ManyToMany
         public class Post
         {
             public int Id { get; set; }
-            public List<Tag> Tags { get; } = new();
+            public List<Tag> Tags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
-            public List<Post> Posts { get; } = new();
+            public List<Post> Posts { get; } = [];
         }
         #endregion
 
@@ -1163,8 +1163,8 @@ public class ManyToMany
         public class Person
         {
             public int Id { get; set; }
-            public List<Person> Parents { get; } = new();
-            public List<Person> Children { get; } = new();
+            public List<Person> Parents { get; } = [];
+            public List<Person> Children { get; } = [];
         }
         #endregion
 
@@ -1221,7 +1221,7 @@ public class ManyToMany
         public class Person
         {
             public int Id { get; set; }
-            public List<Person> Friends { get; } = new();
+            public List<Person> Friends { get; } = [];
         }
         #endregion
 
@@ -1282,29 +1282,29 @@ public class ManyToMany
         public class Post
         {
             public int Id { get; set; }
-            public List<Tag> Tags { get; } = new();
-            public List<JoinType> PostTags { get; } = new();
+            public List<Tag> Tags { get; } = [];
+            public List<JoinType> PostTags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
-            public List<Post> Posts { get; } = new();
-            public List<JoinType> PostTags { get; } = new();
+            public List<Post> Posts { get; } = [];
+            public List<JoinType> PostTags { get; } = [];
         }
 
         public class Blog
         {
             public int Id { get; set; }
-            public List<Author> Authors { get; } = new();
-            public List<JoinType> BlogAuthors { get; } = new();
+            public List<Author> Authors { get; } = [];
+            public List<JoinType> BlogAuthors { get; } = [];
         }
 
         public class Author
         {
             public int Id { get; set; }
-            public List<Blog> Blogs { get; } = new();
-            public List<JoinType> BlogAuthors { get; } = new();
+            public List<Blog> Blogs { get; } = [];
+            public List<JoinType> BlogAuthors { get; } = [];
         }
         #endregion
 
@@ -1402,13 +1402,13 @@ public class ManyToMany
         public class Post
         {
             public int Id { get; set; }
-            public List<PostTag> PostTags { get; } = new();
+            public List<PostTag> PostTags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
-            public List<PostTag> PostTags { get; } = new();
+            public List<PostTag> PostTags { get; } = [];
         }
 
         public class PostTag
@@ -1455,15 +1455,15 @@ public class ManyToMany
         public class Post
         {
             public int Id { get; set; }
-            public List<PostTag> PostTags { get; } = new();
-            public List<Tag> Tags { get; } = new();
+            public List<PostTag> PostTags { get; } = [];
+            public List<Tag> Tags { get; } = [];
         }
 
         public class Tag
         {
             public int Id { get; set; }
-            public List<PostTag> PostTags { get; } = new();
-            public List<Post> Posts { get; } = new();
+            public List<PostTag> PostTags { get; } = [];
+            public List<Post> Posts { get; } = [];
         }
 
         public class PostTag


### PR DESCRIPTION
Replaced `new()` with .NET 8 new collection initialization syntax `[]`
Only in [ManyToMany.cs](https://github.com/dotnet/EntityFramework.Docs/blob/main/samples/core/Modeling/Relationships/ManyToMany.cs) which affects [Many-to-Many relationships docs](https://learn.microsoft.com/en-us/ef/core/modeling/relationships/many-to-many).