### PR TITLE
Verified that starting with EF8, the HasConversion call is not needed.

### DIFF
--- a/entity-framework/core/what-is-new/ef-core-8.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-8.0/whatsnew.md
@@ -2588,7 +2588,6 @@ SQL Server automatic [optimistic concurrency](xref:core/saving/concurrency) is h
 ```csharp
 modelBuilder.Entity<Blog>()
     .Property(e => e.RowVersion)
-    .HasConversion<byte[]>()
     .IsRowVersion();
 ```
 


### PR DESCRIPTION
Fixes #4725

(I thought I tested this before, but apparently I got it wrong or something changed...)