### PR TITLE
Disable MD041 requirement of h1 at top of file

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -6,6 +6,7 @@
     "MD028": false,
     "MD033": false,
     "MD036": false,
+    "MD041": false,
     "MD046": {
         "style": "fenced"
     },

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
     "default": true,
+    "MD002": false,
     "MD013": false,
     "MD024": false,
     "MD025": { "front_matter_title": "" },


### PR DESCRIPTION
Doesn't work for includes.