### PR TITLE
Update managed-identities-test-non-production.md

### DIFF
--- a/entity-framework/core/includes/managed-identities-test-non-production.md
+++ b/entity-framework/core/includes/managed-identities-test-non-production.md
@@ -1,7 +1,7 @@
 ---
 description: A local database that doesn't require the user to be authenticated
 author: rick-anderson
-ms.author: riande
+ms.author: wpickett
 ms.date: 10/23/2024
 ms.topic: include
 title: an include file


### PR DESCRIPTION
Replacing ms.author invalid value so it will stop popping up as a warning in reporting.  The author is no longer at Microsoft and ms.author requires a valid entry.