### PR TITLE
Update QueryTrackingBehavior benchmark as it fails due to attempts to insert nulls into not nullable db columns

### DIFF
--- a/samples/core/Benchmarks/QueryTrackingBehavior.cs
+++ b/samples/core/Benchmarks/QueryTrackingBehavior.cs
@@ -54,8 +54,9 @@ public class QueryTrackingBehavior
         {
             using var context = new BloggingContext();
             context.AddRange(
-                Enumerable.Range(0, numBlogs).Select(
-                    _ => new Blog { Posts = Enumerable.Range(0, numPostsPerBlog).Select(_ => new Post()).ToList() }));
+                Enumerable.Range(0, numBlogs)
+                    .Select(_ => new Blog { Url = "Some URL", Posts = Enumerable.Range(0, numPostsPerBlog)
+                    .Select(_ => new Post() { Title = "Some Title", Content = "Some Content"}).ToList() }));
             context.SaveChanges();
         }
     }


### PR DESCRIPTION
Without modification this benchmark fails as blog url and post title and content are not marked as nullable ? and we don't explicitly insert into these fields in the SeedData method so SQL Server rejects the insert.

Have amended SeedData to insert dummy data into blog.url, and post.title and post.content. 

Alternative is to remove these fields or mark them as nullable but in the context of tracking v no-tracking, better to keep a more realistic scenario and just populate the fields IMHO.