### PR TITLE
docs: typo in ef-core-8.0 whats new

### DIFF
--- a/entity-framework/core/what-is-new/ef-core-8.0/whatsnew.md
+++ b/entity-framework/core/what-is-new/ef-core-8.0/whatsnew.md
@@ -2357,7 +2357,7 @@ modelBuilder.Entity<Course>()
 
 With this configuration, EF will exclude sending the value to the database when it is set to `Level.Beginner`, and instead `Level.Intermediate` is assigned by the database. This isn't what was intended!
 
-The problem would not have occurred if the the enum been defined with the "unknown" or "unspecified" value being the database default:
+The problem would not have occurred if the enum been defined with the "unknown" or "unspecified" value being the database default:
 
 ```csharp
 public enum Level


### PR DESCRIPTION
There is a duplication of `the` in the article about what's new about EF Core 8.

<img width="1574" height="929" alt="image" src="https://github.com/user-attachments/assets/ac1f9643-f9fb-47cc-b791-e71cf9b4f9cf" />
