### PR TITLE
fix typo

### DIFF
--- a/entity-framework/core/what-is-new/ef-core-9.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-9.0/whatsnew.md
@@ -307,7 +307,7 @@ FROM [Stores] AS [s]
 WHERE [s].[Region] = N'Deutschland'
 ```
 
-In EF8, the same update can be performed by passing the complex type instance itself. That is, each member does not need to be explicitly specified. For example:
+In EF9, the same update can be performed by passing the complex type instance itself. That is, each member does not need to be explicitly specified. For example:
 
 <!--
             #region UpdateComplexType


### PR DESCRIPTION
The new `Allow passing complex type instances to ExecuteUpdate` feature is for `EF9` but is mistakenly referred to `EF8`