### PR TITLE
EF Scaffolding many to many join Entity

### DIFF
--- a/entity-framework/core/managing-schemas/scaffolding/templates.md
+++ b/entity-framework/core/managing-schemas/scaffolding/templates.md
@@ -180,7 +180,7 @@ To scaffold these classes, you can use a third template called `EntityTypeConfig
 
 ### Generate Join Table in Many to Many Relationships
 
-By default, the scaffolding process does not generate an entity for join tables in simple many-to-many relationships. However, there are cases where explicitly generating the join table as an entity might be necessary (e.g., when finer control over the generated TSQL query is required).
+By default, the scaffolding process does not generate an entity for join tables in simple many-to-many relationships. However, there are cases where explicitly generating the join table as an entity might be necessary (e.g., when finer control over the generated SQL query is required).
 
 The scaffolding behavior for each entity is controlled by the EntityType.t4 template file. Within this file, there is a condition that short-circuits entity generation for simple many-to-many join tables. To override this behavior and generate the join entity, you can comment out this condition in the 'EntityType.t4' file.
 

--- a/entity-framework/core/managing-schemas/scaffolding/templates.md
+++ b/entity-framework/core/managing-schemas/scaffolding/templates.md
@@ -196,6 +196,24 @@ For large models, the OnModelCreating method of the DbContext class can become u
 
 To scaffold these classes, you can use a third template called `EntityTypeConfiguration.t4`. Like the `EntityType.t4` template, it gets used for each entity type in the model and uses the `EntityType` template parameter.
 
+### Generate Join Table in Many to Many Relationships
+
+By default, the scaffolding process does not generate an entity for join tables in simple many-to-many relationships. However, there are cases where explicitly generating the join table as an entity might be necessary (e.g., when finer control over the generated TSQL query is required).
+
+The scaffolding behavior for each entity is controlled by the EntityType.t4 template file. Within this file, there is a condition that short-circuits entity generation for simple many-to-many join tables. To override this behavior and generate the join entity, you can comment out this condition in the 'EntityType.t4' file.
+
+```T4
+<#
+    // Comment this condition
+    if (EntityType.IsSimpleManyToManyJoinEntityType())
+    {
+        // Don't scaffold these
+        return "";
+    }
+    .  .  .    
+#>
+```
+
 ### Scaffolding other types of files
 
 The primary purpose of reverse engineering in EF Core is to scaffold a DbContext and entity types. However, there's nothing in the tools that require you to actually scaffold code. For example, you could instead scaffold an entity relationship diagram using [Mermaid](https://mermaid-js.github.io/).

--- a/entity-framework/core/managing-schemas/scaffolding/templates.md
+++ b/entity-framework/core/managing-schemas/scaffolding/templates.md
@@ -144,24 +144,6 @@ If you did everything correctly, the collection navigation properties should now
 public virtual ICollection<Album> Albums { get; } = new ObservableCollection<Album>();
 ```
 
-### Generate Join Table in Many to Many Relationships
-
-By default, the scaffolding process does not generate an entity for join tables in simple many-to-many relationships. However, there are cases where explicitly generating the join table as an entity might be necessary (e.g., when finer control over the generated TSQL query is required).
-
-The scaffolding behavior for each entity is controlled by the EntityType.t4 template file. Within this file, there is a condition that short-circuits entity generation for simple many-to-many join tables. To override this behavior and generate the join entity, you can comment out this condition in the 'EntityType.t4' file.
-
-```T4
-<#
-    // Comment this condition
-    if (EntityType.IsSimpleManyToManyJoinEntityType())
-    {
-        // Don't scaffold these
-        return "";
-    }
-    .  .  .    
-#>
-```
-
 ## Updating templates
 
 When you add the default templates to your project, it creates a copy of them based on that version of EF Core. As bugs are fixed and features are added in subsequent versions of EF Core, your templates may become out of date. You should review the changes made in the EF Core templates and merge them into your customized templates.

--- a/entity-framework/core/managing-schemas/scaffolding/templates.md
+++ b/entity-framework/core/managing-schemas/scaffolding/templates.md
@@ -144,6 +144,24 @@ If you did everything correctly, the collection navigation properties should now
 public virtual ICollection<Album> Albums { get; } = new ObservableCollection<Album>();
 ```
 
+## Generate Joint Table in Many to Many Relationships
+
+By default, the scaffolding process does not generate an entity for join tables in simple many-to-many relationships. However, there are cases where explicitly generating the join table as an entity might be necessary (e.g., when finer control over the generated TSQL query is required).
+
+The scaffolding behavior for each entity is controlled by the EntityType.t4 template file. Within this file, there is a condition that short-circuits entity generation for simple many-to-many join tables. To override this behavior and generate the join entity, you can comment out this condition in the 'EntityType.t4' file.
+
+```T4
+<#
+    // Comment this condition
+    if (EntityType.IsSimpleManyToManyJoinEntityType())
+    {
+        // Don't scaffold these
+        return "";
+    }
+    .  .  .    
+#>
+```
+
 ## Updating templates
 
 When you add the default templates to your project, it creates a copy of them based on that version of EF Core. As bugs are fixed and features are added in subsequent versions of EF Core, your templates may become out of date. You should review the changes made in the EF Core templates and merge them into your customized templates.

--- a/entity-framework/core/managing-schemas/scaffolding/templates.md
+++ b/entity-framework/core/managing-schemas/scaffolding/templates.md
@@ -144,7 +144,7 @@ If you did everything correctly, the collection navigation properties should now
 public virtual ICollection<Album> Albums { get; } = new ObservableCollection<Album>();
 ```
 
-## Generate Joint Table in Many to Many Relationships
+### Generate Join Table in Many to Many Relationships
 
 By default, the scaffolding process does not generate an entity for join tables in simple many-to-many relationships. However, there are cases where explicitly generating the join table as an entity might be necessary (e.g., when finer control over the generated TSQL query is required).
 


### PR DESCRIPTION
There isn't any parameter in the scaffolding command to include this type of Entity it is disabled by Default. This is required in cases where fine control of the generated SQL, keeping LINQ queries more TSQL like instead of C# like and others.