### PR TITLE
Update github links to point to live branch

### DIFF
--- a/entity-framework/core/change-tracking/change-detection.md
+++ b/entity-framework/core/change-tracking/change-detection.md
@@ -13,7 +13,7 @@ Each <xref:Microsoft.EntityFrameworkCore.DbContext> instance tracks changes made
 Tracking property and relationship changes requires that the DbContext is able to detect these changes. This document covers how this detection happens, as well as how to use property notifications or change-tracking proxies to force immediate detection of changes.
 
 > [!TIP]
-> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/ChangeTracking/ChangeDetectionAndNotifications).
+> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/ChangeTracking/ChangeDetectionAndNotifications).
 
 ## Snapshot change tracking
 

--- a/entity-framework/core/change-tracking/debug-views.md
+++ b/entity-framework/core/change-tracking/debug-views.md
@@ -17,7 +17,7 @@ The Entity Framework Core (EF Core) change tracker generates two kinds of output
 > This document assumes that entity states and the basics of EF Core change tracking are understood. See [Change Tracking in EF Core](xref:core/change-tracking/index) for more information on these topics.
 
 > [!TIP]
-> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/ChangeTracking/ChangeTrackerDebugging).
+> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/ChangeTracking/ChangeTrackerDebugging).
 
 ## Change tracker debug view
 

--- a/entity-framework/core/change-tracking/entity-entries.md
+++ b/entity-framework/core/change-tracking/entity-entries.md
@@ -21,7 +21,7 @@ Each of these is described in more detail in the sections below.
 > This document assumes that entity states and the basics of EF Core change tracking are understood. See [Change Tracking in EF Core](xref:core/change-tracking/index) for more information on these topics.
 
 > [!TIP]
-> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/ChangeTracking/AccessingTrackedEntities).
+> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/ChangeTracking/AccessingTrackedEntities).
 
 ## Using DbContext.Entry and EntityEntry instances
 

--- a/entity-framework/core/change-tracking/explicit-tracking.md
+++ b/entity-framework/core/change-tracking/explicit-tracking.md
@@ -16,7 +16,7 @@ Entity Framework Core (EF Core) change tracking works best when the same <xref:M
 > This document assumes that entity states and the basics of EF Core change tracking are understood. See [Change Tracking in EF Core](xref:core/change-tracking/index) for more information on these topics.
 
 > [!TIP]
-> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/ChangeTracking/ChangeTrackingInEFCore).
+> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/ChangeTracking/ChangeTrackingInEFCore).
 
 > [!TIP]
 > For simplicity, this document uses and references synchronous methods such as <xref:Microsoft.EntityFrameworkCore.DbContext.SaveChanges*> rather than their async equivalents such as <xref:Microsoft.EntityFrameworkCore.DbContext.SaveChangesAsync*>. Calling and awaiting the async method can be substituted unless otherwise noted.

--- a/entity-framework/core/change-tracking/identity-resolution.md
+++ b/entity-framework/core/change-tracking/identity-resolution.md
@@ -14,7 +14,7 @@ A <xref:Microsoft.EntityFrameworkCore.DbContext> can only track one entity insta
 > This document assumes that entity states and the basics of EF Core change tracking are understood. See [Change Tracking in EF Core](xref:core/change-tracking/index) for more information on these topics.
 
 > [!TIP]
-> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/ChangeTracking/IdentityResolutionInEFCore).
+> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/ChangeTracking/IdentityResolutionInEFCore).
 
 ## Introduction
 

--- a/entity-framework/core/change-tracking/index.md
+++ b/entity-framework/core/change-tracking/index.md
@@ -13,7 +13,7 @@ Each <xref:Microsoft.EntityFrameworkCore.DbContext> instance tracks changes made
 This document presents an overview of Entity Framework Core (EF Core) change tracking and how it relates to queries and updates.
 
 > [!TIP]
-> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/ChangeTracking/ChangeTrackingInEFCore).
+> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/ChangeTracking/ChangeTrackingInEFCore).
 
 > [!TIP]
 > For simplicity, this document uses and references synchronous methods such as <xref:Microsoft.EntityFrameworkCore.DbContext.SaveChanges*> rather than their async equivalents such as <xref:Microsoft.EntityFrameworkCore.DbContext.SaveChangesAsync*>. Calling and awaiting the async method can be substituted unless otherwise noted.

--- a/entity-framework/core/change-tracking/miscellaneous.md
+++ b/entity-framework/core/change-tracking/miscellaneous.md
@@ -14,7 +14,7 @@ This document covers miscellaneous features and scenarios involving change track
 > This document assumes that entity states and the basics of EF Core change tracking are understood. See [Change Tracking in EF Core](xref:core/change-tracking/index) for more information on these topics.
 
 > [!TIP]
-> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/ChangeTracking/AdditionalChangeTrackingFeatures).
+> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/ChangeTracking/AdditionalChangeTrackingFeatures).
 
 ## `Add` versus `AddAsync`
 

--- a/entity-framework/core/change-tracking/relationship-changes.md
+++ b/entity-framework/core/change-tracking/relationship-changes.md
@@ -20,7 +20,7 @@ Navigations can be used on both sides of the relationship, on one side only, or 
 > This document assumes that entity states and the basics of EF Core change tracking are understood. See [Change Tracking in EF Core](xref:core/change-tracking/index) for more information on these topics.
 
 > [!TIP]
-> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/ChangeTracking/ChangingFKsAndNavigations).
+> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/ChangeTracking/ChangingFKsAndNavigations).
 
 ### Example model
 

--- a/entity-framework/core/get-started/overview/first-app.md
+++ b/entity-framework/core/get-started/overview/first-app.md
@@ -12,7 +12,7 @@ In this tutorial, you create a .NET Core console app that performs data access a
 
 You can follow the tutorial by using Visual Studio on Windows, or by using the .NET CLI on Windows, macOS, or Linux.
 
-[View this article's sample on GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/GetStarted).
+[View this article's sample on GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/GetStarted).
 
 ## Prerequisites
 

--- a/entity-framework/core/get-started/winforms.md
+++ b/entity-framework/core/get-started/winforms.md
@@ -13,7 +13,7 @@ This step-by-step walkthrough shows how to build a simple Windows Forms (WinForm
 The screen shots and code listings in this walkthrough are taken from Visual Studio 2022 17.3.0.
 
 > [!TIP]
-> You can view this article's [sample on GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/WinForms).
+> You can view this article's [sample on GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/WinForms).
 
 ## Prerequisites
 

--- a/entity-framework/core/get-started/wpf.md
+++ b/entity-framework/core/get-started/wpf.md
@@ -15,7 +15,7 @@ The model defines two types that participate in one-to-many relationship: **Cate
 The screen shots and code listings in this walkthrough are taken from Visual Studio 2019 16.6.5.
 
 > [!TIP]
-> You can view this article's [sample on GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/WPF).
+> You can view this article's [sample on GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/WPF).
 
 ## Pre-Requisites
 

--- a/entity-framework/core/logging-events-diagnostics/diagnostic-listeners.md
+++ b/entity-framework/core/logging-events-diagnostics/diagnostic-listeners.md
@@ -9,7 +9,7 @@ uid: core/logging-events-diagnostics/diagnostic-listeners
 # Using Diagnostic Listeners in EF Core
 
 > [!TIP]
-> You can [download this article's sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/DiagnosticListeners) from GitHub.
+> You can [download this article's sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/DiagnosticListeners) from GitHub.
 
 Diagnostic listeners allow listening for any EF Core event that occurs in the current .NET process. The <xref:System.Diagnostics.DiagnosticListener> class is a part of a [common mechanism across .NET](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md) for obtaining diagnostic information from running applications.
 
@@ -92,7 +92,7 @@ For example, the code above handles the <xref:Microsoft.EntityFrameworkCore.Diag
 > [!TIP]
 > ToString is overridden in every EF Core event data class to generate the equivalent log message for the event. For example, calling `ContextInitializedEventData.ToString` generates "Entity Framework Core 5.0.0 initialized 'BlogsContext' using provider 'Microsoft.EntityFrameworkCore.Sqlite' with options: None".
 
-The [sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/DiagnosticListeners) contains a simple console application that makes changes to the blogging database and prints out the diagnostic events encountered.
+The [sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/DiagnosticListeners) contains a simple console application that makes changes to the blogging database and prints out the diagnostic events encountered.
 
 <!--
     public static void Main()

--- a/entity-framework/core/logging-events-diagnostics/events.md
+++ b/entity-framework/core/logging-events-diagnostics/events.md
@@ -9,7 +9,7 @@ uid: core/logging-events-diagnostics/events
 # .NET Events in EF Core
 
 > [!TIP]
-> You can [download the events sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/Events) from GitHub.
+> You can [download the events sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/Events) from GitHub.
 
 Entity Framework Core (EF Core) exposes [.NET events](/dotnet/standard/events/) to act as callbacks when certain things happen in the EF Core code. Events are simpler than [interceptors](xref:core/logging-events-diagnostics/interceptors) and allow more flexible registration. However, they are sync only and so cannot perform non-blocking async I/O.
 
@@ -85,7 +85,7 @@ This method has the appropriate signature to use as an event handler for both th
 
 Both events are needed because new entities fire `Tracked` events when they are first tracked. `StateChanged` events are only fired for entities that change state while they are _already_ being tracked.
 
-The [sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/Events) for this example contains a simple console application that makes changes to the blogging database:
+The [sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/Events) for this example contains a simple console application that makes changes to the blogging database:
 
 <!--
         using (var context = new BlogsContext())

--- a/entity-framework/core/logging-events-diagnostics/interceptors.md
+++ b/entity-framework/core/logging-events-diagnostics/interceptors.md
@@ -70,7 +70,7 @@ Each pair of methods have both sync and async variations. This allows for asynch
 ### Example: Command interception to add query hints
 
 > [!TIP]
-> You can [download the command interceptor sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/CommandInterception) from GitHub.
+> You can [download the command interceptor sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/CommandInterception) from GitHub.
 
 An <xref:Microsoft.EntityFrameworkCore.Diagnostics.IDbCommandInterceptor> can be used to modify SQL before it is sent to the database. This example shows how to modify the SQL to include a query hint.
 
@@ -143,7 +143,7 @@ FROM [Blogs] AS [b]
 ### Example: Connection interception for SQL Azure authentication using AAD
 
 > [!TIP]
-> You can [download the connection interceptor sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/ConnectionInterception) from GitHub.
+> You can [download the connection interceptor sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/ConnectionInterception) from GitHub.
 
 An <xref:Microsoft.EntityFrameworkCore.Diagnostics.IDbConnectionInterceptor> can be used to manipulate the <xref:System.Data.Common.DbConnection> before it is used to connect to the database. This can be used to obtain an Azure Active Directory (AAD) access token. For example:
 
@@ -187,7 +187,7 @@ public class AadAuthenticationInterceptor : DbConnectionInterceptor
 ### Example: Advanced command interception for caching
 
 > [!TIP]
-> You can [download the advanced command interceptor sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/CachingInterception) from GitHub.
+> You can [download the advanced command interceptor sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/CachingInterception) from GitHub.
 
 EF Core interceptors can:
 
@@ -293,7 +293,7 @@ If no cached message is available, or if it has expired, then the code above doe
 
 #### Demonstration
 
-The [caching interceptor sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/CachingInterception) contains a simple console application that queries for daily messages to test the caching:
+The [caching interceptor sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/CachingInterception) contains a simple console application that queries for daily messages to test the caching:
 
 <!--
         // 1. Initialize the database with some daily messages.
@@ -390,7 +390,7 @@ Notice from the log output that the application continues to use the cached mess
 ## SaveChanges interception
 
 > [!TIP]
-> You can [download the SaveChanges interceptor sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/SaveChangesInterception) from GitHub.
+> You can [download the SaveChanges interceptor sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/SaveChangesInterception) from GitHub.
 
 <xref:Microsoft.EntityFrameworkCore.DbContext.SaveChanges*> and <xref:Microsoft.EntityFrameworkCore.DbContext.SaveChangesAsync*> interception points are defined by the <xref:Microsoft.EntityFrameworkCore.Diagnostics.ISaveChangesInterceptor> interface. As for other interceptors, the <xref:Microsoft.EntityFrameworkCore.Diagnostics.SaveChangesInterceptor> base class with no-op methods is provided as a convenience.
 
@@ -406,7 +406,7 @@ SaveChanges can be intercepted to create an independent audit record of the chan
 
 #### The application context
 
-The [sample for auditing](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/SaveChangesInterception) uses a simple DbContext with blogs and posts.
+The [sample for auditing](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/SaveChangesInterception) uses a simple DbContext with blogs and posts.
 
 <!--
 public class BlogsContext : DbContext
@@ -664,7 +664,7 @@ Failure is handled in much the same way as success, but in the <xref:Microsoft.E
 
 #### Demonstration
 
-The [auditing sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/SaveChangesInterception) contains a simple console application that makes changes to the blogging database and then shows the auditing that was created.
+The [auditing sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/SaveChangesInterception) contains a simple console application that makes changes to the blogging database and then shows the auditing that was created.
 
 <!--
         // Insert, update, and delete some entities

--- a/entity-framework/core/logging-events-diagnostics/simple-logging.md
+++ b/entity-framework/core/logging-events-diagnostics/simple-logging.md
@@ -9,7 +9,7 @@ uid: core/logging-events-diagnostics/simple-logging
 # Simple Logging
 
 > [!TIP]
-> You can [download this article's sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/Logging/SimpleLogging) from GitHub.
+> You can [download this article's sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/Logging/SimpleLogging) from GitHub.
 
 Entity Framework Core (EF Core) simple logging can be used to easily obtain logs while developing and debugging applications. This form of logging requires minimal configuration and no additional NuGet packages.
 

--- a/entity-framework/core/managing-schemas/migrations/projects.md
+++ b/entity-framework/core/managing-schemas/migrations/projects.md
@@ -11,7 +11,7 @@ uid: core/managing-schemas/migrations/projects
 You may want to store your migrations in a different project than the one containing your `DbContext`. You can also use this strategy to maintain multiple sets of migrations, for example, one for development and another for release-to-release upgrades.
 
 > [!TIP]
-> You can view this article's [sample on GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Schemas/ThreeProjectMigrations).
+> You can view this article's [sample on GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Schemas/ThreeProjectMigrations).
 
 ## Steps
 

--- a/entity-framework/core/managing-schemas/migrations/providers.md
+++ b/entity-framework/core/managing-schemas/migrations/providers.md
@@ -48,7 +48,7 @@ Add-Migration InitialCreate -Context SqliteBlogContext -OutputDir Migrations\Sql
 It's also possible to use one DbContext type. This currently requires moving the migrations into a separate assembly. Please refer to [Using a Separate Migrations Project](xref:core/managing-schemas/migrations/projects) for instructions on setting up your projects.
 
 > [!TIP]
-> You can view this article's [sample on GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Schemas/TwoProjectMigrations).
+> You can view this article's [sample on GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Schemas/TwoProjectMigrations).
 
 You can pass arguments into the app from the tools. This can enable a more streamlined workflow that avoids having to make manual changes to the project when running the tools.
 

--- a/entity-framework/core/miscellaneous/multitenancy.md
+++ b/entity-framework/core/miscellaneous/multitenancy.md
@@ -16,7 +16,7 @@ Many line of business applications are designed to work with multiple customers.
 > This document provides examples and solutions "as is." These are not intended to be "best practices" but rather "working practices" for your consideration.
 
 > [!TIP]
-> You can view the source code for this [sample on GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/Multitenancy)
+> You can view the source code for this [sample on GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/Multitenancy)
 
 ## Supporting multi-tenancy
 

--- a/entity-framework/core/modeling/bulk-configuration.md
+++ b/entity-framework/core/modeling/bulk-configuration.md
@@ -9,7 +9,7 @@ uid: core/modeling/bulk-configuration
 
 When an aspect needs to be configured in the same way across multiple entity types, the following techniques allow to reduce code duplication and consolidate the logic.
 
-See the [full sample project](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/BulkConfiguration) containing the code snippets presented below.
+See the [full sample project](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/BulkConfiguration) containing the code snippets presented below.
 
 ## Bulk configuration in OnModelCreating
 

--- a/entity-framework/core/modeling/data-seeding.md
+++ b/entity-framework/core/modeling/data-seeding.md
@@ -78,7 +78,7 @@ Owned entity types can be configured in a similar fashion:
 
 [!code-csharp[LanguageDetailsSeed](../../../samples/core/Modeling/DataSeeding/ManagingDataContext.cs?name=LanguageDetailsSeed)]
 
-See the [full sample project](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/DataSeeding) for more context.
+See the [full sample project](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/DataSeeding) for more context.
 
 Once the data has been added to the model, [migrations](xref:core/managing-schemas/migrations/index) should be used to apply the changes.
 

--- a/entity-framework/core/modeling/dynamic-model.md
+++ b/entity-framework/core/modeling/dynamic-model.md
@@ -29,4 +29,4 @@ Finally, register your new `IModelCacheKeyFactory` in your context's `OnConfigur
 
 [!code-csharp[Main](../../../samples/core/Modeling/DynamicModel/DynamicContext.cs?name=OnConfiguring)]
 
-See the [full sample project](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/DynamicModel) for more context.
+See the [full sample project](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/DynamicModel) for more context.

--- a/entity-framework/core/modeling/index.md
+++ b/entity-framework/core/modeling/index.md
@@ -12,7 +12,7 @@ EF Core uses a metadata _model_ to describe how the application's entity types a
 Most configuration can be applied to a model targeting any data store. Providers may also enable configuration that is specific to a particular data store and they can also ignore configuration that is not supported or not applicable. For documentation on provider-specific configuration see the [Database providers](xref:core/providers/index) section.
 
 > [!TIP]
-> You can view this article's [samples](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/) on GitHub.
+> You can view this article's [samples](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/) on GitHub.
 
 ## Use fluent API to configure a model
 
@@ -93,7 +93,7 @@ EF Core includes many model building conventions that are enabled by default. Yo
 Applications can remove or replace any of these conventions, as well as add new [custom conventions](xref:core/modeling/bulk-configuration#conventions) that apply configuration for patterns that are not recognized by EF out of the box.
 
 > [!TIP]
-> The code shown below comes from [ModelBuildingConventionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/BulkConfiguration/ModelBuildingConventionsSample.cs).
+> The code shown below comes from [ModelBuildingConventionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/BulkConfiguration/ModelBuildingConventionsSample.cs).
 
 ### Removing an existing convention
 

--- a/entity-framework/core/modeling/keyless-entity-types.md
+++ b/entity-framework/core/modeling/keyless-entity-types.md
@@ -63,7 +63,7 @@ Mapping a keyless entity type to a database object is achieved using the `ToTabl
 The following example shows how to use keyless entity types to query a database view.
 
 > [!TIP]
-> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/KeylessEntityTypes) on GitHub.
+> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/KeylessEntityTypes) on GitHub.
 
 First, we define a simple Blog and Post model:
 

--- a/entity-framework/core/modeling/owned-entities.md
+++ b/entity-framework/core/modeling/owned-entities.md
@@ -35,7 +35,7 @@ The model above is mapped to the following database schema:
 
 ![Screenshot of the database model for entity containing owned reference](_static/owned-entities-ownsone.png)
 
-See the [full sample project](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/OwnedEntities) for more context.
+See the [full sample project](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/OwnedEntities) for more context.
 
 > [!TIP]
 > The owned entity type can be marked as required, see [Required one-to-one dependents](xref:core/modeling/relationships/navigations#required-navigations) for more information.

--- a/entity-framework/core/modeling/relationships/conventions.md
+++ b/entity-framework/core/modeling/relationships/conventions.md
@@ -13,7 +13,7 @@ EF Core uses a set of [conventions](xref:core/modeling/bulk-configuration#conven
 > The conventions described here can be overridden by explicit configuration of the relationship using either [mapping attributes](xref:core/modeling/relationships/mapping-attributes) or the model building API.
 
 > [!TIP]
-> The code below can be found in [RelationshipConventions.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/Relationships/RelationshipConventions.cs).
+> The code below can be found in [RelationshipConventions.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/Relationships/RelationshipConventions.cs).
 
 ## Discovering navigations
 

--- a/entity-framework/core/modeling/relationships/foreign-and-principal-keys.md
+++ b/entity-framework/core/modeling/relationships/foreign-and-principal-keys.md
@@ -10,7 +10,7 @@ uid: core/modeling/relationships/foreign-and-principal-keys
 All [one-to-one](xref:core/modeling/relationships/one-to-one) and [one-to-many](xref:core/modeling/relationships/one-to-many) relationships are defined by a foreign key on the dependent end that references a primary or alternate key on the principal end. For convenience, this primary or alternate key is known as the "principal key" for the relationship. [Many-to-many](xref:core/modeling/relationships/one-to-many) relationships are composed of two one-to-many relationships, each of which is itself defined by a foreign key referencing a principal key.
 
 > [!TIP]
-> The code below can be found in [ForeignAndPrincipalKeys.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/Relationships/ForeignAndPrincipalKeys.cs).
+> The code below can be found in [ForeignAndPrincipalKeys.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/Relationships/ForeignAndPrincipalKeys.cs).
 
 ## Foreign keys
 

--- a/entity-framework/core/modeling/relationships/many-to-many.md
+++ b/entity-framework/core/modeling/relationships/many-to-many.md
@@ -113,7 +113,7 @@ Indeed, EF [model building conventions](xref:core/modeling/relationships/convent
 The following sections contain examples of many-to-many relationships, including the configuration needed to achieve each mapping.
 
 > [!TIP]
-> The code for all the examples below can be found in [ManyToMany.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/Relationships/ManyToMany.cs).
+> The code for all the examples below can be found in [ManyToMany.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/Relationships/ManyToMany.cs).
 
 ## Basic many-to-many
 

--- a/entity-framework/core/modeling/relationships/mapping-attributes.md
+++ b/entity-framework/core/modeling/relationships/mapping-attributes.md
@@ -13,7 +13,7 @@ Mapping attributes are used to modify or override the configuration discovered b
 > This document only covers mapping attributes in the context of relationship configuration. Other uses of mapping attributes are covered in the relevant sections of the wider [modeling documentation](xref:core/modeling/index).
 
 > [!TIP]
-> The code below can be found in [MappingAttributes.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/Relationships/MappingAttributes.cs).
+> The code below can be found in [MappingAttributes.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/Relationships/MappingAttributes.cs).
 
 ## Where to get mapping attributes
 

--- a/entity-framework/core/modeling/relationships/one-to-many.md
+++ b/entity-framework/core/modeling/relationships/one-to-many.md
@@ -12,7 +12,7 @@ One-to-many relationships are used when a single entity is associated with any n
 This document is structured around lots of examples. The examples start with common cases, which also introduce concepts. Later examples cover less common kinds of configuration. A good approach here is to understand the first few examples and concepts, and then go to the later examples based on your specific needs. Based on this approach, we will start with simple "required" and "optional" one-to-many relationships.
 
 > [!TIP]
-> The code for all the examples below can be found in [OneToMany.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/Relationships/OneToMany.cs).
+> The code for all the examples below can be found in [OneToMany.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/Relationships/OneToMany.cs).
 
 ## Required one-to-many
 

--- a/entity-framework/core/modeling/relationships/one-to-one.md
+++ b/entity-framework/core/modeling/relationships/one-to-one.md
@@ -12,7 +12,7 @@ One-to-one relationships are used when one entity is associated with at most one
 This document is structured around lots of examples. The examples start with common cases, which also introduce concepts. Later examples cover less common kinds of configuration. A good approach here is to understand the first few examples and concepts, and then go to the later examples based on your specific needs. Based on this approach, we will start with simple "required" and "optional" one-to-one relationships.
 
 > [!TIP]
-> The code for all the examples below can be found in [OneToOne.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/Relationships/OneToOne.cs).
+> The code for all the examples below can be found in [OneToOne.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/Relationships/OneToOne.cs).
 
 ## Required one-to-one
 

--- a/entity-framework/core/modeling/table-splitting.md
+++ b/entity-framework/core/modeling/table-splitting.md
@@ -33,7 +33,7 @@ In addition to the required configuration we call `Property(o => o.Status).HasCo
 [!code-csharp[TableSplittingConfiguration](../../../samples/core/Modeling/TableSplitting/TableSplittingContext.cs?name=TableSplitting)]
 
 > [!TIP]
-> See the [full sample project](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/TableSplitting) for more context.
+> See the [full sample project](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/TableSplitting) for more context.
 
 ### Usage
 

--- a/entity-framework/core/modeling/value-comparers.md
+++ b/entity-framework/core/modeling/value-comparers.md
@@ -9,7 +9,7 @@ uid: core/modeling/value-comparers
 # Value Comparers
 
 > [!TIP]
-> The code in this document can be found on GitHub as a [runnable sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/ValueConversions/).
+> The code in this document can be found on GitHub as a [runnable sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/ValueConversions/).
 
 ## Background
 

--- a/entity-framework/core/modeling/value-conversions.md
+++ b/entity-framework/core/modeling/value-conversions.md
@@ -10,7 +10,7 @@ uid: core/modeling/value-conversions
 Value converters allow property values to be converted when reading from or writing to the database. This conversion can be from one value to another of the same type (for example, encrypting strings) or from a value of one type to a value of another type (for example, converting enum values to and from strings in the database.)
 
 > [!TIP]
-> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Modeling/ValueConversions/).
+> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Modeling/ValueConversions/).
 
 ## Overview
 

--- a/entity-framework/core/performance/advanced-performance-topics.md
+++ b/entity-framework/core/performance/advanced-performance-topics.md
@@ -35,7 +35,7 @@ The `poolSize` parameter of the `PooledDbContextFactory` constructor sets the ma
 
 ### Benchmarks
 
-Following are the benchmark results for fetching a single row from a SQL Server database running locally on the same machine, with and without context pooling. As always, results will change with the number of rows, the latency to your database server and other factors. Importantly, this benchmarks single-threaded pooling performance, while a real-world contended scenario may have different results; benchmark on your platform before making any decisions. [The source code is available here](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Benchmarks/ContextPooling.cs), feel free to use it as a basis for your own measurements.
+Following are the benchmark results for fetching a single row from a SQL Server database running locally on the same machine, with and without context pooling. As always, results will change with the number of rows, the latency to your database server and other factors. Importantly, this benchmarks single-threaded pooling performance, while a real-world contended scenario may have different results; benchmark on your platform before making any decisions. [The source code is available here](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Benchmarks/ContextPooling.cs), feel free to use it as a basis for your own measurements.
 
 |                Method | NumBlogs |     Mean |    Error |   StdDev |   Gen 0 | Gen 1 | Gen 2 | Allocated |
 |---------------------- |--------- |---------:|---------:|---------:|--------:|------:|------:|----------:|
@@ -72,7 +72,7 @@ Finally, arrange for a context to get injected from our Scoped factory:
 
 As this point, your controllers automatically get injected with a context instance that has the right tenant ID, without having to know anything about it.
 
-The full source code for this sample is available [here](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Performance/AspNetContextPoolingWithState).
+The full source code for this sample is available [here](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Performance/AspNetContextPoolingWithState).
 
 > [!NOTE]
 > Although EF Core takes care of resetting internal state for `DbContext` and its related services, it generally does not reset state in the underlying database driver, which is outside of EF. For example, if you manually open and use a `DbConnection` or otherwise manipulate ADO.NET state, it's up to you to restore that state before returning the context instance to the pool, e.g. by closing the connection. Failure to do so may cause state to get leaked across unrelated requests.

--- a/entity-framework/core/performance/efficient-querying.md
+++ b/entity-framework/core/performance/efficient-querying.md
@@ -180,7 +180,7 @@ In read-only scenarios where changes aren't saved back to the database, the abov
 
 To illustrate, assume we are loading a large number of Posts from the database, as well as the Blog referenced by each Post. If 100 Posts happen to reference the same Blog, a tracking query detects this via identity resolution, and all Post instances will refer the same de-duplicated Blog instance. A no-tracking query, in contrast, duplicates the same Blog 100 times - and application code must be written accordingly.
 
-Here are the results for a benchmark comparing tracking vs. no-tracking behavior for a query loading 10 Blogs with 20 Posts each. [The source code is available here](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Benchmarks/QueryTrackingBehavior.cs), feel free to use it as a basis for your own measurements.
+Here are the results for a benchmark comparing tracking vs. no-tracking behavior for a query loading 10 Blogs with 20 Posts each. [The source code is available here](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Benchmarks/QueryTrackingBehavior.cs), feel free to use it as a basis for your own measurements.
 
 |       Method | NumBlogs | NumPostsPerBlog |       Mean |    Error |   StdDev |     Median | Ratio | RatioSD |   Gen 0 |   Gen 1 | Gen 2 | Allocated |
 |------------- |--------- |---------------- |-----------:|---------:|---------:|-----------:|------:|--------:|--------:|--------:|------:|----------:|

--- a/entity-framework/core/performance/modeling-for-performance.md
+++ b/entity-framework/core/performance/modeling-for-performance.md
@@ -58,7 +58,7 @@ However, measuring shows that TPT is in most cases the inferior mapping techniqu
 
 TPC has similar performance characteristics to TPH, but is slightly slower when selecting entities of all types as this involves several tables. However, TPC really excels when querying for entities of a single leaf type - the query only uses a single table and needs no filtering.
 
-For a concrete example, [see this benchmark](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Benchmarks/Inheritance.cs) which sets up a simple model with a 7-type hierarchy; 5000 rows are seeded for each type - totalling 35000 rows - and the benchmark simply loads all rows from the database:
+For a concrete example, [see this benchmark](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Benchmarks/Inheritance.cs) which sets up a simple model with a 7-type hierarchy; 5000 rows are seeded for each type - totalling 35000 rows - and the benchmark simply loads all rows from the database:
 
 | Method |     Mean |   Error |   StdDev |     Gen 0 |     Gen 1 | Allocated |
 |------- |---------:|--------:|---------:|----------:|----------:|----------:|

--- a/entity-framework/core/performance/performance-diagnosis.md
+++ b/entity-framework/core/performance/performance-diagnosis.md
@@ -92,7 +92,7 @@ See the dedicated page on [EF's metrics](xref:core/logging-events-diagnostics/me
 At the end of the day, you sometimes need to know whether a particular way of writing or executing a query is faster than another. It's important to never assume or speculate the answer, and it's extremely easy to put together a quick benchmark to get the answer. When writing benchmarks, it's strongly recommended to use the well-known [BenchmarkDotNet](https://benchmarkdotnet.org/index.html) library, which handles many pitfalls users encounter when trying to write their own benchmarks: have you performed some warmup iterations? How many iterations does your benchmark actually run, and why? Let's take a look at what a benchmark with EF Core looks like.
 
 > [!TIP]
-> The full benchmark project for the source below is available [here](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Benchmarks/AverageBlogRanking.cs). You are encouraged to copy it and use it as a template for your own benchmarks.
+> The full benchmark project for the source below is available [here](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Benchmarks/AverageBlogRanking.cs). You are encouraged to copy it and use it as a template for your own benchmarks.
 
 As a simple benchmark scenario, let's compare the following different methods of calculating the average ranking of all Blogs in our database:
 
@@ -101,7 +101,7 @@ As a simple benchmark scenario, let's compare the following different methods of
 * Avoid loading the entire Blog entity instances at all, by projecting out the ranking only. The saves us from transferring the other, unneeded columns of the Blog entity type.
 * Calculate the average in the database by making it part of the query. This should be the fastest way, since everything is calculated in the database and only the result is transferred back to the client.
 
-With BenchmarkDotNet, you write the code to be benchmarked as a simple method - just like a unit test - and BenchmarkDotNet automatically runs each method for a sufficient number of iterations, reliably measuring how long it takes and how much memory is allocated. Here are the different methods ([the full benchmark code can be seen here](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Benchmarks/AverageBlogRanking.cs)):
+With BenchmarkDotNet, you write the code to be benchmarked as a simple method - just like a unit test - and BenchmarkDotNet automatically runs each method for a sufficient number of iterations, reliably measuring how long it takes and how much memory is allocated. Here are the different methods ([the full benchmark code can be seen here](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Benchmarks/AverageBlogRanking.cs)):
 
 ### [Load entities](#tab/load-entities)
 

--- a/entity-framework/core/providers/cosmos/index.md
+++ b/entity-framework/core/providers/cosmos/index.md
@@ -38,7 +38,7 @@ Install-Package Microsoft.EntityFrameworkCore.Cosmos
 ## Get started
 
 > [!TIP]
-> You can view this article's [sample on GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Cosmos).
+> You can view this article's [sample on GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Cosmos).
 
 As for other providers the first step is to call [UseCosmos](/dotnet/api/Microsoft.EntityFrameworkCore.CosmosDbContextOptionsExtensions.UseCosmos):
 

--- a/entity-framework/core/providers/sql-server/hierarchyid.md
+++ b/entity-framework/core/providers/sql-server/hierarchyid.md
@@ -81,7 +81,7 @@ The `HierarchyId` type can be used for properties of an entity type. For example
 [!code-csharp[Halfling](../../../../samples/core/Miscellaneous/NewInEFCore8/HierarchyIdSample.cs?name=Halfling)]
 
 > [!TIP]
-> The code shown here and in the examples below comes from [HierarchyIdSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore8/HierarchyIdSample.cs).
+> The code shown here and in the examples below comes from [HierarchyIdSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore8/HierarchyIdSample.cs).
 
 > [!TIP]
 > If desired, `HierarchyId` is suitable for use as a key property type.

--- a/entity-framework/core/providers/sql-server/temporal-tables.md
+++ b/entity-framework/core/providers/sql-server/temporal-tables.md
@@ -29,7 +29,7 @@ modelBuilder
 [!code-csharp[SimpleConfig](../../../../samples/core/Miscellaneous/NewInEFCore6/TemporalTablesSample.cs?name=SimpleConfig)]
 
 > [!TIP]
-> The code shown here comes from [TemporalTablesSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore6/TemporalTablesSample.cs).
+> The code shown here comes from [TemporalTablesSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore6/TemporalTablesSample.cs).
 
 When using EF Core to create the database, the new table is configured as a temporal table with the SQL Server defaults for the timestamps and history table. For example, consider an `Employee` entity type:
 

--- a/entity-framework/core/querying/client-eval.md
+++ b/entity-framework/core/querying/client-eval.md
@@ -13,7 +13,7 @@ As a general rule, Entity Framework Core attempts to evaluate a query on the ser
 > Prior to version 3.0, Entity Framework Core supported client evaluation anywhere in the query. For more information, see the [previous versions section](#previous-versions).
 
 > [!TIP]
-> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Querying/ClientEvaluation) on GitHub.
+> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Querying/ClientEvaluation) on GitHub.
 
 ## Client evaluation in the top-level projection
 

--- a/entity-framework/core/querying/complex-query-operators.md
+++ b/entity-framework/core/querying/complex-query-operators.md
@@ -10,7 +10,7 @@ uid: core/querying/complex-query-operators
 Language Integrated Query (LINQ) contains many complex operators, which combine multiple data sources or does complex processing. Not all LINQ operators have suitable translations on the server side. Sometimes, a query in one form translates to the server but if written in a different form doesn't translate even if the result is the same. This page describes some of the complex operators and their supported variations. In future releases, we may recognize more patterns and add their corresponding translations. It's also important to keep in mind that translation support varies between providers. A particular query, which is translated in SqlServer, may not work for SQLite databases.
 
 > [!TIP]
-> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Querying/ComplexQuery) on GitHub.
+> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Querying/ComplexQuery) on GitHub.
 
 ## Join
 

--- a/entity-framework/core/querying/filters.md
+++ b/entity-framework/core/querying/filters.md
@@ -17,7 +17,7 @@ Global query filters are LINQ query predicates applied to Entity Types in the me
 The following example shows how to use Global Query Filters to implement multi-tenancy and soft-delete query behaviors in a simple blogging model.
 
 > [!TIP]
-> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Querying/QueryFilters) on GitHub.
+> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Querying/QueryFilters) on GitHub.
 
 > [!NOTE]
 > Multi-tenancy is used here as a simple example. There is also an article with comprehensive guidance for [multi-tenancy in EF Core applications](xref:core/miscellaneous/multitenancy).

--- a/entity-framework/core/querying/index.md
+++ b/entity-framework/core/querying/index.md
@@ -10,7 +10,7 @@ uid: core/querying/index
 Entity Framework Core uses Language-Integrated Query (LINQ) to query data from the database. LINQ allows you to use C# (or your .NET language of choice) to write strongly typed queries. It uses your derived context and entity classes to reference database objects. EF Core passes a representation of the LINQ query to the database provider. Database providers in turn translate it to database-specific query language (for example, SQL for a relational database). Queries are always executed against the database even if the entities returned in the result already exist in the context.
 
 > [!TIP]
-> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Querying/Overview) on GitHub.
+> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Querying/Overview) on GitHub.
 
 The following snippets show a few examples of how to achieve common tasks with Entity Framework Core.
 

--- a/entity-framework/core/querying/related-data/index.md
+++ b/entity-framework/core/querying/related-data/index.md
@@ -14,4 +14,4 @@ Entity Framework Core allows you to use the navigation properties in your model 
 * **[Lazy loading](xref:core/querying/related-data/lazy)** means that the related data is transparently loaded from the database when the navigation property is accessed.
 
 > [!TIP]
-> You can view the [samples](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Querying/RelatedData) under this section on GitHub.
+> You can view the [samples](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Querying/RelatedData) under this section on GitHub.

--- a/entity-framework/core/querying/tags.md
+++ b/entity-framework/core/querying/tags.md
@@ -12,7 +12,7 @@ Query tags help correlate LINQ queries in code with generated SQL queries captur
 You annotate a LINQ query using the new `TagWith()` method:
 
 > [!TIP]
-> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Querying/Tags) on GitHub.
+> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Querying/Tags) on GitHub.
 
 [!code-csharp[Main](../../../samples/core/Querying/Tags/Program.cs#BasicQueryTag)]
 

--- a/entity-framework/core/querying/tracking.md
+++ b/entity-framework/core/querying/tracking.md
@@ -13,7 +13,7 @@ Tracking behavior controls if Entity Framework Core keeps information about an e
 > [Keyless entity types](xref:core/modeling/keyless-entity-types) are never tracked. Wherever this article mentions entity types, it refers to entity types which have a key defined.
 
 > [!TIP]
-> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Querying/Tracking) on GitHub.
+> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Querying/Tracking) on GitHub.
 
 ## Tracking queries
 

--- a/entity-framework/core/saving/basic.md
+++ b/entity-framework/core/saving/basic.md
@@ -10,7 +10,7 @@ uid: core/saving/basic
 <xref:Microsoft.EntityFrameworkCore.DbContext.SaveChanges?displayProperty=nameWithType> is one of two techniques for saving changes to the database with EF. With this method, you perform one or more *tracked changes* (add, update, delete), and then apply those changes by calling the `SaveChanges` method. As an alternative, <xref:Microsoft.EntityFrameworkCore.RelationalQueryableExtensions.ExecuteUpdate*> and <xref:Microsoft.EntityFrameworkCore.RelationalQueryableExtensions.ExecuteDelete*> can be used without involving the change tracker. For an introductory comparison of these two techniques, see the [Overview page](xref:core/saving/index) on saving data.
 
 > [!TIP]
-> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Saving/Basics/) on GitHub.
+> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Saving/Basics/) on GitHub.
 
 ## Adding Data
 

--- a/entity-framework/core/saving/cascade-delete.md
+++ b/entity-framework/core/saving/cascade-delete.md
@@ -24,7 +24,7 @@ The second option is valid for any kind of relationship and is known as "cascade
 > This document describes cascade deletes (and deleting orphans) from the perspective of updating the database. It makes heavy use of concepts introduced in [Change Tracking in EF Core](xref:core/change-tracking/index) and [Changing Foreign Keys and Navigations](xref:core/change-tracking/relationship-changes). Make sure to fully understand these concepts before tackling the material here.
 
 > [!TIP]  
-> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/CascadeDeletes).
+> You can run and debug into all the code in this document by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/CascadeDeletes).
 
 ## When cascading behaviors happen
 

--- a/entity-framework/core/saving/concurrency.md
+++ b/entity-framework/core/saving/concurrency.md
@@ -8,7 +8,7 @@ uid: core/saving/concurrency
 # Handling Concurrency Conflicts
 
 > [!TIP]
-> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Saving/Concurrency/) on GitHub.
+> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Saving/Concurrency/) on GitHub.
 
 In most scenarios, databases are used concurrently by multiple application instances, each performing modifications to data independently of each other. When the same data gets modified at the same time, inconsistencies and data corruption can occur, e.g. when two clients modify different columns in the same row which are related in some way. This page discusses mechanisms for ensuring that your data stays consistent in the face of such concurrent changes.
 

--- a/entity-framework/core/saving/disconnected-entities.md
+++ b/entity-framework/core/saving/disconnected-entities.md
@@ -13,7 +13,7 @@ However, sometimes entities are queried using one context instance and then save
 
 <!-- markdownlint-disable MD028 -->
 > [!TIP]
-> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Saving/Disconnected/) on GitHub.
+> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Saving/Disconnected/) on GitHub.
 
 > [!TIP]
 > EF Core can only track one instance of any entity with a given primary key value. The best way to avoid this being an issue is to use a short-lived context for each unit-of-work such that the context starts empty, has entities attached to it, saves those entities, and then the context is disposed and discarded.

--- a/entity-framework/core/saving/related-data.md
+++ b/entity-framework/core/saving/related-data.md
@@ -10,7 +10,7 @@ uid: core/saving/related-data
 In addition to isolated entities, you can also make use of the relationships defined in your model.
 
 > [!TIP]
-> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Saving/RelatedData/) on GitHub.
+> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Saving/RelatedData/) on GitHub.
 
 ## Adding a graph of new entities
 

--- a/entity-framework/core/saving/transactions.md
+++ b/entity-framework/core/saving/transactions.md
@@ -10,7 +10,7 @@ uid: core/saving/transactions
 Transactions allow several database operations to be processed in an atomic manner. If the transaction is committed, all of the operations are successfully applied to the database. If the transaction is rolled back, none of the operations are applied to the database.
 
 > [!TIP]
-> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Saving/Transactions/) on GitHub.
+> You can view this article's [sample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Saving/Transactions/) on GitHub.
 
 ## Default transaction behavior
 

--- a/entity-framework/core/what-is-new/ef-core-6.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-6.0/whatsnew.md
@@ -11,7 +11,7 @@ uid: core/what-is-new/ef-core-6.0/whatsnew
 EF Core 6.0 has [shipped to NuGet](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/). This page contains an overview of interesting changes introduced in this release.
 
 > [!TIP]
-> You can run and debug into the samples shown below by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore6).
+> You can run and debug into the samples shown below by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore6).
 
 ## SQL Server temporal tables
 
@@ -682,7 +682,7 @@ If supporting any of these features is critical to your success, then please vot
 ### Benchmarks
 
 > [!TIP]
-> You can try compiling a large model and running a benchmark on it by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/CompiledModels).
+> You can try compiling a large model and running a benchmark on it by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/CompiledModels).
 
 The model in the GitHub repo referenced above contains 449 entity types, 6390 properties, and 720 relationships. This is a moderately large model. Using [BenchmarkDotNet](https://www.nuget.org/packages/BenchmarkDotNet) to measure, the average time to first query is 1.02 seconds on a reasonably powerful laptop. Using compiled models brings this down to 117 milliseconds on the same hardware. An 8x to 10x improvement like this stays relatively constant as the model size increases.
 
@@ -712,7 +712,7 @@ After these improvements, the gap between the popular "micro-ORM" [Dapper](https
 EF Core 6.0 contains many improvements to the Azure Cosmos DB database provider.
 
 > [!TIP]
-> You can run and debug into all the the Cosmos-specific samples by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore6.Cosmos).
+> You can run and debug into all the the Cosmos-specific samples by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore6.Cosmos).
 
 ### Default to implicit ownership
 
@@ -2622,7 +2622,7 @@ modelBuilder
 -->
 [!code-csharp[WithDifferentTable](../../../../samples/core/Miscellaneous/NewInEFCore6/OptionalDependentsSample.cs?name=WithDifferentTable)]
 
-See the [OptionalDependentsSample](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore6) in GitHub for more examples of optional dependents, including cases with nested optional dependents.
+See the [OptionalDependentsSample](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore6) in GitHub for more examples of optional dependents, including cases with nested optional dependents.
 
 ## New mapping attributes
 
@@ -3568,7 +3568,7 @@ The EF Core codebase now uses [C# nullable reference types (NRTs)](/dotnet/cshar
 ## Microsoft.Data.Sqlite 6.0
 
 > [!TIP]
-> You can run and debug into all the samples shown below by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore6).
+> You can run and debug into all the samples shown below by [downloading the sample code from GitHub](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore6).
 
 ### Connection Pooling
 

--- a/entity-framework/core/what-is-new/ef-core-7.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-7.0/whatsnew.md
@@ -30,7 +30,7 @@ And a second aggregate type for post metadata:
 [!code-csharp[PostMetadataAggregate](../../../../samples/core/Miscellaneous/NewInEFCore7/BlogsContext.cs?name=PostMetadataAggregate)]
 
 > [!TIP]
-> The sample model can be found in [BlogsContext.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/BlogsContext.cs).
+> The sample model can be found in [BlogsContext.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/BlogsContext.cs).
 
 ## JSON Columns
 
@@ -96,7 +96,7 @@ The aggregate type is configured  in `OnModelCreating` using `OwnsOne`:
 [!code-csharp[TableSharingAggregate](../../../../samples/core/Miscellaneous/NewInEFCore7/JsonColumnsSample.cs?name=TableSharingAggregate)]
 
 > [!TIP]
-> The code shown here comes from [JsonColumnsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/JsonColumnsSample.cs).
+> The code shown here comes from [JsonColumnsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/JsonColumnsSample.cs).
 
 By default, relational database providers map aggregate types like this to the same table as the owning entity type. That is, each property of the `ContactDetails` and `Address` classes is mapped to a column in the `Authors` table.
 
@@ -549,7 +549,7 @@ All of this means that the `ExecuteUpdate` and `ExecuteDelete` methods complemen
 ### Basic `ExecuteDelete` examples
 
 > [!TIP]
-> The code shown here comes from [ExecuteDeleteSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/ExecuteDeleteSample.cs).
+> The code shown here comes from [ExecuteDeleteSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/ExecuteDeleteSample.cs).
 
 Calling `ExecuteDelete` or `ExecuteDeleteAsync` on a `DbSet` immediately deletes all entities of that `DbSet` from the database. For example, to delete all `Tag` entities:
 
@@ -602,7 +602,7 @@ WHERE NOT EXISTS (
 ### Basic `ExecuteUpdate` examples
 
 > [!TIP]
-> The code shown here comes from [ExecuteUpdateSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/ExecuteUpdateSample.cs).
+> The code shown here comes from [ExecuteUpdateSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/ExecuteUpdateSample.cs).
 
 `ExecuteUpdate` and `ExecuteUpdateAsync` behave in a very similar way to the `ExecuteDelete` methods. The main difference is that an update requires knowing _which_ properties to update, and _how_ to update them. This is achieved using one or more calls to `SetProperty`. For example, to update the `Name` of every blog:
 
@@ -790,7 +790,7 @@ Some examples of these improvements are shown below.
 > See [Announcing Entity Framework Core 7 Preview 6: Performance Edition](https://devblogs.microsoft.com/dotnet/announcing-ef-core-7-preview6-performance-optimizations/) on the .NET Blog for an in-depth discussion of these changes.
 
 > [!TIP]
-> The code shown here comes from [SaveChangesPerformanceSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/SaveChangesPerformanceSample.cs).
+> The code shown here comes from [SaveChangesPerformanceSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/SaveChangesPerformanceSample.cs).
 
 ### Unneeded transactions are eliminated
 
@@ -1020,7 +1020,7 @@ In addition, different database systems require different SQL for many of these 
 By default, EF Core maps an inheritance hierarchy of .NET types to a single database table. This is known as the [table-per-hierarchy (TPH)](xref:core/modeling/inheritance#table-per-hierarchy-and-discriminator-configuration) mapping strategy. EF Core 5.0 introduced the [table-per-type (TPT)](xref:core/modeling/inheritance#table-per-type-configuration) strategy, which supports mapping each .NET type to a different database table. EF7 introduces the table-per-concrete-type (TPC) strategy. TPC also maps .NET types to different tables, but in a way that addresses some common performance issues with the TPT strategy.
 
 > [!TIP]
-> The code shown here comes from [TpcInheritanceSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/TpcInheritanceSample.cs).
+> The code shown here comes from [TpcInheritanceSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/TpcInheritanceSample.cs).
 
 > [!TIP]
 > The EF Team demonstrated and talked in depth about TPC mapping in an episode of the .NET Data Community Standup. As with [all Community Standup episodes](https://aka.ms/efstandups), you can [watch the TPC episode now on YouTube](https://youtu.be/HaL6DKW1mrg).
@@ -1486,7 +1486,7 @@ protected override void ConfigureConventions(ModelConfigurationBuilder configura
 > To find all built-in model building conventions, look for every class that implements the <xref:Microsoft.EntityFrameworkCore.Metadata.Conventions.IConvention> interface.
 
 > [!TIP]
-> The code shown here comes from [ModelBuildingConventionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/ModelBuildingConventionsSample.cs).
+> The code shown here comes from [ModelBuildingConventionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/ModelBuildingConventionsSample.cs).
 
 ### Removing an existing convention
 
@@ -2324,7 +2324,7 @@ The following sections show some examples of using these new interception capabi
 ### Simple actions on entity creation
 
 > [!TIP]
-> The code shown here comes from [SimpleMaterializationSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/SimpleMaterializationSample.cs).
+> The code shown here comes from [SimpleMaterializationSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/SimpleMaterializationSample.cs).
 
 The new <xref:Microsoft.EntityFrameworkCore.Diagnostics.IMaterializationInterceptor> supports interception before and after an entity instance is created, and before and after properties of that instance are initialized. The interceptor can change or replace the entity instance at each point. This allows:
 
@@ -2418,7 +2418,7 @@ Customer 'Alice' was retrieved at '9/22/2022 5:25:54 PM'
 ### Injecting services into entities
 
 > [!TIP]
-> The code shown here comes from [InjectLoggerSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/InjectLoggerSample.cs).
+> The code shown here comes from [InjectLoggerSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/InjectLoggerSample.cs).
 
 EF Core already has built-in support for injecting some special services into context instances; for example, see [Lazy loading without proxies](xref:core/querying/related-data/lazy#lazy-loading-without-proxies), which works by injecting the `ILazyLoader` service.
 
@@ -2503,7 +2503,7 @@ info: CustomersLogger[1]
 ### LINQ expression tree interception
 
 > [!TIP]
-> The code shown here comes from [QueryInterceptionSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/QueryInterceptionSample.cs).
+> The code shown here comes from [QueryInterceptionSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/QueryInterceptionSample.cs).
 
 EF Core makes use of [.NET LINQ queries](xref:core/querying/how-query-works). This typically involves using the C#, VB, or F# compiler to build an expression tree which is then translated by EF Core into the appropriate SQL. For example, consider a method that returns a page of customers:
 
@@ -2649,7 +2649,7 @@ In this case the `ThenBy` is simply added to the query. Yes, it may need to be d
 ### Optimistic concurrency interception
 
 > [!TIP]
-> The code shown here comes from [OptimisticConcurrencyInterceptionSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/OptimisticConcurrencyInterceptionSample.cs).
+> The code shown here comes from [OptimisticConcurrencyInterceptionSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/OptimisticConcurrencyInterceptionSample.cs).
 
 EF Core supports the [optimistic concurrency pattern](xref:core/saving/concurrency) by checking that the number of rows actually affected by an update or delete is the same as the number of rows expected to be affected. This is often coupled with a concurrency token; that is, a column value that will only match its expected value if the row has not been updated since the expected value was read.
 
@@ -2694,7 +2694,7 @@ There are several things worth noting about this interceptor:
 ### Lazy initialization of a connection string
 
 > [!TIP]
-> The code shown here comes from [LazyConnectionStringSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/LazyConnectionStringSample.cs).
+> The code shown here comes from [LazyConnectionStringSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/LazyConnectionStringSample.cs).
 
 Connection strings are often static assets read from a configuration file. These can easily be passed to `UseSqlServer` or similar when configuring a `DbContext`. However, sometimes the connection string can change for each context instance. For example, each tenant in a multi-tenant system may have a different connection string.
 
@@ -2783,7 +2783,7 @@ Finally, the interceptor uses this service to obtain the connection string async
 ### Logging SQL Server query statistics
 
 > [!TIP]
-> The code shown here comes from [QueryStatisticsLoggerSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/QueryStatisticsLoggerSample.cs).
+> The code shown here comes from [QueryStatisticsLoggerSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/QueryStatisticsLoggerSample.cs).
 
 Finally, let's create two interceptors that work together to send SQL Server query statistics to the application log. To generate the statistics, we need an <xref:Microsoft.EntityFrameworkCore.Diagnostics.IDbCommandInterceptor> to do two things.
 
@@ -2870,7 +2870,7 @@ EF7 contains many improvements in the translation of LINQ queries.
 ### GroupBy as final operator
 
 > [!TIP]
-> The code shown here comes from [GroupByFinalOperatorSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/GroupByFinalOperatorSample.cs).
+> The code shown here comes from [GroupByFinalOperatorSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/GroupByFinalOperatorSample.cs).
 
 EF7 supports using `GroupBy` as the final operator in a query. For example, this LINQ query:
 
@@ -2893,7 +2893,7 @@ ORDER BY [b].[Price]
 ### GroupJoin as final operator
 
 > [!TIP]
-> The code shown here comes from [GroupJoinFinalOperatorSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/GroupByFinalOperatorSample.cs).
+> The code shown here comes from [GroupJoinFinalOperatorSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/GroupByFinalOperatorSample.cs).
 
 EF7 supports using `GroupJoin` as the final operator in a query. For example, this LINQ query:
 
@@ -2919,7 +2919,7 @@ ORDER BY [c].[Id]
 ### GroupBy entity type
 
 > [!TIP]
-> The code shown here comes from [GroupByEntityTypeSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/GroupByEntityTypeSample.cs).
+> The code shown here comes from [GroupByEntityTypeSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/GroupByEntityTypeSample.cs).
 
 EF7 supports grouping by an entity type. For example, this LINQ query:
 
@@ -2961,7 +2961,7 @@ FROM [Authors] AS [a]
 ### Subqueries don't reference ungrouped columns from outer query
 
 > [!TIP]
-> The code shown here comes from [UngroupedColumnsQuerySample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/UngroupedColumnsQuerySample.cs).
+> The code shown here comes from [UngroupedColumnsQuerySample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/UngroupedColumnsQuerySample.cs).
 
 In EF Core 6.0, a `GROUP BY` clause would reference columns in the outer query, which fails with some databases and is inefficient in others. For example, consider the following query:
 
@@ -3005,7 +3005,7 @@ GROUP BY [t].[Key]
 ### Read-only collections can be used for `Contains`
 
 > [!TIP]
-> The code shown here comes from [ReadOnlySetQuerySample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/ReadOnlySetQuerySample.cs).
+> The code shown here comes from [ReadOnlySetQuerySample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/ReadOnlySetQuerySample.cs).
 
 EF7 supports using `Contains` when the items to search for are contained in an `IReadOnlySet` or `IReadOnlyCollection`, or `IReadOnlyList`. For example, this LINQ query:
 
@@ -3040,7 +3040,7 @@ EF7 introduces better extensibility for providers to translate aggregate functio
 #### String aggregate functions
 
 > [!TIP]
-> The code shown here comes from [StringAggregateFunctionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/StringAggregateFunctionsSample.cs).
+> The code shown here comes from [StringAggregateFunctionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/StringAggregateFunctionsSample.cs).
 
 Queries using <xref:System.String.Join*> and <xref:System.String.Concat*> are now translated when appropriate. For example:
 
@@ -3109,7 +3109,7 @@ ORDER BY [t].[Name]
 #### Spatial aggregate functions
 
 > [!TIP]
-> The code shown here comes from [SpatialAggregateFunctionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/SpatialAggregateFunctionsSample.cs).
+> The code shown here comes from [SpatialAggregateFunctionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/SpatialAggregateFunctionsSample.cs).
 
 It is now possible for [database providers that support for NetTopologySuite](xref:core/modeling/spatial) to translate the following spatial aggregate functions:
 
@@ -3147,7 +3147,7 @@ GROUP BY [c].[Owner]
 #### Statistical aggregate functions
 
 > [!TIP]
-> The code shown here comes from [StatisticalAggregateFunctionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/StatisticalAggregateFunctionsSample.cs).
+> The code shown here comes from [StatisticalAggregateFunctionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/StatisticalAggregateFunctionsSample.cs).
 
 SQL Server translations have been implemented for the following statistical functions:
 
@@ -3190,7 +3190,7 @@ GROUP BY [u].[Id]
 ### Translation of `string.IndexOf`
 
 > [!TIP]
-> The code shown here comes from [MiscellaneousTranslationsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/MiscellaneousTranslationsSample.cs).
+> The code shown here comes from [MiscellaneousTranslationsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/MiscellaneousTranslationsSample.cs).
 
 EF7 now translates <xref:System.String.IndexOf*?displayProperty=nameWithType> in LINQ queries. For example:
 
@@ -3212,7 +3212,7 @@ WHERE (CAST(CHARINDEX(N'Entity', [p].[Content]) AS int) - 1) > 0
 ### Translation of `GetType` for entity types
 
 > [!TIP]
-> The code shown here comes from [MiscellaneousTranslationsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/MiscellaneousTranslationsSample.cs).
+> The code shown here comes from [MiscellaneousTranslationsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/MiscellaneousTranslationsSample.cs).
 
 EF7 now translates <xref:System.Object.GetType?displayProperty=nameWithType> in LINQ queries. For example:
 
@@ -3248,7 +3248,7 @@ And will return both `Post` and `FeaturedPost` entities.
 ### Support for `AT TIME ZONE`
 
 > [!TIP]
-> The code shown here comes from [MiscellaneousTranslationsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/MiscellaneousTranslationsSample.cs).
+> The code shown here comes from [MiscellaneousTranslationsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/MiscellaneousTranslationsSample.cs).
 
 EF7 introduces new <xref:Microsoft.EntityFrameworkCore.SqlServerDbFunctionsExtensions.AtTimeZone*> functions for <xref:System.DateTime> and <xref:System.DateTimeOffset>. These functions translate to `AT TIME ZONE` clauses in the generated SQL. For example:
 
@@ -3276,7 +3276,7 @@ FROM [Posts] AS [p]
 ### Filtered Include on hidden navigations
 
 > [!TIP]
-> The code shown here comes from [MiscellaneousTranslationsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/MiscellaneousTranslationsSample.cs).
+> The code shown here comes from [MiscellaneousTranslationsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/MiscellaneousTranslationsSample.cs).
 
 The [Include methods](xref:core/querying/related-data/eager) can now be used with <xref:Microsoft.EntityFrameworkCore.EF.Property*?displayProperty=nameWithType>. This allows [filtering and ordering](xref:core/querying/related-data/eager#filtered-include) even for private navigation properties, or private navigations represented by fields. For example:
 
@@ -3315,7 +3315,7 @@ ORDER BY [b].[Id], [t].[Title]
 ### Cosmos translation for `Regex.IsMatch`
 
 > [!TIP]
-> The code shown here comes from [CosmosQueriesSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/CosmosQueriesSample.cs).
+> The code shown here comes from [CosmosQueriesSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/CosmosQueriesSample.cs).
 
 EF7 supports using <xref:System.Text.RegularExpressions.Regex.IsMatch*?displayProperty=nameWithType> in LINQ queries against Azure Cosmos DB. For example:
 
@@ -3339,7 +3339,7 @@ WHERE ((c["Discriminator"] = "Triangle") AND RegexMatch(c["Name"], "[a-z]t[a-z]"
 EF7 contains a variety of small improvements to <xref:Microsoft.EntityFrameworkCore.DbContext> and related classes.
 
 > [!TIP]
-> The code for samples in this section comes from [DbContextApiSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/DbContextApiSample.cs).
+> The code for samples in this section comes from [DbContextApiSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/DbContextApiSample.cs).
 
 ### Suppressor for uninitialized DbSet properties
 
@@ -3553,7 +3553,7 @@ Notice:
 EF7 contains a variety of small improvements in model building.
 
 > [!TIP]
-> The code for samples in this section comes from [ModelBuildingSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/ModelBuildingSample.cs).
+> The code for samples in this section comes from [ModelBuildingSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/ModelBuildingSample.cs).
 
 ### Indexes can be ascending or descending
 
@@ -4067,7 +4067,7 @@ If these types are mapped to the same table, then in EF7 that table can be made 
 EF7 includes two significant improvements to the automatic generation of values for key properties.
 
 > [!TIP]
-> The code for samples in this section comes from [ValueGenerationSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore7/ValueGenerationSample.cs).
+> The code for samples in this section comes from [ValueGenerationSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore7/ValueGenerationSample.cs).
 
 ### Value generation for DDD guarded types
 
@@ -4331,4 +4331,4 @@ public partial class MainForm : Form
 }
 ```
 
-See [Getting Started with Windows Forms](xref:core/get-started/winforms) for a complete walkthrough and [downloadable WinForms sample application](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/WinForms).
+See [Getting Started with Windows Forms](xref:core/get-started/winforms) for a complete walkthrough and [downloadable WinForms sample application](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/WinForms).

--- a/entity-framework/core/what-is-new/ef-core-8.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-8.0/whatsnew.md
@@ -665,7 +665,7 @@ The first option has advantages in many situations--we'll take a quick look at i
 Starting with Preview 4, EF8 now includes built-in support for the second option, using JSON as the serialization format. JSON works well for this since modern relational databases include built-in mechanisms for querying and manipulating JSON, such that the JSON column can, effectively, be treated as a table when needed, without the overhead of actually creating that table. These same mechanisms allow JSON to be passed in parameters and then used in similar way to table-valued parameters in queries--more about this later.
 
 > [!TIP]
-> The code shown here comes from [PrimitiveCollectionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore8/PrimitiveCollectionsSample.cs).
+> The code shown here comes from [PrimitiveCollectionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore8/PrimitiveCollectionsSample.cs).
 
 ### Primitive collection properties
 
@@ -1017,7 +1017,7 @@ In all the examples above, column for primitive collection contains JSON. Howeve
 [!code-csharp[Pub](../../../../samples/core/Miscellaneous/NewInEFCore8/PrimitiveCollectionsInJsonSample.cs?name=Pub)]
 
 > [!TIP]
-> The code shown here comes from [PrimitiveCollectionsInJsonSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore8/PrimitiveCollectionsInJsonSample.cs).
+> The code shown here comes from [PrimitiveCollectionsInJsonSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore8/PrimitiveCollectionsInJsonSample.cs).
 
 We can now run a variation of our final query that, this time, extracts data from the JSON document, including queries into the primitive collections contained in the document:
 
@@ -1120,7 +1120,7 @@ CREATE TABLE [Beer] (
 EF8 includes improvements to the [JSON column mapping support introduced in EF7](xref:core/what-is-new/ef-core-7.0/whatsnew#json-columns).
 
 > [!TIP]
-> The code shown here comes from [JsonColumnsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore8/JsonColumnsSample.cs).
+> The code shown here comes from [JsonColumnsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore8/JsonColumnsSample.cs).
 
 ### Translate element access into JSON arrays
 
@@ -1241,7 +1241,7 @@ EF7 introduced support for mapping to JSON columns when using Azure SQL/SQL Serv
 The existing [documentation from What's New in EF7](xref:core/what-is-new/ef-core-7.0/whatsnew#json-columns) provides detailed information on JSON mapping, queries, and updates. This documentation now also applies to SQLite.
 
 > [!TIP]
-> The code shown in the EF7 documentation has been updated to also run on SQLite can can be found in [JsonColumnsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore8/JsonColumnsSample.cs).
+> The code shown in the EF7 documentation has been updated to also run on SQLite can can be found in [JsonColumnsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore8/JsonColumnsSample.cs).
 
 #### Queries into JSON columns
 
@@ -1347,7 +1347,7 @@ The `HierarchyId` type can be used for properties of an entity type. For example
 [!code-csharp[Halfling](../../../../samples/core/Miscellaneous/NewInEFCore8/HierarchyIdSample.cs?name=Halfling)]
 
 > [!TIP]
-> The code shown here and in the examples below comes from [HierarchyIdSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore8/HierarchyIdSample.cs).
+> The code shown here and in the examples below comes from [HierarchyIdSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore8/HierarchyIdSample.cs).
 
 > [!TIP]
 > If desired, `HierarchyId` is suitable for use as a key property type.
@@ -1661,7 +1661,7 @@ Following the update, querying for the descendents of "Mungo" returns "Bungo", "
 EF7 introduced [raw SQL queries returning scalar types](xref:core/querying/sql-queries#querying-scalar-(non-entity)-types). This is enhanced in EF8 to include raw SQL queries returning any mappable CLR type, without including that type in the EF model.
 
 > [!TIP]
-> The code shown here comes from [RawSqlSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore8/RawSqlSample.cs).
+> The code shown here comes from [RawSqlSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore8/RawSqlSample.cs).
 
 Queries using unmapped types are executed using <xref:Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions.SqlQuery*> or <xref:Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions.SqlQueryRaw*>. The former uses string interpolation to parameterize the query, which helps ensure that all non-constant values are parameterized. For example, consider the following database table:
 
@@ -1850,7 +1850,7 @@ The returned `IQueryable` can be composed upon when it is the result of a view o
 EF8 adds support for [lazy-loading of navigations](xref:core/querying/related-data/lazy) on entities that are not being tracked by the `DbContext`. This means a no-tracking query can be followed by lazy-loading of navigations on the entities returned by the no-tracking query.
 
 > [!TIP]
-> The code for the lazy-loading examples shown below comes from [LazyLoadingSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore8/LazyLoadingSample.cs).
+> The code for the lazy-loading examples shown below comes from [LazyLoadingSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore8/LazyLoadingSample.cs).
 
 For example, consider a no-tracking query for blogs:
 
@@ -1943,7 +1943,7 @@ EF8 contains new public APIs so that applications can now use these data structu
 [!code-csharp[LookupByPrimaryKey](../../../../samples/core/Miscellaneous/NewInEFCore8/LookupByKeySample.cs?name=LookupByPrimaryKey)]
 
 > [!TIP]
-> The code shown here comes from [LookupByKeySample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore8/LookupByKeySample.cs).
+> The code shown here comes from [LookupByKeySample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore8/LookupByKeySample.cs).
 
 The [`FindEntry`](https://github.com/dotnet/efcore/blob/81886272a761df8fafe4970b895b1e1fe35effb8/src/EFCore/ChangeTracking/LocalView.cs#L543) method returns either the <xref:Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry`1> for the tracked entity, or `null` if no entity with the given key is being tracked. Like all methods on `LocalView`, the database is never queried, even if the entity is not found. The returned entry contains the entity itself, as well as tracking information. For example:
 
@@ -2082,7 +2082,7 @@ public class OpeningHours
 [!code-csharp[BritishSchools](../../../../samples/core/Miscellaneous/NewInEFCore8/DateOnlyTimeOnlySample.cs?name=BritishSchools)]
 
 > [!TIP]
-> The code shown here comes from [DateOnlyTimeOnlySample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore8/DateOnlyTimeOnlySample.cs).
+> The code shown here comes from [DateOnlyTimeOnlySample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore8/DateOnlyTimeOnlySample.cs).
 
 > [!NOTE]
 > This model represents only British schools and stores times as local (GMT) times. Handling different timezones would complicate this code significantly. Note that using `DateTimeOffset` would not help here, since opening and closing times have different offsets depending whether daylight saving time is active or not.
@@ -2283,7 +2283,7 @@ b.Property(e => e.LeaseDate).HasDefaultValueSql("getutcdate()");
 ```
 
 > [!TIP]
-> The code shown below comes from [DefaultConstraintSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore8/DefaultConstraintSample.cs).
+> The code shown below comes from [DefaultConstraintSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore8/DefaultConstraintSample.cs).
 
 In order for EF to make use of this, it must determine when and when not to send a value for the column. By default, EF uses the CLR default as a sentinel for this. That is, when the value of `Status` or `LeaseDate` in the examples above are the CLR defaults for these types, then EF _interprets that to mean that the property has not been set_, and so does not send a value to the database. This works well for reference types--for example, if the `string` property `Status` is `null`, then EF doesn't send `null` to the database, but rather does not include any value so that the database default (`"Hidden"`) is used. Likewise, for the `DateTime` property `LeaseDate`, EF will not insert the CLR default value of `1/1/0001 12:00:00 AM`, but will instead omit this value so that database default is used.
 

--- a/entity-framework/core/what-is-new/ef-core-9.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-9.0/whatsnew.md
@@ -75,7 +75,7 @@ To learn more about querying with partition keys and point reads, [see the query
 ### Hierarchical partition keys
 
 > [!TIP]
-> The code shown here comes from [HierarchicalPartitionKeysSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore9.Cosmos/HierarchicalPartitionKeysSample.cs).
+> The code shown here comes from [HierarchicalPartitionKeysSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore9.Cosmos/HierarchicalPartitionKeysSample.cs).
 
 Azure Cosmos DB originally supported a single partition key, but has since expanded partitioning capabilities to also support [subpartitioning through the specification of up to three levels of hierarchy in the partition key](/azure/cosmos-db/hierarchical-partition-keys). EF Core 9 brings full support for hierarchical partition keys, allowing you take advantage of the better performance and cost savings associated with this feature.
 
@@ -342,7 +342,7 @@ We'd like to call out Andrea Canciani ([@ranma42](https://github.com/ranma42)) f
 #### GroupBy
 
 > [!TIP]
-> The code shown here comes from [ComplexTypesSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore9/ComplexTypesSample.cs).
+> The code shown here comes from [ComplexTypesSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore9/ComplexTypesSample.cs).
 
 EF9 supports grouping by a complex type instance. For example:
 
@@ -365,7 +365,7 @@ GROUP BY [s].[StoreAddress_City], [s].[StoreAddress_Country], [s].[StoreAddress_
 #### ExecuteUpdate
 
 > [!TIP]
-> The code shown here comes from [ExecuteUpdateSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore9/ExecuteUpdateSample.cs).
+> The code shown here comes from [ExecuteUpdateSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore9/ExecuteUpdateSample.cs).
 
 Similarly, in EF9 `ExecuteUpdate` has also been improved to accept complex type properties. However, each member of the complex type must be specified explicitly. For example:
 
@@ -506,7 +506,7 @@ FROM (
 ### Translations involving GREATEST/LEAST
 
 > [!TIP]
-> The code shown here comes from [LeastGreatestSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore9/LeastGreatestSample.cs).
+> The code shown here comes from [LeastGreatestSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore9/LeastGreatestSample.cs).
 
 Several new translations have been introduced that use the `GREATEST` and `LEAST` SQL functions.
 
@@ -584,7 +584,7 @@ FROM [Pubs] AS [p]
 ### Force or prevent query parameterization
 
 > [!TIP]
-> The code shown here comes from [QuerySample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore9/QuerySample.cs).
+> The code shown here comes from [QuerySample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore9/QuerySample.cs).
 
 Except in some special cases, EF Core parameterizes variables used in a LINQ query, but includes constants in the generated SQL. For example, consider the following query method:
 
@@ -710,7 +710,7 @@ Moreover, EF9 introduces `TranslateParameterizedCollectionsToConstants` [context
 ### Inlined uncorrelated subqueries
 
 > [!TIP]
-> The code shown here comes from [QuerySample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore9/QuerySample.cs).
+> The code shown here comes from [QuerySample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore9/QuerySample.cs).
 
 In EF8, an IQueryable referenced in another query may be executed as a separate database roundtrip. For example, consider the following LINQ query:
 
@@ -824,7 +824,7 @@ var topRatedPostsAverageRatingByLanguage = await context.Blogs.
 ### Queries using Count != 0 are optimized
 
 > [!TIP]
-> The code shown here comes from [QuerySample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore9/QuerySample.cs).
+> The code shown here comes from [QuerySample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore9/QuerySample.cs).
 
 In EF8, the following LINQ query was translated to use the SQL `COUNT` function:
 
@@ -1121,7 +1121,7 @@ More information can be found [here](/ef/core/modeling/data-seeding#use-seeding-
 ### Auto-compiled models
 
 > [!TIP]
-> The code shown here comes from the [NewInEFCore9.CompiledModels](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore9.CompiledModels/) sample.
+> The code shown here comes from the [NewInEFCore9.CompiledModels](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore9.CompiledModels/) sample.
 
 Compiled models can improve startup time for applications with large models--that is entity type counts in the 100s or 1000s. In previous versions of EF Core, a compiled model had to be generated manually, using the command line. For example:
 
@@ -1221,7 +1221,7 @@ For more information see [MSBuild integration](xref:core/cli/msbuild).
 ### Read-only primitive collections
 
 > [!TIP]
-> The code shown here comes from [PrimitiveCollectionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore9/PrimitiveCollectionsSample.cs).
+> The code shown here comes from [PrimitiveCollectionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore9/PrimitiveCollectionsSample.cs).
 
 EF8 introduced support for [mapping arrays and mutable lists of primitive types](xref:core/what-is-new/ef-core-8.0/whatsnew#primitive-collections). This has been expanded in EF9 to include read-only collections/lists. Specifically, EF9 supports collections typed as `IReadOnlyList`, `IReadOnlyCollection`, or `ReadOnlyCollection`. For example, in the following code, `DaysVisited` will be mapped by convention as a primitive collection of dates:
 
@@ -1281,7 +1281,7 @@ INNER JOIN "Pubs" AS "p" ON "w"."ClosestPubId" = "p"."Id"
 ### Specify fill-factor for keys and indexes
 
 > [!TIP]
-> The code shown here comes from [ModelBuildingSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore9/ModelBuildingSample.cs).
+> The code shown here comes from [ModelBuildingSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore9/ModelBuildingSample.cs).
 
 EF9 supports specification of the [SQL Server fill-factor](/sql/relational-databases/indexes/specify-fill-factor-for-an-index) when using EF Core Migrations to create keys and indexes. From the SQL Server docs, "When an index is created or rebuilt, the fill-factor value determines the percentage of space on each leaf-level page to be filled with data, reserving the remainder on each page as free space for future growth."
 
@@ -1328,7 +1328,7 @@ This enhancement was contributed by [@deano-hunter](https://github.com/deano-hun
 ### Make existing model building conventions more extensible
 
 > [!TIP]
-> The code shown here comes from [CustomConventionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore9/CustomConventionsSample.cs).
+> The code shown here comes from [CustomConventionsSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore9/CustomConventionsSample.cs).
 
 Public model building conventions for applications were [introduced in EF7](xref:core/modeling/bulk-configuration#Conventions). In EF9, we have made it easier to extend some of the existing conventions. For example, [the code to map properties by attribute in EF7](xref:core/what-is-new/ef-core-7.0/whatsnew#model-building-conventions) is this:
 
@@ -1451,7 +1451,7 @@ As an aside, some people think this pattern is an abomination because it couples
 ## SQL Server HierarchyId
 
 > [!TIP]
-> The code shown here comes from [HierarchyIdSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/main/samples/core/Miscellaneous/NewInEFCore9/HierarchyIdSample.cs).
+> The code shown here comes from [HierarchyIdSample.cs](https://github.com/dotnet/EntityFramework.Docs/tree/live/samples/core/Miscellaneous/NewInEFCore9/HierarchyIdSample.cs).
 
 <a name="hierarchyid-path-generation"></a>
 


### PR DESCRIPTION
Now that we no longer have a `main` branch, update all links to the EF docs github repo to point to the live branch instead.

Fixes #5045