### PR TITLE
Fix header violation

### DIFF
--- a/entity-framework/core/logging-events-diagnostics/metrics.md
+++ b/entity-framework/core/logging-events-diagnostics/metrics.md
@@ -8,8 +8,6 @@ uid: core/logging-events-diagnostics/metrics
 
 # Metrics in EF Core
 
-## Introduction
-
 Entity Framework Core (EF Core) exposes continuous numeric metrics which can provide a good indication of your program's health. These metrics can be used for the following purposes:
 
 * Track general database load in realtime as the application is running


### PR DESCRIPTION
Can't put an H2 as the first piece of content. The text under H1 **is** the introduction and is used for SEO