### PR TITLE
Enable new Open Source feedback control

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,0 @@
-This issue tracker is for ***documentation***
-
-For ***product*** issues, use https://github.com/aspnet/EntityFramework/issues

--- a/.github/ISSUE_TEMPLATE/a-general-issue.yml
+++ b/.github/ISSUE_TEMPLATE/a-general-issue.yml
@@ -1,0 +1,13 @@
+name: "General feedback"
+description: Provide general feedback about the Entity Framework docs or a specific article.
+body:
+  - type: markdown
+    attributes:
+      value: "Describe the issue or suggestion. NOTE: If your issue is about a specific article, it's best to submit your feedback by clicking the 'Open a documentation issue' link in the 'EntityFramework feedback' box at the end of the article."
+  - type: input
+    id: topic
+    attributes:
+      label: Issue or suggestion
+      description: Describe the issue
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Entity Framework product feedback
+    url: https://github.com/dotnet/efcore/issues
+    about: Log Entity Framework product feedback here
+  - name: learn.microsoft.com site feedback
+    url: https://github.com/MicrosoftDocs/feedback/issues/new/choose
+    about: Log general learn.microsoft.com site issues here

--- a/.github/ISSUE_TEMPLATE/z-customer-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/z-customer-feedback.yml
@@ -1,0 +1,58 @@
+name: Learn feedback control.
+description: |
+  ⛔ This template is hooked into the feedback control on the bottom of every page on the live site. It automatically fills in several fields for you. Don't use for other purposes. ⛔
+body:
+  - type: markdown
+    attributes:
+      value: "## Issue information"
+  - type: markdown
+    attributes:
+      value: Select the issue type, and describe the issue in the text box below. Add as much detail as needed to help us resolve the issue.
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Type of issue
+      options:
+        - Typo
+        - Code doesn't work
+        - Missing information
+        - Outdated article
+        - Other (describe below)
+    validations:
+      required: true
+  - type: textarea
+    id: feedback
+    validations:
+      required: true
+    attributes:
+      label: Description
+  - type: markdown
+    attributes:
+      value: "## 🚧 Article information 🚧"
+  - type: markdown
+    attributes:
+      value: "*Don't modify the following fields*. They are automatically filled in for you. Doing so will disconnect your issue from the affected article. *Don't edit them*."
+  - type: input
+    id: pageUrl
+    validations:
+      required: true
+    attributes:
+      label: Page URL
+  - type: input
+    id: contentSourceUrl
+    validations:
+      required: true
+    attributes:
+      label: Content source URL
+  - type: input
+    id: documentVersionIndependentId
+    validations:
+      required: true
+    attributes:
+      label: Document Version Independent Id
+  - type: input
+    id: author
+    validations:
+      required: true
+    attributes:
+      label: Article author

--- a/entity-framework/docfx.json
+++ b/entity-framework/docfx.json
@@ -73,9 +73,15 @@
       "ms.tgt_pltfrm": "dotnet",
       "ms.devlang": "dotnet",
       "ms.author": "avickers",
-      "feedback_system": "GitHub",
+      "feedback_system": "OpenSource",
       "feedback_github_repo": "dotnet/EntityFramework.Docs",
       "feedback_product_url": "https://github.com/dotnet/efcore/issues/new/choose",
+      "open_source_feedback_contributorGuideUrl": "https://learn.microsoft.com/contribute/content/dotnet/dotnet-contribute",
+      "open_source_feedback_issueTitle": "",
+      "open_source_feedback_productLogoLightUrl": "https://learn.microsoft.com/media/logos/logo_net.svg",
+      "open_source_feedback_productLogoDarkUrl": "https://learn.microsoft.com/media/logos/logo_net.svg",
+      "open_source_feedback_issueUrl": "https://github.com/dotnet/EntityFramework.Docs/issues/new?template=z-customer-feedback.yml",
+      "open_source_feedback_productName": ".NET",
       "uhfHeaderId": "MSDocsHeader-DotNet"
     },
     "fileMetadata": {


### PR DESCRIPTION
1. Create new YML based templates, removing the old markdown based template.
1. Add the issue-template config file.
1. Update docfx.json to match the new templates.