### PR TITLE
Update docfx.json with ms.update-cycle meta data

### DIFF
--- a/entity-framework/docfx.json
+++ b/entity-framework/docfx.json
@@ -95,7 +95,10 @@
         "ef6/**/**.md": "https://github.com/dotnet/ef6/issues/new"
       },
       "ms.technology": {
-      }      
+      },
+      "ms.update-cycle": {
+        "**/**.{md,yml}": "3650-days"
+      }           
     },
     "dest": "_site",
     "template": [


### PR DESCRIPTION
Update docfx.json with ms.update-cycle meta data reflecting current tiered support freshness cycle.
This setting is required by Learn and helps with reporting.

Fixes dotnet/aspnetcore.docs#35962