### PR TITLE
What's new docs for 10.0.0-preview.7

### DIFF
--- a/entity-framework/toc.yml
+++ b/entity-framework/toc.yml
@@ -75,38 +75,38 @@
             href: core/what-is-new/ef-core-9.0/breaking-changes.md
       - name: EF Core 8.0
         items:
-          - name: High-level plan
-            href: core/what-is-new/ef-core-8.0/plan.md
           - name: "What's new?"
             href: core/what-is-new/ef-core-8.0/whatsnew.md
           - name: Breaking changes
             href: core/what-is-new/ef-core-8.0/breaking-changes.md
+          - name: High-level plan
+            href: core/what-is-new/ef-core-8.0/plan.md
       - name: Out of support
         items:
         - name: EF Core 7.0
           items:
-            - name: High-level plan
-              href: core/what-is-new/ef-core-7.0/plan.md
             - name: "What's new?"
               href: core/what-is-new/ef-core-7.0/whatsnew.md
             - name: Breaking changes
               href: core/what-is-new/ef-core-7.0/breaking-changes.md
+            - name: High-level plan
+              href: core/what-is-new/ef-core-7.0/plan.md
         - name: EF Core 6.0
           items:
-            - name: High-level plan
-              href: core/what-is-new/ef-core-6.0/plan.md
             - name: "What's new?"
               href: core/what-is-new/ef-core-6.0/whatsnew.md
             - name: Breaking changes
               href: core/what-is-new/ef-core-6.0/breaking-changes.md
+            - name: High-level plan
+              href: core/what-is-new/ef-core-6.0/plan.md
         - name: EF Core 5.0
           items:
-            - name: High-level plan
-              href: core/what-is-new/ef-core-5.0/plan.md
             - name: "What's new?"
               href: core/what-is-new/ef-core-5.0/whatsnew.md
             - name: Breaking changes
               href: core/what-is-new/ef-core-5.0/breaking-changes.md
+            - name: High-level plan
+              href: core/what-is-new/ef-core-5.0/plan.md
         - name: EF Core 3.1
           items:
             - name: New features


### PR DESCRIPTION
Mostly @cincuranet's new translation mode fo parameterized collections.

This targets the WhatsNewPreview7 branch, so can be reviewed and merged immediately. We can do any further work/tweaks on that branch, and then merge it into live once preview.7 is out.

.NET-side release notes: https://github.com/dotnet/core/pull/9998