### PR TITLE
Revert "Fix  H1 is required"

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,5 @@
 {
-    "default": true,    
-    "first-header-h1": false,
-    "first-line-h1": false,
+    "default": true,
     "MD002": false,
     "MD013": false,
     "MD024": false,


### PR DESCRIPTION
Reverts dotnet/EntityFramework.Docs#4856

#4860 is the better way to fix the include problem