### PR TITLE
fix "Unrecognized escape sequence" in snippet

### DIFF
--- a/entity-framework/core/providers/index.md
+++ b/entity-framework/core/providers/index.md
@@ -82,7 +82,7 @@ For example, the following line configures the SQL Server provider with the pass
 
 ```csharp
 optionsBuilder.UseSqlServer(
-    "Server=(localdb)\mssqllocaldb;Database=MyDatabase;Trusted_Connection=True;");
+    @"Server=(localdb)\mssqllocaldb;Database=MyDatabase;Trusted_Connection=True;");
 ```
 
 Database providers can extend EF Core to enable functionality unique to specific databases. Some concepts are common to most databases, and are included in the primary EF Core components. Such concepts include expressing queries in LINQ, transactions, and tracking changes to objects once they are loaded from the database.


### PR DESCRIPTION
Today, a student tried to copy paste the existing snippet, which resulted in the "Unrecognized escape sequence" error.
This PR updates the example to indicate that the connection string is to be interpreted verbatim.

This occurs on the page: https://learn.microsoft.com/en-us/ef/core/providers/?tabs=dotnet-core-cli#adding-a-database-provider-to-your-application