### PR TITLE
Highlight that migrating from EF6->EF Core requires being off .NET Framework

### DIFF
--- a/entity-framework/efcore-and-ef6/porting/index.md
+++ b/entity-framework/efcore-and-ef6/porting/index.md
@@ -14,7 +14,7 @@ Entity Framework Core, or EF Core for short, is a total rewrite of Entity Framew
 > Before you start the porting process it is important to validate that EF Core meets the data access requirements for your application. You can find everything you need in the [EF Core documentation](xref:core/index).
 
 > [!WARNING]
-> Your project must not be targeting nor consumed by a .NET Framework target to proceed with migration from EF6 to EF Core. EF6 is supported on .NET Framework and .NET, so during a migration you may either continue to target solely EF6 or maintain separate contexts for EF6 and EF Core.
+> Your project must not be targeting nor consumed by a .NET Framework target to proceed with migration from EF6 to EF Core. EF6 is supported on .NET Framework and .NET, so during a migration you may either continue to just target EF6 or maintain separate contexts for EF6 and EF Core.
 
 ## Reasons to upgrade
 

--- a/entity-framework/efcore-and-ef6/porting/index.md
+++ b/entity-framework/efcore-and-ef6/porting/index.md
@@ -14,7 +14,8 @@ Entity Framework Core, or EF Core for short, is a total rewrite of Entity Framew
 > Before you start the porting process it is important to validate that EF Core meets the data access requirements for your application. You can find everything you need in the [EF Core documentation](xref:core/index).
 
 > [!WARNING]
-> Your project must not be targeting nor consumed by a .NET Framework target to proceed with migration from EF6 to EF Core. EF6 is supported on .NET Framework and .NET, so during a migration you may either continue to just target EF6 or maintain separate contexts for EF6 and EF Core.
+> EF Core only supports modern .NET, and does not support .NET Framework.
+> As such, if your project is still targeting .NET Framework, you will have to migrate to modern .NET before you can start your migration from EF6 to EF Core. Note that EF6 supports modern .NET, so you can migrate to modern .NET first while keeping EF6, and then tackle the migration from EF6 to EF Core.
 
 ## Reasons to upgrade
 

--- a/entity-framework/efcore-and-ef6/porting/index.md
+++ b/entity-framework/efcore-and-ef6/porting/index.md
@@ -13,8 +13,8 @@ Entity Framework Core, or EF Core for short, is a total rewrite of Entity Framew
 > [!IMPORTANT]
 > Before you start the porting process it is important to validate that EF Core meets the data access requirements for your application. You can find everything you need in the [EF Core documentation](xref:core/index).
 
-> [!IMPORTANT]
-> There is a known issue ([microsoft/dotnet-apiport #993](https://github.com/microsoft/dotnet-apiport/issues/993)) with the [portability analyzer](/dotnet/standard/analyzers/portability-analyzer) that erroneously reports EF Core as incompatible with .NET 5 and .NET 6. These warnings can be safely ignored as EF Core is 100% compatible with .NET 5 and .NET 6 target frameworks.
+> [!WARNING]
+> Your project must not be targeting nor consumed by a .NET Framework target to proceed with migration from EF6 to EF Core. EF6 is supported on .NET Framework and .NET, so during a migration you may either continue to target solely EF6 or maintain separate contexts for EF6 and EF Core.
 
 ## Reasons to upgrade
 


### PR DESCRIPTION
I have seen a lot of confusion around when to perform the EF6->EF Core migration while migrating applications from framework to core. This adds a warning that EF6 is supported on all supported targets, while EF Core is only on .NET Core/.NET.

It also removes a comment around ApiPort that is no longer valid since that tool has been deprecated and is unavailable.