### PR TITLE
Enable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Entity Framework product feedback
     url: https://github.com/dotnet/efcore/issues


### PR DESCRIPTION
Otherwise it makes it very difficult for the team to file normal docs issues to track upcoming doc work.