### PR TITLE
Add Reconciler to list of extensions

### DIFF
--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -338,7 +338,7 @@ For EF Core: 8.
 
 ### Reconciler
 
-Update an entity graph in store to a given one by inserting, updating and removing the respective entities.
+Update an entity graph in store to a given one by inserting, updating and removing the respective entities. For EF Core: 3-7.
 
 [GitHub repository](https://github.com/jtheisen/reconciler)
 

--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -338,7 +338,7 @@ For EF Core: 8.
 
 ### Reconciler
 
-Update an entity graph in store to a given one by inserting, updating and removing the respective entities. For EF Core: 3-7.
+Update an entity graph in store to a given one by inserting, updating and removing the respective entities. For EF Core: 6-7.
 
 [GitHub repository](https://github.com/jtheisen/reconciler)
 

--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -336,6 +336,12 @@ For EF Core: 8.
 
 [GitHub repository](https://github.com/thliborius/EfCoreNexus) | [NuGet](https://www.nuget.org/packages/EfCoreNexus.Framework/)
 
+### Reconciler
+
+Update an entity graph in store to a given one by inserting, updating and removing the respective entities.
+
+[GitHub repository](https://github.com/jtheisen/reconciler)
+
 ## API Integrations
 
 These packages are designed to integrate directly with EF Core to expose various APIs.


### PR DESCRIPTION
Reconciler is an extension that allows to update an entity graph to match a given one.

This was already once part of this page, but I asked to remove it several years ago as it was too buggy. I recently had a good overhaul and extended the test suite significantly. I think it's now ready to be listed again.