### PR TITLE
Updated EF Core Power Tools CLI link

### DIFF
--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -25,7 +25,7 @@ EF Core Power Tools is a Visual Studio extension that exposes various EF Core de
 
 EF Core Power Tools CLI is a .NET global command line tool. It enables advanced reverse engineering of DbContext and entity classes from existing databases and [SQL Server DACPACs](/sql/relational-databases/data-tier-applications/data-tier-applications). For EF Core: 6-8.
 
-[GitHub readme](https://github.com/ErikEJ/EFCorePowerTools/blob/master/src/Core/efcpt.7/readme.md)
+[GitHub readme](https://www.nuget.org/packages/ErikEJ.EFCorePowerTools.Cli/#readme-body-tab)
 
 ### LLBLGen Pro
 

--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -25,7 +25,7 @@ EF Core Power Tools is a Visual Studio extension that exposes various EF Core de
 
 EF Core Power Tools CLI is a .NET global command line tool. It enables advanced reverse engineering of DbContext and entity classes from existing databases and [SQL Server DACPACs](/sql/relational-databases/data-tier-applications/data-tier-applications). For EF Core: 6-8.
 
-[GitHub readme](https://github.com/ErikEJ/EFCorePowerTools/blob/master/src/GUI/efcpt/readme.md)
+[GitHub readme](https://github.com/ErikEJ/EFCorePowerTools/blob/master/src/Core/efcpt.7/readme.md)
 
 ### LLBLGen Pro
 

--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -25,7 +25,7 @@ EF Core Power Tools is a Visual Studio extension that exposes various EF Core de
 
 EF Core Power Tools CLI is a .NET global command line tool. It enables advanced reverse engineering of DbContext and entity classes from existing databases and [SQL Server DACPACs](/sql/relational-databases/data-tier-applications/data-tier-applications). For EF Core: 6-8.
 
-[GitHub readme](https://www.nuget.org/packages/ErikEJ.EFCorePowerTools.Cli/#readme-body-tab)
+[NuGet](https://www.nuget.org/packages/ErikEJ.EFCorePowerTools.Cli/#readme-body-tab)
 
 ### LLBLGen Pro
 


### PR DESCRIPTION
The original link to the EF Core Power Tools CLI was broken. 

I have updated it with a link to the most recent (EF7) readme