### PR TITLE
Update '.NET implementations supported by EF Core' page to include EF Core 8.0

### DIFF
--- a/entity-framework/core/miscellaneous/platforms.md
+++ b/entity-framework/core/miscellaneous/platforms.md
@@ -14,6 +14,7 @@ Several older .NET implementations are no longer supported. See the sections bel
 
 | EF Core           | .NET & .NET Core | .NET Standard | .NET Framework |
 |-------------------|------------------|---------------|----------------|
+| **8.0**           | 8.0              |               |                |
 | **7.0**           | 6.0              |               |                |
 | **6.0**           | 6.0              |               |                |
 | ~~**5.0**~~ (EOL) | 5.0              | 2.1           |                |
@@ -21,7 +22,7 @@ Several older .NET implementations are no longer supported. See the sections bel
 
 ## .NET
 
-EF Core is a .NET library. Both EF Core versions 6.0 and 7.0 target .NET version 6.0. In general, we target the latest [LTS release](/lifecycle/products/microsoft-net-and-net-core) of .NET. This enables you to upgrade to a newer, STS release of EF Core to take advantage of the latest features without having to upgrade your entire app. There may be exceptions to this, however, as runtime features sometimes get added that require us to depend on the latest version of .NET.
+EF Core is a .NET library. EF Core version 8.0 targets .NET version 8.0, while both EF Core versions 6.0 and 7.0 target .NET version 6.0. In general, we target the latest [LTS release](/lifecycle/products/microsoft-net-and-net-core) of .NET. This enables you to upgrade to a newer, STS release of EF Core to take advantage of the latest features without having to upgrade your entire app. There may be exceptions to this, however, as runtime features sometimes get added that require us to depend on the latest version of .NET.
 
 .NET supports multiple platforms including Windows, Linux, macOS, iOS, Android, and Wasm. For more details on which version are supported, see the [.NET Supported OS Policy](https://github.com/dotnet/core/blob/main/os-lifecycle-policy.md).
 


### PR DESCRIPTION
Small update to include EF Core 8.0 and mention it targets .NET 8.0